### PR TITLE
feat: add HeavenlyDoubleHalberd weapon with multi-target kill

### DIFF
--- a/LegendsOfTheThreeKingdoms/app/src/main/java/com/gaas/threeKingdoms/usecase/UseHeavenlyDoubleHalberdKillUseCase.java
+++ b/LegendsOfTheThreeKingdoms/app/src/main/java/com/gaas/threeKingdoms/usecase/UseHeavenlyDoubleHalberdKillUseCase.java
@@ -1,0 +1,47 @@
+package com.gaas.threeKingdoms.usecase;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.exception.NotFoundException;
+import com.gaas.threeKingdoms.outport.GameRepository;
+import jakarta.inject.Named;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Named
+public class UseHeavenlyDoubleHalberdKillUseCase {
+    private final GameRepository gameRepository;
+
+    public void execute(String gameId, UseHeavenlyDoubleHalberdKillRequest request, UseHeavenlyDoubleHalberdKillPresenter presenter) {
+        Game game = gameRepository.findById(gameId)
+                .orElseThrow(() -> new NotFoundException("Game not found"));
+        List<DomainEvent> events = game.playerUseHeavenlyDoubleHalberdKill(
+                request.playerId,
+                request.cardId,
+                request.primaryTargetPlayerId,
+                request.additionalTargetPlayerIds);
+        gameRepository.save(game);
+        presenter.renderEvents(events);
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UseHeavenlyDoubleHalberdKillRequest {
+        private String playerId;
+        private String cardId;
+        private String primaryTargetPlayerId;
+        private List<String> additionalTargetPlayerIds; // size 0..2
+    }
+
+    public interface UseHeavenlyDoubleHalberdKillPresenter<T> {
+        void renderEvents(List<DomainEvent> events);
+
+        T present();
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -15,6 +15,7 @@ import com.gaas.threeKingdoms.handcard.*;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.VirtualKill;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.EighteenSpanViperSpearCard;
+import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.HeavenlyDoubleHalberdCard;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.RepeatingCrossbowCard;
 import com.gaas.threeKingdoms.handcard.scrollcard.Contentment;
 import com.gaas.threeKingdoms.handcard.scrollcard.Lightning;
@@ -902,6 +903,92 @@ public class Game {
         reactionPlayers.add(targetPlayerId);
         ViperSpearKillBehavior behavior = new ViperSpearKillBehavior(
                 this, attacker, reactionPlayers, target, virtualKill, discardCardIds);
+        updateTopBehavior(behavior);
+
+        List<DomainEvent> events = behavior.playerAction();
+        removeCompletedBehaviors();
+        return events;
+    }
+
+    public List<DomainEvent> playerUseHeavenlyDoubleHalberdKill(String playerId,
+                                                                 String cardId,
+                                                                 String primaryTargetPlayerId,
+                                                                 List<String> additionalTargetPlayerIds) {
+        Player attacker = getPlayer(playerId);
+
+        // 1. activePlayer 驗證
+        checkIsCurrentRoundValid(playerId);
+
+        // 2. 不得有 pending behavior
+        if (!topBehavior.isEmpty()) {
+            throw new IllegalStateException("Cannot use halberd kill while another behavior is pending");
+        }
+
+        // 3. 裝備方天畫戟
+        if (!(attacker.getEquipmentWeaponCard() instanceof HeavenlyDoubleHalberdCard)) {
+            throw new IllegalStateException("Player is not equipped with HeavenlyDoubleHalberd");
+        }
+
+        // 4. 卡牌在手牌且為 Kill
+        HandCard handCard = attacker.getHand().getCard(cardId)
+                .orElseThrow(() -> new IllegalArgumentException("Card not in hand: " + cardId));
+        if (!(handCard instanceof Kill)) {
+            throw new IllegalArgumentException("Card is not a Kill: " + cardId);
+        }
+
+        // 5. 此殺必須是最後一張手牌
+        if (attacker.getHandSize() != 1) {
+            throw new IllegalStateException("Halberd effect only usable when the Kill is the last hand card");
+        }
+
+        // 6. primary target
+        Player primaryTarget = getPlayer(primaryTargetPlayerId);
+        if (playerId.equals(primaryTargetPlayerId)) {
+            throw new IllegalArgumentException("Cannot target self");
+        }
+
+        // 7. additional targets 驗證
+        List<String> additionalIds = additionalTargetPlayerIds == null ? new ArrayList<>() : additionalTargetPlayerIds;
+        if (additionalIds.size() > 2) {
+            throw new IllegalArgumentException("At most 2 additional targets");
+        }
+
+        // 8. 短路：沒有 additional target → 走正常 playCard 路徑
+        if (additionalIds.isEmpty()) {
+            return playerPlayCard(playerId, cardId, primaryTargetPlayerId, PlayType.ACTIVE.getPlayType());
+        }
+
+        // 9. 組成完整目標列表並檢查重複 / 自己 / 存活 / 攻擊範圍
+        List<String> fullTargets = new ArrayList<>();
+        fullTargets.add(primaryTargetPlayerId);
+        fullTargets.addAll(additionalIds);
+
+        if (new HashSet<>(fullTargets).size() != fullTargets.size()) {
+            throw new IllegalArgumentException("Duplicate targets");
+        }
+        if (fullTargets.contains(playerId)) {
+            throw new IllegalArgumentException("Cannot target self");
+        }
+        for (String targetId : fullTargets) {
+            Player target = getPlayer(targetId);
+            if (!isInAttackRange(attacker, target)) {
+                throw new IllegalStateException(String.format("%s is not in attack range", targetId));
+            }
+        }
+
+        // 10. 回合出殺次數限制（考慮諸葛連弩——實際上不會同時裝兩把武器，但保留邏輯對稱性）
+        if (currentRound.isShowKill() && !(attacker.getEquipmentWeaponCard() instanceof RepeatingCrossbowCard)) {
+            throw new IllegalStateException("Player already played Kill Card");
+        }
+
+        // 11. 棄殺到墓地，標記本回合已出殺
+        HandCard killCard = attacker.playCard(cardId);
+        graveyard.add(killCard);
+        currentRound.setShowKill(true);
+
+        // 12. push HeavenlyDoubleHalberdKillBehavior
+        HeavenlyDoubleHalberdKillBehavior behavior = new HeavenlyDoubleHalberdKillBehavior(
+                this, attacker, fullTargets, primaryTarget, cardId, killCard);
         updateTopBehavior(behavior);
 
         List<DomainEvent> events = behavior.playerAction();

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DyingAskPeachBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DyingAskPeachBehavior.java
@@ -217,7 +217,8 @@ public class DyingAskPeachBehavior extends Behavior {
     private void addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(List<DomainEvent> events) {
         game.peekTopBehaviorSecondElement().ifPresent(secondBehavior -> {
             if (secondBehavior instanceof HeavenlyDoubleHalberdKillBehavior halberdBehavior) {
-                Player halberdCurrentReactionPlayer = halberdBehavior.getCurrentReactionPlayer();
+                // 最後一個目標已處理完（isOneRound=true），不需要再問下一位
+                if (halberdBehavior.isOneRound()) return;
                 // halberd 在扣血進入瀕死時已將 currentReactionPlayer 推進到下一位
                 List<DomainEvent> dodgeOrEquipmentEvents = new ArrayList<>();
                 halberdBehavior.askCurrentTargetDodgeOrEquipmentEffect(dodgeOrEquipmentEvents);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DyingAskPeachBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DyingAskPeachBehavior.java
@@ -81,6 +81,7 @@ public class DyingAskPeachBehavior extends Behavior {
                     events.addAll(List.of(settlementEvent, drawCardEvent));
                     addAskKillEventIfCurrentBehaviorIsBarbarianInvasionBehavior(events);
                     addAskDodgeEventIfCurrentBehaviorIsArrowBarrageBehavior(events);
+                    addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(events);
                 } else if (isMINISTER(dyingPlayer)) {
                     SettlementEvent settlementEvent = new SettlementEvent(dyingPlayer);
                     events.add(settlementEvent);
@@ -104,11 +105,13 @@ public class DyingAskPeachBehavior extends Behavior {
                     }
                     addAskKillEventIfCurrentBehaviorIsBarbarianInvasionBehavior(events);
                     addAskDodgeEventIfCurrentBehaviorIsArrowBarrageBehavior(events);
+                    addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(events);
                 } else {
                     SettlementEvent settlementEvent = new SettlementEvent(dyingPlayer);
                     events.add(settlementEvent);
                     addAskKillEventIfCurrentBehaviorIsBarbarianInvasionBehavior(events);
                     addAskDodgeEventIfCurrentBehaviorIsArrowBarrageBehavior(events);
+                    addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(events);
                 }
 
                 //  需要移除的 Behavior，isOneRound 要設為 true
@@ -156,6 +159,7 @@ public class DyingAskPeachBehavior extends Behavior {
                 } else {
                     addAskKillEventIfCurrentBehaviorIsBarbarianInvasionBehavior(events);
                     addAskDodgeEventIfCurrentBehaviorIsArrowBarrageBehavior(events);
+                    addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(events);
                 }
             } else {
                 events.add(createAskPeachEvent(currentPlayer, dyingPlayer));
@@ -173,7 +177,9 @@ public class DyingAskPeachBehavior extends Behavior {
         Stack<Behavior> topBehavior = game.getTopBehavior();
         IntStream.range(0, topBehavior.size())
                 .mapToObj(i -> topBehavior.get(topBehavior.size() - 1 - i))
-                .filter(behavior -> behavior instanceof NormalActiveKillBehavior
+                .filter(behavior -> (behavior instanceof NormalActiveKillBehavior
+                        // 方天畫戟為多目標輪詢，中間目標死亡不應自動 pop
+                        && !(behavior instanceof HeavenlyDoubleHalberdKillBehavior))
                         || behavior instanceof DuelBehavior
                         || behavior instanceof BorrowedSwordBehavior)
                 .findFirst()
@@ -204,6 +210,18 @@ public class DyingAskPeachBehavior extends Behavior {
                     events.add(new AskDodgeEvent(arrowBarrageCurrentReactionPlayer.getId()));
                 }
                 game.getCurrentRound().setActivePlayer(arrowBarrageCurrentReactionPlayer);
+            }
+        });
+    }
+
+    private void addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(List<DomainEvent> events) {
+        game.peekTopBehaviorSecondElement().ifPresent(secondBehavior -> {
+            if (secondBehavior instanceof HeavenlyDoubleHalberdKillBehavior halberdBehavior) {
+                Player halberdCurrentReactionPlayer = halberdBehavior.getCurrentReactionPlayer();
+                // halberd 在扣血進入瀕死時已將 currentReactionPlayer 推進到下一位
+                List<DomainEvent> dodgeOrEquipmentEvents = new ArrayList<>();
+                halberdBehavior.askCurrentTargetDodgeOrEquipmentEffect(dodgeOrEquipmentEvents);
+                events.addAll(dodgeOrEquipmentEvents);
             }
         });
     }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/HeavenlyDoubleHalberdKillBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/HeavenlyDoubleHalberdKillBehavior.java
@@ -1,0 +1,175 @@
+package com.gaas.threeKingdoms.behavior.behavior;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.events.AskDodgeEvent;
+import com.gaas.threeKingdoms.events.AskPlayEquipmentEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.HeavenlyDoubleHalberdKillTriggerEvent;
+import com.gaas.threeKingdoms.events.PlayCardEvent;
+import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.round.Round;
+import com.gaas.threeKingdoms.round.Stage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.gaas.threeKingdoms.handcard.PlayCard.isDodgeCard;
+import static com.gaas.threeKingdoms.handcard.PlayCard.isSkip;
+
+/**
+ * 方天畫戟多目標殺 Behavior。
+ *
+ * 繼承 NormalActiveKillBehavior 以複用 isEquipmentHasSpecialEffect 等 helper，但完全 override
+ * playerAction() 與 doResponseToPlayerAction() 以實作 sequential polling（mirror ArrowBarrage）。
+ *
+ * 核心設計：
+ *  - reactionPlayers = 使用者指定的完整目標列表（[primary, additional1, additional2?]）
+ *  - currentReactionPlayer 逐一推進（依 reactionPlayers 順序，不是座位順序）
+ *  - 每個目標獨立結算閃/防具/扣血/瀕死
+ *  - 因為武器槽唯一，方天畫戟路徑不需要處理 GDCB/SPA/QilinBow/YinYangSwords/BlackPommel 交互
+ *
+ * 瀕死處理：若中間目標在扣血後進入瀕死流程（getDamagedEvent 會 push DyingAskPeachBehavior），
+ * 此 behavior 的 isOneRound 會維持 false，等瀕死結束後由 DyingAskPeachBehavior 的
+ * addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior hook 恢復下一個 target
+ * 的詢問（mirror ArrowBarrage 的既有機制）。
+ */
+public class HeavenlyDoubleHalberdKillBehavior extends NormalActiveKillBehavior {
+
+    public HeavenlyDoubleHalberdKillBehavior(Game game,
+                                             Player behaviorPlayer,
+                                             List<String> reactionPlayers,
+                                             Player currentReactionPlayer,
+                                             String cardId,
+                                             HandCard killCard) {
+        super(game, behaviorPlayer, reactionPlayers, currentReactionPlayer,
+                cardId, PlayType.ACTIVE.getPlayType(), killCard);
+    }
+
+    @Override
+    public List<DomainEvent> playerAction() {
+        // 殺已在 Game.playerUseHeavenlyDoubleHalberdKill() 從手牌移至墓地，這裡不再呼叫 playerPlayCard
+        List<DomainEvent> events = new ArrayList<>();
+
+        // 廣播多目標殺 — targetPlayerId 欄位留空，以 trigger event 的 targetPlayerIds 為準
+        events.add(new PlayCardEvent("出牌", behaviorPlayer.getId(), "", cardId, playType));
+        events.add(new HeavenlyDoubleHalberdKillTriggerEvent(
+                behaviorPlayer.getId(), cardId, new ArrayList<>(reactionPlayers)));
+
+        // 問第一個目標（currentReactionPlayer）出閃或發動防具
+        askCurrentTargetDodgeOrEquipmentEffect(events);
+        events.add(game.getGameStatusEvent("方天畫戟發動"));
+        return events;
+    }
+
+    @Override
+    public List<DomainEvent> doResponseToPlayerAction(String playerId, String targetPlayerId, String cardId, String playType) {
+        Round currentRound = game.getCurrentRound();
+
+        if (isSkip(playType)) {
+            int originalHp = currentReactionPlayer.getHP();
+            List<DomainEvent> events = new ArrayList<>(
+                    game.getDamagedEvent(playerId, targetPlayerId, cardId, card, playType,
+                            originalHp, currentReactionPlayer, currentRound, Optional.of(this)));
+
+            boolean isLast = isLastReactionPlayer(playerId);
+
+            if (!game.getGamePhase().getPhaseName().equals("GeneralDying")) {
+                // 扣血但沒死：繼續詢問下一個目標
+                if (isLast) {
+                    isOneRound = true;
+                    currentRound.setActivePlayer(currentRound.getCurrentRoundPlayer());
+                } else {
+                    isOneRound = false;
+                    advanceToNextTarget();
+                    askCurrentTargetDodgeOrEquipmentEffect(events);
+                }
+                events.add(game.getGameStatusEvent("扣血但還活著"));
+            } else {
+                // 進入瀕死流程：下一個目標的詢問交由 DyingAskPeachBehavior 的 hook 處理
+                events.add(game.getGameStatusEvent("扣血已瀕臨死亡"));
+                if (isLast) {
+                    isOneRound = true;
+                } else {
+                    // 先把 currentReactionPlayer 推進到下一位，DyingAskPeach 結束後會讀取此位置
+                    advanceToNextTarget();
+                }
+            }
+
+            return events;
+        } else if (isDodgeCard(cardId)) {
+            // 消耗閃到墓地
+            playerPlayCardNotUpdateActivePlayer(game.getPlayer(playerId), cardId);
+
+            List<DomainEvent> events = new ArrayList<>();
+            events.add(new PlayCardEvent("出牌", playerId, targetPlayerId, cardId, playType));
+
+            boolean isLast = isLastReactionPlayer(playerId);
+            if (isLast) {
+                isOneRound = true;
+                currentRound.setActivePlayer(currentRound.getCurrentRoundPlayer());
+            } else {
+                isOneRound = false;
+                advanceToNextTarget();
+                askCurrentTargetDodgeOrEquipmentEffect(events);
+            }
+            events.add(game.getGameStatusEvent(playerId + " 出閃"));
+            return events;
+        } else {
+            //TODO: 其他 case（Phase 2）
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * 八卦陣 handler 會呼叫此 method 取代 isOneRound 的判斷邏輯。
+     * 方天畫戟為多目標輪詢，八卦陣在中間目標成功並不代表整個 behavior 結束。
+     */
+    @Override
+    public boolean judgeWhetherRemoveTopBehavior() {
+        return false;
+    }
+
+    /**
+     * 判斷某玩家是否為 reactionPlayers 列表的最後一位（注意：依列表順序，非座位順序）。
+     */
+    public boolean isLastReactionPlayer(String playerId) {
+        return reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId);
+    }
+
+    /**
+     * 將 currentReactionPlayer 推進到 reactionPlayers 列表中的下一位。
+     * 注意：使用列表順序 (index + 1)，不是座位順序。
+     */
+    public void advanceToNextTarget() {
+        int currentIndex = reactionPlayers.indexOf(currentReactionPlayer.getId());
+        if (currentIndex < 0 || currentIndex + 1 >= reactionPlayers.size()) {
+            return;
+        }
+        String nextId = reactionPlayers.get(currentIndex + 1);
+        currentReactionPlayer = game.getPlayer(nextId);
+    }
+
+    /**
+     * 詢問當前 currentReactionPlayer 出閃（或發動防具效果）。
+     * 將 activePlayer 設為該目標。
+     */
+    public void askCurrentTargetDodgeOrEquipmentEffect(List<DomainEvent> events) {
+        Round currentRound = game.getCurrentRound();
+        Player targetPlayer = currentReactionPlayer;
+        currentRound.setActivePlayer(targetPlayer);
+
+        if (isEquipmentHasSpecialEffect(targetPlayer)) {
+            currentRound.setStage(Stage.Wait_Equipment_Effect);
+            events.add(new AskPlayEquipmentEffectEvent(
+                    targetPlayer.getId(),
+                    targetPlayer.getEquipment().getArmor(),
+                    List.of(targetPlayer.getId())));
+        } else {
+            currentRound.setStage(Stage.Normal);
+            events.add(new AskDodgeEvent(targetPlayer.getId()));
+        }
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/effect/EightDiagramTacticEquipmentEffectHandler.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/effect/EightDiagramTacticEquipmentEffectHandler.java
@@ -3,6 +3,7 @@ package com.gaas.threeKingdoms.effect;
 import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.behavior.Behavior;
 import com.gaas.threeKingdoms.behavior.behavior.ArrowBarrageBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.HeavenlyDoubleHalberdKillBehavior;
 import com.gaas.threeKingdoms.events.*;
 import com.gaas.threeKingdoms.handcard.EquipmentPlayType;
 import com.gaas.threeKingdoms.handcard.HandCard;
@@ -58,6 +59,7 @@ public class EightDiagramTacticEquipmentEffectHandler extends EquipmentEffectHan
         topBehavior.setIsOneRound(isOneRoundBehavior && isEightDiagramTacticEffectSuccess);
         if (isEightDiagramTacticEffectSuccess) {
             addAskDodgeEventIfCurrentBehaviorIsArrowBarrageBehavior(domainEvents);
+            addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(domainEvents, playerId);
         } else {
             domainEvents.add(new AskDodgeEvent(playerId));
         }
@@ -80,6 +82,25 @@ public class EightDiagramTacticEquipmentEffectHandler extends EquipmentEffectHan
                 events.add(new AskDodgeEvent(arrowBarrageCurrentReactionPlayer.getId()));
             }
             game.getCurrentRound().setActivePlayer(arrowBarrageCurrentReactionPlayer);
+        }
+    }
+
+    /**
+     * 方天畫戟：當前目標用八卦陣成功抵擋後，依「目標列表順序」推進到下一位目標並詢問出閃/防具效果。
+     * 若當前目標已是最後一位，則將 behavior 標記為結束。
+     */
+    private void addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(List<DomainEvent> events, String playerId) {
+        Behavior topBehavior = game.peekTopBehavior();
+        if (topBehavior instanceof HeavenlyDoubleHalberdKillBehavior halberdBehavior) {
+            boolean isLast = halberdBehavior.isLastReactionPlayer(playerId);
+            if (isLast) {
+                halberdBehavior.setIsOneRound(true);
+                game.getCurrentRound().setActivePlayer(game.getCurrentRound().getCurrentRoundPlayer());
+            } else {
+                halberdBehavior.setIsOneRound(false);
+                halberdBehavior.advanceToNextTarget();
+                halberdBehavior.askCurrentTargetDodgeOrEquipmentEffect(events);
+            }
         }
     }
 

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/HeavenlyDoubleHalberdKillTriggerEvent.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/HeavenlyDoubleHalberdKillTriggerEvent.java
@@ -1,0 +1,25 @@
+package com.gaas.threeKingdoms.events;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 方天畫戟發動事件：攻擊者使用殺並額外指定至多 2 名目標。
+ * 前端收到此事件後應顯示多目標殺的動畫與狀態。
+ */
+@Getter
+public class HeavenlyDoubleHalberdKillTriggerEvent extends DomainEvent {
+
+    private final String attackerPlayerId;
+    private final String cardId;
+    private final List<String> targetPlayerIds;
+
+    public HeavenlyDoubleHalberdKillTriggerEvent(String attackerPlayerId, String cardId, List<String> targetPlayerIds) {
+        super("HeavenlyDoubleHalberdKillTriggerEvent",
+                String.format("方天畫戟發動：%s 用殺攻擊 %s", attackerPlayerId, targetPlayerIds));
+        this.attackerPlayerId = attackerPlayerId;
+        this.cardId = cardId;
+        this.targetPlayerIds = targetPlayerIds;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/handcard/PlayCard.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/handcard/PlayCard.java
@@ -13,6 +13,7 @@ import com.gaas.threeKingdoms.handcard.equipmentcard.mountscard.YellowFlash;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.BlackPommelCard;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.EighteenSpanViperSpearCard;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.GreenDragonCrescentBladeCard;
+import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.HeavenlyDoubleHalberdCard;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.QilinBowCard;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.StonePiercingAxeCard;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.RepeatingCrossbowCard;
@@ -203,6 +204,7 @@ public enum PlayCard {
         CARD_FACTORY_MAP.put("ES5005", new GreenDragonCrescentBladeCard(ES5005));
         CARD_FACTORY_MAP.put("ED5083", new StonePiercingAxeCard(ED5083));
         CARD_FACTORY_MAP.put("ESQ025", new EighteenSpanViperSpearCard(ESQ025));
+        CARD_FACTORY_MAP.put("EDQ103", new HeavenlyDoubleHalberdCard(EDQ103));
         CARD_FACTORY_MAP.put("ES6019", new BlackPommelCard(ES6019));
         CARD_FACTORY_MAP.put("SSK013", new BarbarianInvasion(SSK013));
         CARD_FACTORY_MAP.put("SC7072", new BarbarianInvasion(SC7072));

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/handcard/equipmentcard/weaponcard/HeavenlyDoubleHalberdCard.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/handcard/equipmentcard/weaponcard/HeavenlyDoubleHalberdCard.java
@@ -1,0 +1,23 @@
+package com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.handcard.PlayCard;
+
+import java.util.List;
+
+/**
+ * 方天畫戟 Heavenly Double Halberd
+ * 攻擊範圍 4，當玩家使用殺且該殺是最後一張手牌時，可為此殺額外指定至多 2 名目標。
+ */
+public class HeavenlyDoubleHalberdCard extends WeaponCard {
+
+    public HeavenlyDoubleHalberdCard(PlayCard playCard) {
+        super(playCard, 4);
+    }
+
+    @Override
+    public List<DomainEvent> equipmentEffect(Game game) {
+        return null;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HeavenlyDoubleHalberdTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HeavenlyDoubleHalberdTest.java
@@ -227,6 +227,40 @@ public class HeavenlyDoubleHalberdTest {
                 && ((AskDodgeEvent) e).getPlayerId().equals("player-d")));
     }
 
+    @DisplayName("最後一個目標 D HP=1 且死亡 → behavior 正確結束，不發 spurious AskDodge")
+    @Test
+    public void testUseHalberdKill_LastTargetDying_BehaviorTerminatesCleanly() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        Player playerD = game.getPlayer("player-d");
+        playerD.setBloodCard(new BloodCard(1));
+        equipHalberdWithSingleKill(playerA);
+
+        game.playerUseHeavenlyDoubleHalberdKill(
+                "player-a", BS8008.getCardId(), "player-b", List.of("player-d"));
+
+        // B 不出閃
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        // D 不出閃 → HP=0 → 瀕死（D 是最後一個目標）
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+
+        assertEquals(0, playerD.getHP());
+
+        // 所有人跳過桃 → D 永久死亡 (peach-ask: D → E → A → B → C)
+        game.playerPlayCard("player-d", "", "player-d", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-e", "", "player-d", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-a", "", "player-d", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-b", "", "player-d", PlayType.SKIP.getPlayType());
+        List<DomainEvent> finalEvents =
+                game.playerPlayCard("player-c", "", "player-d", PlayType.SKIP.getPlayType());
+
+        // behavior stack 應為空（halberd 已結束）
+        assertEquals(0, game.getTopBehavior().size());
+        // 不應有 spurious AskDodgeEvent
+        assertFalse(finalEvents.stream().anyMatch(e -> e instanceof AskDodgeEvent),
+                "Should not emit AskDodgeEvent after last target dies");
+    }
+
     @DisplayName("A 沒裝備方天畫戟 → 拋例外")
     @Test
     public void testNoHalberd_ThrowsException() {

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HeavenlyDoubleHalberdTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HeavenlyDoubleHalberdTest.java
@@ -1,0 +1,386 @@
+package com.gaas.threeKingdoms;
+
+import com.gaas.threeKingdoms.behavior.behavior.HeavenlyDoubleHalberdKillBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
+import com.gaas.threeKingdoms.builders.PlayerBuilder;
+import com.gaas.threeKingdoms.events.*;
+import com.gaas.threeKingdoms.gamephase.Normal;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.generalcard.GeneralCard;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic;
+import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.HeavenlyDoubleHalberdCard;
+import com.gaas.threeKingdoms.player.*;
+import com.gaas.threeKingdoms.rolecard.Role;
+import com.gaas.threeKingdoms.rolecard.RoleCard;
+import com.gaas.threeKingdoms.round.Round;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HeavenlyDoubleHalberdTest {
+
+    @DisplayName("A 裝備方天畫戟 → 攻擊範圍 4")
+    @Test
+    public void testEquipHalberd_AttackRangeIs4() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        playerA.getHand().addCardToHand(new HeavenlyDoubleHalberdCard(EDQ103));
+
+        game.playerPlayCard(playerA.getId(), EDQ103.getCardId(), playerA.getId(), PlayType.ACTIVE.getPlayType());
+
+        assertInstanceOf(HeavenlyDoubleHalberdCard.class, playerA.getEquipmentWeaponCard());
+        assertEquals(4, ((HeavenlyDoubleHalberdCard) playerA.getEquipmentWeaponCard()).getWeaponDistance());
+    }
+
+    @DisplayName("A 用方天畫戟出殺 + 2 個額外目標 → 廣播 trigger event 並問 B 出閃")
+    @Test
+    public void testUseHalberdKill_TwoAdditionalTargets_EmitsTriggerEventAndAsksFirstTarget() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        equipHalberdWithSingleKill(playerA);
+
+        List<DomainEvent> events = game.playerUseHeavenlyDoubleHalberdKill(
+                "player-a", BS8008.getCardId(), "player-b", List.of("player-c", "player-d"));
+
+        HeavenlyDoubleHalberdKillTriggerEvent trigger = events.stream()
+                .filter(e -> e instanceof HeavenlyDoubleHalberdKillTriggerEvent)
+                .map(e -> (HeavenlyDoubleHalberdKillTriggerEvent) e)
+                .findFirst().orElseThrow(() -> new AssertionError("trigger event missing"));
+        assertEquals("player-a", trigger.getAttackerPlayerId());
+        assertEquals(BS8008.getCardId(), trigger.getCardId());
+        assertEquals(List.of("player-b", "player-c", "player-d"), trigger.getTargetPlayerIds());
+
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent
+                && ((AskDodgeEvent) e).getPlayerId().equals("player-b")));
+        assertEquals(0, playerA.getHandSize());
+    }
+
+    @DisplayName("A 用方天畫戟出殺 + 1 個額外目標 → 問 B 出閃（只有 2 個目標）")
+    @Test
+    public void testUseHalberdKill_OneAdditionalTarget_EmitsAsksFirstTarget() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        equipHalberdWithSingleKill(playerA);
+
+        List<DomainEvent> events = game.playerUseHeavenlyDoubleHalberdKill(
+                "player-a", BS8008.getCardId(), "player-b", List.of("player-c"));
+
+        HeavenlyDoubleHalberdKillTriggerEvent trigger = events.stream()
+                .filter(e -> e instanceof HeavenlyDoubleHalberdKillTriggerEvent)
+                .map(e -> (HeavenlyDoubleHalberdKillTriggerEvent) e)
+                .findFirst().orElseThrow();
+        assertEquals(List.of("player-b", "player-c"), trigger.getTargetPlayerIds());
+    }
+
+    @DisplayName("A 用方天畫戟出殺但 0 個額外目標 → 短路走一般 playCard 流程，不產生 halberd 事件")
+    @Test
+    public void testUseHalberdKill_ZeroAdditionalTargets_ShortCircuits() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        equipHalberdWithSingleKill(playerA);
+
+        List<DomainEvent> events = game.playerUseHeavenlyDoubleHalberdKill(
+                "player-a", BS8008.getCardId(), "player-b", List.of());
+
+        // 走 NormalActiveKillBehavior 路徑
+        assertFalse(game.getTopBehavior().isEmpty());
+        assertInstanceOf(NormalActiveKillBehavior.class, game.getTopBehavior().peek());
+        assertFalse(game.getTopBehavior().peek() instanceof HeavenlyDoubleHalberdKillBehavior);
+        // 不會發 halberd trigger event
+        assertFalse(events.stream().anyMatch(e -> e instanceof HeavenlyDoubleHalberdKillTriggerEvent));
+        // 會有一般出牌流程的 AskDodgeEvent
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent));
+    }
+
+    @DisplayName("全部目標都不出閃 → 每個都扣 1 血")
+    @Test
+    public void testUseHalberdKill_AllTargetsSkipDodge_AllTakeDamage() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+        Player playerD = game.getPlayer("player-d");
+        equipHalberdWithSingleKill(playerA);
+
+        game.playerUseHeavenlyDoubleHalberdKill(
+                "player-a", BS8008.getCardId(), "player-b", List.of("player-c", "player-d"));
+
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+
+        assertEquals(3, playerB.getHP());
+        assertEquals(3, playerC.getHP());
+        assertEquals(3, playerD.getHP());
+        assertEquals(0, game.getTopBehavior().size());
+    }
+
+    @DisplayName("全部目標都出閃 → 沒有人扣血")
+    @Test
+    public void testUseHalberdKill_AllTargetsPlayDodge_NoDamage() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+        Player playerD = game.getPlayer("player-d");
+        equipHalberdWithSingleKill(playerA);
+        playerB.getHand().addCardToHand(new Dodge(BH2028));
+        playerC.getHand().addCardToHand(new Dodge(BH2041));
+        playerD.getHand().addCardToHand(new Dodge(BD2080));
+
+        game.playerUseHeavenlyDoubleHalberdKill(
+                "player-a", BS8008.getCardId(), "player-b", List.of("player-c", "player-d"));
+
+        game.playerPlayCard("player-b", BH2028.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
+        game.playerPlayCard("player-c", BH2041.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
+        game.playerPlayCard("player-d", BD2080.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
+
+        assertEquals(4, playerB.getHP());
+        assertEquals(4, playerC.getHP());
+        assertEquals(4, playerD.getHP());
+        assertEquals(0, game.getTopBehavior().size());
+    }
+
+    @DisplayName("B 出閃、C 不出閃、D 出閃 → 只有 C 扣血")
+    @Test
+    public void testUseHalberdKill_MixedResponses_OnlySkipperTakesDamage() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+        Player playerD = game.getPlayer("player-d");
+        equipHalberdWithSingleKill(playerA);
+        playerB.getHand().addCardToHand(new Dodge(BH2028));
+        playerD.getHand().addCardToHand(new Dodge(BD2080));
+
+        game.playerUseHeavenlyDoubleHalberdKill(
+                "player-a", BS8008.getCardId(), "player-b", List.of("player-c", "player-d"));
+
+        game.playerPlayCard("player-b", BH2028.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
+        game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-d", BD2080.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
+
+        assertEquals(4, playerB.getHP());
+        assertEquals(3, playerC.getHP());
+        assertEquals(4, playerD.getHP());
+        assertEquals(0, game.getTopBehavior().size());
+    }
+
+    @DisplayName("第一個目標有八卦陣 → 先發 AskPlayEquipmentEffectEvent")
+    @Test
+    public void testUseHalberdKill_FirstTargetHasEightDiagram_AsksEquipmentEffectFirst() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        equipHalberdWithSingleKill(playerA);
+        playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
+
+        List<DomainEvent> events = game.playerUseHeavenlyDoubleHalberdKill(
+                "player-a", BS8008.getCardId(), "player-b", List.of("player-c"));
+
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskPlayEquipmentEffectEvent));
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskDodgeEvent));
+    }
+
+    @DisplayName("C HP=1 且不出閃 → C 進入瀕死流程，D 仍被詢問")
+    @Test
+    public void testUseHalberdKill_MiddleTargetDying_DFlowStillResumes() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        Player playerC = game.getPlayer("player-c");
+        playerC.setBloodCard(new BloodCard(1));
+        equipHalberdWithSingleKill(playerA);
+        Player playerB = game.getPlayer("player-b");
+        playerB.getHand().addCardToHand(new Dodge(BH2028));
+
+        game.playerUseHeavenlyDoubleHalberdKill(
+                "player-a", BS8008.getCardId(), "player-b", List.of("player-c", "player-d"));
+
+        // B 出閃
+        game.playerPlayCard("player-b", BH2028.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
+        // C 不出閃 → 扣血至 0 → 進入瀕死
+        List<DomainEvent> dyingEvents = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+
+        assertTrue(dyingEvents.stream().anyMatch(e -> e instanceof AskPeachEvent));
+        assertEquals(0, playerC.getHP());
+
+        // 所有人跳過救桃 → C 死亡 (peach-ask 順序從 dying player 開始: C → D → E → A → B)
+        game.playerPlayCard("player-c", "", "player-c", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-d", "", "player-c", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-e", "", "player-c", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-a", "", "player-c", PlayType.SKIP.getPlayType());
+        List<DomainEvent> resumeEvents =
+                game.playerPlayCard("player-b", "", "player-c", PlayType.SKIP.getPlayType());
+
+        // 應該恢復詢問 D 出閃
+        assertTrue(resumeEvents.stream().anyMatch(e -> e instanceof AskDodgeEvent
+                && ((AskDodgeEvent) e).getPlayerId().equals("player-d")));
+    }
+
+    @DisplayName("A 沒裝備方天畫戟 → 拋例外")
+    @Test
+    public void testNoHalberd_ThrowsException() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        playerA.getHand().addCardToHand(new Kill(BS8008));
+
+        assertThrows(IllegalStateException.class, () ->
+                game.playerUseHeavenlyDoubleHalberdKill(
+                        "player-a", BS8008.getCardId(), "player-b", List.of("player-c")));
+    }
+
+    @DisplayName("A 的殺不是最後一張手牌 → 拋例外")
+    @Test
+    public void testNotLastHandCard_ThrowsException() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        playerA.getEquipment().setWeapon(new HeavenlyDoubleHalberdCard(EDQ103));
+        playerA.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Peach(BH3029)));
+
+        assertThrows(IllegalStateException.class, () ->
+                game.playerUseHeavenlyDoubleHalberdKill(
+                        "player-a", BS8008.getCardId(), "player-b", List.of("player-c")));
+    }
+
+    @DisplayName("additionalTargets 超過 2 → 拋例外")
+    @Test
+    public void testMoreThanTwoAdditionalTargets_ThrowsException() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        equipHalberdWithSingleKill(playerA);
+
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseHeavenlyDoubleHalberdKill(
+                        "player-a", BS8008.getCardId(), "player-b",
+                        List.of("player-c", "player-d", "player-e")));
+    }
+
+    @DisplayName("additionalTargets 包含重複玩家 → 拋例外")
+    @Test
+    public void testDuplicateAdditionalTarget_ThrowsException() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        equipHalberdWithSingleKill(playerA);
+
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseHeavenlyDoubleHalberdKill(
+                        "player-a", BS8008.getCardId(), "player-b",
+                        List.of("player-b", "player-c")));
+    }
+
+    @DisplayName("additionalTargets 包含自己 → 拋例外")
+    @Test
+    public void testSelfAsAdditionalTarget_ThrowsException() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        equipHalberdWithSingleKill(playerA);
+
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseHeavenlyDoubleHalberdKill(
+                        "player-a", BS8008.getCardId(), "player-b",
+                        List.of("player-c", "player-a")));
+    }
+
+    @DisplayName("primaryTarget 是自己 → 拋例外")
+    @Test
+    public void testSelfAsPrimaryTarget_ThrowsException() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        equipHalberdWithSingleKill(playerA);
+
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseHeavenlyDoubleHalberdKill(
+                        "player-a", BS8008.getCardId(), "player-a",
+                        List.of("player-b", "player-c")));
+    }
+
+    @DisplayName("cardId 不在手牌 → 拋例外")
+    @Test
+    public void testCardNotInHand_ThrowsException() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        playerA.getEquipment().setWeapon(new HeavenlyDoubleHalberdCard(EDQ103));
+        playerA.getHand().addCardToHand(new Kill(BS8008));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseHeavenlyDoubleHalberdKill(
+                        "player-a", BS9009.getCardId(), "player-b", List.of("player-c")));
+    }
+
+    @DisplayName("cardId 指向非殺 → 拋例外")
+    @Test
+    public void testCardNotKill_ThrowsException() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        playerA.getEquipment().setWeapon(new HeavenlyDoubleHalberdCard(EDQ103));
+        playerA.getHand().addCardToHand(new Peach(BH3029));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseHeavenlyDoubleHalberdKill(
+                        "player-a", BH3029.getCardId(), "player-b", List.of("player-c")));
+    }
+
+    @DisplayName("本回合已出過殺 → 拋例外")
+    @Test
+    public void testAlreadyPlayedKillThisRound_ThrowsException() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        playerA.getEquipment().setWeapon(new HeavenlyDoubleHalberdCard(EDQ103));
+        playerA.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Kill(BS9009)));
+
+        // 先出一張普通殺
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", PlayType.ACTIVE.getPlayType());
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+
+        // 再嘗試用方天畫戟出殺 → 應拋例外（此時只剩 BS9009 一張，滿足 last hand card）
+        assertThrows(IllegalStateException.class, () ->
+                game.playerUseHeavenlyDoubleHalberdKill(
+                        "player-a", BS9009.getCardId(), "player-c", List.of("player-d")));
+    }
+
+    // -------- Helpers --------
+
+    /** 給 A 裝備方天畫戟並只放一張殺在手中 */
+    private void equipHalberdWithSingleKill(Player playerA) {
+        playerA.getEquipment().setWeapon(new HeavenlyDoubleHalberdCard(EDQ103));
+        playerA.getHand().addCardToHand(new Kill(BS8008));
+    }
+
+    /** 建立 5 人場 game，玩家 A (monarch)、B、C、D、E */
+    private Game createGame() {
+        Game game = new Game();
+        game.initDeck();
+        Player playerA = playerBuilder("player-a", Role.MONARCH);
+        Player playerB = playerBuilder("player-b", Role.TRAITOR);
+        Player playerC = playerBuilder("player-c", Role.MINISTER);
+        Player playerD = playerBuilder("player-d", Role.REBEL);
+        Player playerE = playerBuilder("player-e", Role.REBEL);
+        game.setPlayers(asList(playerA, playerB, playerC, playerD, playerE));
+        game.enterPhase(new Normal(game));
+        game.setCurrentRound(new Round(playerA));
+        return game;
+    }
+
+    private Player playerBuilder(String id, Role role) {
+        return PlayerBuilder.construct()
+                .withId(id)
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(General.劉備))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(role))
+                .withEquipment(new Equipment())
+                .withHand(new Hand())
+                .build();
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/GameController.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/GameController.java
@@ -37,6 +37,7 @@ public class GameController {
     private final UseGreenDragonCrescentBladeEffectUseCase useGreenDragonCrescentBladeEffectUseCase;
     private final UseStonePiercingAxeEffectUseCase useStonePiercingAxeEffectUseCase;
     private final UseViperSpearKillUseCase useViperSpearKillUseCase;
+    private final UseHeavenlyDoubleHalberdKillUseCase useHeavenlyDoubleHalberdKillUseCase;
 
     @Autowired
     private WebSocketBroadCast webSocketBroadCast;
@@ -174,6 +175,14 @@ public class GameController {
         UseViperSpearKillPresenter presenter = new UseViperSpearKillPresenter();
         useViperSpearKillUseCase.execute(gameId, request.toUseViperSpearKillRequest(), presenter);
         webSocketBroadCast.pushUseViperSpearKillEvent(presenter);
+        return ResponseEntity.ok(HttpStatus.OK);
+    }
+
+    @PostMapping("/api/games/{gameId}/player:useHeavenlyDoubleHalberdKill")
+    public ResponseEntity<?> playerUseHeavenlyDoubleHalberdKill(@PathVariable String gameId, @RequestBody UseHeavenlyDoubleHalberdKillRequest request) {
+        UseHeavenlyDoubleHalberdKillPresenter presenter = new UseHeavenlyDoubleHalberdKillPresenter();
+        useHeavenlyDoubleHalberdKillUseCase.execute(gameId, request.toUseHeavenlyDoubleHalberdKillRequest(), presenter);
+        webSocketBroadCast.pushUseHeavenlyDoubleHalberdKillEvent(presenter);
         return ResponseEntity.ok(HttpStatus.OK);
     }
 

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/WebSocketBroadCast.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/WebSocketBroadCast.java
@@ -231,6 +231,19 @@ public class WebSocketBroadCast {
         }
     }
 
+    public void pushUseHeavenlyDoubleHalberdKillEvent(UseHeavenlyDoubleHalberdKillPresenter presenter) {
+        List<UseHeavenlyDoubleHalberdKillPresenter.GameViewModel> viewModels = presenter.present();
+        try {
+            for (UseHeavenlyDoubleHalberdKillPresenter.GameViewModel viewModel : viewModels) {
+                String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(viewModel);
+                messagingTemplate.convertAndSend(String.format("/websocket/legendsOfTheThreeKingdoms/%s/%s", viewModel.getGameId(), viewModel.getPlayerId()), json);
+            }
+        } catch (Exception e) {
+            System.err.println("****************** pushUseHeavenlyDoubleHalberdKillEvent ");
+            e.printStackTrace();
+        }
+    }
+
     public void pushUseDismantleEvent(UseDismantlePresenter presenter) {
         List<UseDismantlePresenter.GameViewModel> useDismantleViewModels = presenter.present();
         try {

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/UseHeavenlyDoubleHalberdKillRequest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/UseHeavenlyDoubleHalberdKillRequest.java
@@ -1,0 +1,21 @@
+package com.gaas.threeKingdoms.controller.dto;
+
+import com.gaas.threeKingdoms.usecase.UseHeavenlyDoubleHalberdKillUseCase;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class UseHeavenlyDoubleHalberdKillRequest {
+    private String playerId;
+    private String cardId;
+    private String primaryTargetPlayerId;
+    private List<String> additionalTargetPlayerIds;
+
+    public UseHeavenlyDoubleHalberdKillUseCase.UseHeavenlyDoubleHalberdKillRequest toUseHeavenlyDoubleHalberdKillRequest() {
+        return new UseHeavenlyDoubleHalberdKillUseCase.UseHeavenlyDoubleHalberdKillRequest(
+                playerId, cardId, primaryTargetPlayerId, additionalTargetPlayerIds);
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseEquipmentEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseEquipmentEffectPresenter.java
@@ -120,6 +120,12 @@ public class UseEquipmentEffectPresenter implements UseEquipmentUseCase.UseEquip
         }
     }
 
+    public static class HeavenlyDoubleHalberdKillTriggerViewModel extends ViewModel<HeavenlyDoubleHalberdKillTriggerDataViewModel> {
+        public HeavenlyDoubleHalberdKillTriggerViewModel(HeavenlyDoubleHalberdKillTriggerDataViewModel data) {
+            super("HeavenlyDoubleHalberdKillTriggerEvent", data, "方天畫戟發動");
+        }
+    }
+
     public static class SkipEquipmentEffectViewModel extends ViewModel<SkipEquipmentEffectDataViewModel> {
         public SkipEquipmentEffectViewModel(SkipEquipmentEffectDataViewModel data) {
             super("SkipEquipmentEffectEvent", data, "跳過裝備效果");
@@ -209,6 +215,15 @@ public class UseEquipmentEffectPresenter implements UseEquipmentUseCase.UseEquip
         private String attackerPlayerId;
         private String targetPlayerId;
         private List<String> discardedCardIds;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class HeavenlyDoubleHalberdKillTriggerDataViewModel {
+        private String attackerPlayerId;
+        private String cardId;
+        private List<String> targetPlayerIds;
     }
 
     @Data

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseHeavenlyDoubleHalberdKillPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseHeavenlyDoubleHalberdKillPresenter.java
@@ -1,0 +1,79 @@
+package com.gaas.threeKingdoms.presenter;
+
+import com.gaas.threeKingdoms.events.*;
+import com.gaas.threeKingdoms.presenter.common.GameDataViewModel;
+import com.gaas.threeKingdoms.presenter.common.PlayerDataViewModel;
+import com.gaas.threeKingdoms.presenter.common.RoundDataViewModel;
+import com.gaas.threeKingdoms.presenter.mapper.DomainEventToViewModelMapper;
+import com.gaas.threeKingdoms.usecase.UseHeavenlyDoubleHalberdKillUseCase;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.gaas.threeKingdoms.presenter.ViewModel.getEvent;
+
+public class UseHeavenlyDoubleHalberdKillPresenter implements UseHeavenlyDoubleHalberdKillUseCase.UseHeavenlyDoubleHalberdKillPresenter<List<UseHeavenlyDoubleHalberdKillPresenter.GameViewModel>> {
+
+    private List<GameViewModel> viewModels = new ArrayList<>();
+    private final DomainEventToViewModelMapper domainEventToViewModelMapper = new DomainEventToViewModelMapper();
+
+    @Override
+    public void renderEvents(List<DomainEvent> events) {
+        List<ViewModel<?>> effectViewModels = domainEventToViewModelMapper.mapEventsToViewModels(events);
+
+        GameStatusEvent gameStatusEvent = getEvent(events, GameStatusEvent.class).orElseThrow();
+        List<PlayerEvent> playerEvents = gameStatusEvent.getSeats();
+        RoundEvent roundEvent = gameStatusEvent.getRound();
+        List<PlayerDataViewModel> playerDataViewModels = playerEvents.stream().map(PlayerDataViewModel::new).toList();
+
+        RoundDataViewModel roundDataViewModel = new RoundDataViewModel(roundEvent);
+
+        for (PlayerDataViewModel viewModel : playerDataViewModels) {
+            GameDataViewModel gameDataViewModel = new GameDataViewModel(
+                    PlayerDataViewModel.hiddenOtherPlayerRoleInformation(
+                            playerDataViewModels, viewModel.getId()), roundDataViewModel, gameStatusEvent.getGamePhase());
+
+            List<ViewModel<?>> personalEventToViewModels = new ArrayList<>(effectViewModels);
+
+            personalEventToViewModels = personalEventToViewModels.stream().map(personalViewModel -> {
+                if (personalViewModel instanceof PlayCardPresenter.WaitForWardViewModel waitForWardViewModel) {
+                    WaitForWardEvent waitForWardEvent = getEvent(events, WaitForWardEvent.class).orElseThrow(RuntimeException::new);
+                    if (waitForWardEvent.getPlayerIds().contains(viewModel.getId())) {
+                        return (ViewModel<?>) new PlayCardPresenter.AskPlayWardViewModel(waitForWardViewModel.getData());
+                    }
+                }
+                return personalViewModel;
+            }).collect(Collectors.toList());
+
+            viewModels.add(new GameViewModel(
+                    personalEventToViewModels,
+                    gameDataViewModel,
+                    gameStatusEvent.getMessage(),
+                    gameStatusEvent.getGameId(),
+                    viewModel.getId()));
+        }
+    }
+
+    @Override
+    public List<GameViewModel> present() {
+        return viewModels;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class GameViewModel extends GameProcessViewModel<GameDataViewModel> {
+        private String gameId;
+        private String playerId;
+
+        public GameViewModel(List<ViewModel<?>> viewModels, GameDataViewModel data, String message, String gameId, String playerId) {
+            super(viewModels, data, message);
+            this.gameId = gameId;
+            this.playerId = playerId;
+        }
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/mapper/DomainEventToViewModelMapper.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/mapper/DomainEventToViewModelMapper.java
@@ -262,6 +262,16 @@ public class DomainEventToViewModelMapper {
             return new UseEquipmentEffectPresenter.ViperSpearKillTriggerViewModel(dataViewModel);
         });
 
+        eventToViewModelMappers.put(HeavenlyDoubleHalberdKillTriggerEvent.class, event -> {
+            HeavenlyDoubleHalberdKillTriggerEvent triggerEvent = (HeavenlyDoubleHalberdKillTriggerEvent) event;
+            UseEquipmentEffectPresenter.HeavenlyDoubleHalberdKillTriggerDataViewModel dataViewModel = new UseEquipmentEffectPresenter.HeavenlyDoubleHalberdKillTriggerDataViewModel(
+                    triggerEvent.getAttackerPlayerId(),
+                    triggerEvent.getCardId(),
+                    triggerEvent.getTargetPlayerIds()
+            );
+            return new UseEquipmentEffectPresenter.HeavenlyDoubleHalberdKillTriggerViewModel(dataViewModel);
+        });
+
         eventToViewModelMappers.put(AskChooseMountCardEvent.class, event -> {
             AskChooseMountCardEvent askChooseMountEvent = (AskChooseMountCardEvent) event;
             UseEquipmentEffectPresenter.AskChooseMountCardDataViewModel dataViewModel = new UseEquipmentEffectPresenter.AskChooseMountCardDataViewModel(

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
@@ -150,6 +150,14 @@ public class BehaviorData {
                         discardedCardIds
                 );
             }
+            case "HeavenlyDoubleHalberdKillBehavior" -> new HeavenlyDoubleHalberdKillBehavior(
+                    game,
+                    game.getPlayer(behaviorPlayerId),
+                    reactionPlayers,
+                    game.getPlayer(currentReactionPlayerId),
+                    cardId,
+                    PlayCard.findById(cardId)
+            );
             case "PeachBehavior" -> new PeachBehavior(
                     game,
                     game.getPlayer(behaviorPlayerId),

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/data/BehaviorDataTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/data/BehaviorDataTest.java
@@ -4,6 +4,7 @@ import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.behavior.Behavior;
 import com.gaas.threeKingdoms.behavior.behavior.BarbarianInvasionBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.BountifulHarvestBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.HeavenlyDoubleHalberdKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.ViperSpearKillBehavior;
 import com.gaas.threeKingdoms.e2e.MockUtil;
 import com.gaas.threeKingdoms.generalcard.General;
@@ -286,5 +287,38 @@ public class BehaviorDataTest {
         assertEquals("player-b", restoredViperSpear.getCurrentReactionPlayer().getId());
         assertEquals(reactionPlayers, restoredViperSpear.getReactionPlayers());
         assertInstanceOf(VirtualKill.class, restoredViperSpear.getCard());
+    }
+
+    @Test
+    public void testHeavenlyDoubleHalberdKillBehaviorRoundTrip_PreservesMultiTargetState() {
+        // Arrange
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(PlayCard.BS8008));
+        Player playerB = createPlayer("player-b", 4, General.張飛, HealthStatus.ALIVE, Role.REBEL);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+
+        List<String> reactionPlayers = Arrays.asList("player-b", "player-c");
+        Game game = MockUtil.initGame("123456", List.of(playerA, playerB, playerC), playerA);
+
+        HeavenlyDoubleHalberdKillBehavior behavior = new HeavenlyDoubleHalberdKillBehavior(
+                game, playerA, reactionPlayers, playerB,
+                "BS8008", new Kill(PlayCard.BS8008));
+
+        // Act: fromDomain → toDomain round-trip
+        BehaviorData behaviorData = BehaviorData.fromDomain(behavior);
+        Behavior restored = behaviorData.toDomain(game);
+
+        // Assert
+        assertEquals("HeavenlyDoubleHalberdKillBehavior", behaviorData.getBehaviorName());
+        assertEquals("BS8008", behaviorData.getCardId());
+        assertEquals(reactionPlayers, behaviorData.getReactionPlayers());
+        assertEquals("player-b", behaviorData.getCurrentReactionPlayerId());
+
+        assertInstanceOf(HeavenlyDoubleHalberdKillBehavior.class, restored);
+        HeavenlyDoubleHalberdKillBehavior restoredHalberd = (HeavenlyDoubleHalberdKillBehavior) restored;
+        assertEquals(reactionPlayers, restoredHalberd.getReactionPlayers());
+        assertEquals("player-b", restoredHalberd.getCurrentReactionPlayer().getId());
+        assertEquals("player-a", restoredHalberd.getBehaviorPlayer().getId());
+        assertInstanceOf(Kill.class, restoredHalberd.getCard());
     }
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/MockMvcUtil.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/MockMvcUtil.java
@@ -110,6 +110,22 @@ public class MockMvcUtil {
                         }""", playerId, targetPlayerId, cardIdsJson)));
     }
 
+    public ResultActions useHeavenlyDoubleHalberdKill(String gameId, String playerId, String cardId,
+                                                      String primaryTargetPlayerId,
+                                                      java.util.List<String> additionalTargetPlayerIds) throws Exception {
+        String additionalJson = additionalTargetPlayerIds.stream()
+                .map(id -> "\"" + id + "\"")
+                .collect(java.util.stream.Collectors.joining(","));
+        return this.mockMvc.perform(post("/api/games/" + gameId + "/player:useHeavenlyDoubleHalberdKill")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(String.format("""
+                        { "playerId": "%s",
+                          "cardId": "%s",
+                          "primaryTargetPlayerId": "%s",
+                          "additionalTargetPlayerIds": [%s]
+                        }""", playerId, cardId, primaryTargetPlayerId, additionalJson)));
+    }
+
     public ResultActions playCard(String gameId, String currentPlayerId, String targetPlayerId, String cardId, String playType) throws Exception {
         return this.mockMvc.perform(post("/api/games/" + gameId + "/player:playCard")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/equipment/HeavenlyDoubleHalberdTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/equipment/HeavenlyDoubleHalberdTest.java
@@ -1,0 +1,180 @@
+package com.gaas.threeKingdoms.e2e.equipment;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.Deck;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.HeavenlyDoubleHalberdCard;
+import com.gaas.threeKingdoms.player.HealthStatus;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.rolecard.Role;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.gaas.threeKingdoms.e2e.MockUtil.createPlayer;
+import static com.gaas.threeKingdoms.e2e.MockUtil.initGame;
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class HeavenlyDoubleHalberdTest extends AbstractBaseIntegrationTest {
+
+    // 若需要重產本 class 的 fixture，把下列 @Override 取消註解並改為 return true，
+    // 產完後務必改回 false 或刪除 override 再 commit。
+    // @Override protected boolean shouldRegenerateFixtures() { return true; }
+
+    @Test
+    public void testEquipHeavenlyDoubleHalberd() throws Exception {
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new HeavenlyDoubleHalberdCard(EDQ103));
+        Player playerB = createPlayer("player-b", 4, General.劉備, HealthStatus.ALIVE, Role.TRAITOR);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Kill(BS8008), new Peach(BH3029), new Dodge(BH2028), new Kill(BS9009)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        mockMvcUtil.playCard(gameId, "player-a", "player-a", "EDQ103", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+
+        assertAllPlayerJson("src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/player_a_equip_halberd_for_%s.json");
+    }
+
+    @Test
+    public void testUseHalberdKill_TriggerEventBroadcast() throws Exception {
+        givenPlayerAEquippedHalberdWithSingleKill();
+
+        mockMvcUtil.useHeavenlyDoubleHalberdKill(gameId, "player-a", "BS8008",
+                        "player-b", List.of("player-c"))
+                .andExpect(status().isOk()).andReturn();
+
+        // 驗證 HeavenlyDoubleHalberdKillTriggerEvent + AskDodgeEvent(B) 有廣播到 4 位玩家
+        assertAllPlayerJson("src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_trigger_for_%s.json");
+    }
+
+    @Test
+    public void testUseHalberdKill_TwoTargetsSkip_BothTakeDamage() throws Exception {
+        givenPlayerAEquippedHalberdWithSingleKill();
+
+        mockMvcUtil.useHeavenlyDoubleHalberdKill(gameId, "player-a", "BS8008",
+                        "player-b", List.of("player-c"))
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", PlayType.SKIP.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        mockMvcUtil.playCard(gameId, "player-c", "player-a", "", PlayType.SKIP.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+
+        assertAllPlayerJson("src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_all_skip_for_%s.json");
+    }
+
+    @Test
+    public void testUseHalberdKill_MixedDodgeAndSkip() throws Exception {
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008));
+        playerA.getEquipment().setWeapon(new HeavenlyDoubleHalberdCard(EDQ103));
+
+        Player playerB = createPlayer("player-b", 4, General.劉備, HealthStatus.ALIVE, Role.TRAITOR,
+                new Dodge(BH2028));
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Kill(BS0010), new Peach(BH6032), new Dodge(BH7033), new Kill(BS7020)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        mockMvcUtil.useHeavenlyDoubleHalberdKill(gameId, "player-a", "BS8008",
+                        "player-b", List.of("player-c"))
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B 出閃
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "BH2028", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // C 不出閃 → 扣血
+        mockMvcUtil.playCard(gameId, "player-c", "player-a", "", PlayType.SKIP.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+
+        assertAllPlayerJson("src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_mixed_for_%s.json");
+    }
+
+    @Test
+    public void testUseHalberdKill_ZeroAdditional_ShortCircuitsToNormalKill() throws Exception {
+        givenPlayerAEquippedHalberdWithSingleKill();
+
+        // additional 空陣列 → 短路為一般殺
+        mockMvcUtil.useHeavenlyDoubleHalberdKill(gameId, "player-a", "BS8008",
+                        "player-b", List.of())
+                .andExpect(status().isOk()).andReturn();
+
+        // 驗證沒有 HeavenlyDoubleHalberdKillTriggerEvent，只有一般 PlayCardEvent + AskDodgeEvent
+        assertAllPlayerJson("src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_short_circuit_for_%s.json");
+    }
+
+    @Test
+    public void testUseHalberdKill_NotEquipped_Returns4xx() throws Exception {
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008));
+        Player playerB = createPlayer("player-b", 4, General.劉備, HealthStatus.ALIVE, Role.TRAITOR);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        game.setDeck(new Deck());
+        repository.save(game);
+
+        mockMvcUtil.useHeavenlyDoubleHalberdKill(gameId, "player-a", "BS8008",
+                        "player-b", List.of("player-c"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    public void testUseHalberdKill_NotLastHandCard_Returns4xx() throws Exception {
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008), new Peach(BH3029));
+        playerA.getEquipment().setWeapon(new HeavenlyDoubleHalberdCard(EDQ103));
+
+        Player playerB = createPlayer("player-b", 4, General.劉備, HealthStatus.ALIVE, Role.TRAITOR);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        game.setDeck(new Deck());
+        repository.save(game);
+
+        // A 有兩張手牌 → halberd 不可觸發
+        mockMvcUtil.useHeavenlyDoubleHalberdKill(gameId, "player-a", "BS8008",
+                        "player-b", List.of("player-c"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    private void givenPlayerAEquippedHalberdWithSingleKill() {
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008));
+        playerA.getEquipment().setWeapon(new HeavenlyDoubleHalberdCard(EDQ103));
+
+        Player playerB = createPlayer("player-b", 4, General.劉備, HealthStatus.ALIVE, Role.TRAITOR);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Kill(BS0010), new Peach(BH6032), new Dodge(BH7033), new Kill(BS7020)));
+        game.setDeck(deck);
+        repository.save(game);
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_all_skip_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_all_skip_for_player_a.json
@@ -1,0 +1,78 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "targetPlayerId" : "player-a",
+      "cardId" : "",
+      "playType" : "skip"
+    },
+    "message" : "不出牌"
+  }, {
+    "event" : "PlayerDamagedEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "from" : 4,
+      "to" : 3
+    },
+    "message" : "扣血"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "不出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_all_skip_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_all_skip_for_player_b.json
@@ -1,0 +1,78 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "targetPlayerId" : "player-a",
+      "cardId" : "",
+      "playType" : "skip"
+    },
+    "message" : "不出牌"
+  }, {
+    "event" : "PlayerDamagedEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "from" : 4,
+      "to" : 3
+    },
+    "message" : "扣血"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "Traitor",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "不出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_all_skip_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_all_skip_for_player_c.json
@@ -1,0 +1,78 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "targetPlayerId" : "player-a",
+      "cardId" : "",
+      "playType" : "skip"
+    },
+    "message" : "不出牌"
+  }, {
+    "event" : "PlayerDamagedEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "from" : 4,
+      "to" : 3
+    },
+    "message" : "扣血"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "不出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_all_skip_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_all_skip_for_player_d.json
@@ -1,0 +1,78 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "targetPlayerId" : "player-a",
+      "cardId" : "",
+      "playType" : "skip"
+    },
+    "message" : "不出牌"
+  }, {
+    "event" : "PlayerDamagedEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "from" : 4,
+      "to" : 3
+    },
+    "message" : "扣血"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "不出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_mixed_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_mixed_for_player_a.json
@@ -1,0 +1,78 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "targetPlayerId" : "player-a",
+      "cardId" : "",
+      "playType" : "skip"
+    },
+    "message" : "不出牌"
+  }, {
+    "event" : "PlayerDamagedEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "from" : 4,
+      "to" : 3
+    },
+    "message" : "扣血"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "不出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_mixed_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_mixed_for_player_b.json
@@ -1,0 +1,78 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "targetPlayerId" : "player-a",
+      "cardId" : "",
+      "playType" : "skip"
+    },
+    "message" : "不出牌"
+  }, {
+    "event" : "PlayerDamagedEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "from" : 4,
+      "to" : 3
+    },
+    "message" : "扣血"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "Traitor",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "不出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_mixed_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_mixed_for_player_c.json
@@ -1,0 +1,78 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "targetPlayerId" : "player-a",
+      "cardId" : "",
+      "playType" : "skip"
+    },
+    "message" : "不出牌"
+  }, {
+    "event" : "PlayerDamagedEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "from" : 4,
+      "to" : 3
+    },
+    "message" : "扣血"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "不出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_mixed_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_mixed_for_player_d.json
@@ -1,0 +1,78 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "targetPlayerId" : "player-a",
+      "cardId" : "",
+      "playType" : "skip"
+    },
+    "message" : "不出牌"
+  }, {
+    "event" : "PlayerDamagedEvent",
+    "data" : {
+      "playerId" : "player-c",
+      "from" : 4,
+      "to" : 3
+    },
+    "message" : "扣血"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "不出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_short_circuit_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_short_circuit_for_player_a.json
@@ -1,0 +1,76 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "targetPlayerId" : "player-b",
+      "cardId" : "BS8008",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-b"
+    },
+    "message" : "請問 player-b 要否要出閃"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-b",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_short_circuit_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_short_circuit_for_player_b.json
@@ -1,0 +1,76 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "targetPlayerId" : "player-b",
+      "cardId" : "BS8008",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-b"
+    },
+    "message" : "請問 player-b 要否要出閃"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "Traitor",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-b",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_short_circuit_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_short_circuit_for_player_c.json
@@ -1,0 +1,76 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "targetPlayerId" : "player-b",
+      "cardId" : "BS8008",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-b"
+    },
+    "message" : "請問 player-b 要否要出閃"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-b",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_short_circuit_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_short_circuit_for_player_d.json
@@ -1,0 +1,76 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "targetPlayerId" : "player-b",
+      "cardId" : "BS8008",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-b"
+    },
+    "message" : "請問 player-b 要否要出閃"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-b",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_trigger_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_trigger_for_player_a.json
@@ -1,0 +1,84 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "targetPlayerId" : "",
+      "cardId" : "BS8008",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  }, {
+    "event" : "HeavenlyDoubleHalberdKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-a",
+      "cardId" : "BS8008",
+      "targetPlayerIds" : [ "player-b", "player-c" ]
+    },
+    "message" : "方天畫戟發動"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-b"
+    },
+    "message" : "請問 player-b 要否要出閃"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-b",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "方天畫戟發動",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_trigger_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_trigger_for_player_b.json
@@ -1,0 +1,84 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "targetPlayerId" : "",
+      "cardId" : "BS8008",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  }, {
+    "event" : "HeavenlyDoubleHalberdKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-a",
+      "cardId" : "BS8008",
+      "targetPlayerIds" : [ "player-b", "player-c" ]
+    },
+    "message" : "方天畫戟發動"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-b"
+    },
+    "message" : "請問 player-b 要否要出閃"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "Traitor",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-b",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "方天畫戟發動",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_trigger_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_trigger_for_player_c.json
@@ -1,0 +1,84 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "targetPlayerId" : "",
+      "cardId" : "BS8008",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  }, {
+    "event" : "HeavenlyDoubleHalberdKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-a",
+      "cardId" : "BS8008",
+      "targetPlayerIds" : [ "player-b", "player-c" ]
+    },
+    "message" : "方天畫戟發動"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-b"
+    },
+    "message" : "請問 player-b 要否要出閃"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-b",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "方天畫戟發動",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_trigger_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/halberd_kill_trigger_for_player_d.json
@@ -1,0 +1,84 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "targetPlayerId" : "",
+      "cardId" : "BS8008",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  }, {
+    "event" : "HeavenlyDoubleHalberdKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-a",
+      "cardId" : "BS8008",
+      "targetPlayerIds" : [ "player-b", "player-c" ]
+    },
+    "message" : "方天畫戟發動"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-b"
+    },
+    "message" : "請問 player-b 要否要出閃"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-b",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "方天畫戟發動",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/player_a_equip_halberd_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/player_a_equip_halberd_for_player_a.json
@@ -1,0 +1,78 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "targetPlayerId" : "player-a",
+      "cardId" : "EDQ103",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  }, {
+    "event" : "PlayEquipmentEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "cardId" : "EDQ103",
+      "deprecatedCardId" : ""
+    },
+    "message" : "玩家出裝備卡"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/player_a_equip_halberd_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/player_a_equip_halberd_for_player_b.json
@@ -1,0 +1,78 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "targetPlayerId" : "player-a",
+      "cardId" : "EDQ103",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  }, {
+    "event" : "PlayEquipmentEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "cardId" : "EDQ103",
+      "deprecatedCardId" : ""
+    },
+    "message" : "玩家出裝備卡"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "Traitor",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/player_a_equip_halberd_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/player_a_equip_halberd_for_player_c.json
@@ -1,0 +1,78 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "targetPlayerId" : "player-a",
+      "cardId" : "EDQ103",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  }, {
+    "event" : "PlayEquipmentEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "cardId" : "EDQ103",
+      "deprecatedCardId" : ""
+    },
+    "message" : "玩家出裝備卡"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/player_a_equip_halberd_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/HeavenlyDoubleHalberd/player_a_equip_halberd_for_player_d.json
@@ -1,0 +1,78 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "targetPlayerId" : "player-a",
+      "cardId" : "EDQ103",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  }, {
+    "event" : "PlayEquipmentEvent",
+    "data" : {
+      "playerId" : "player-a",
+      "cardId" : "EDQ103",
+      "deprecatedCardId" : ""
+    },
+    "message" : "玩家出裝備卡"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "EDQ103", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}


### PR DESCRIPTION
## Summary
- 方天畫戟 (EDQ103)：攻擊範圍 4，出殺時若該殺是最後一張手牌，可額外指定至多 2 名目標
- 三國殺 codebase 第一個多目標殺機制 — sequential polling（mirror ArrowBarrage pattern）
- 採用 dedicated API (`useHeavenlyDoubleHalberdKill`)，一次傳入 primary + additional targets
- 0 個 additional target → 短路走 `playerPlayCard`，等同正常殺（零 regression 保證）

## 實作重點

### Domain
- `HeavenlyDoubleHalberdCard.java` — 武器卡 (range 4)
- `HeavenlyDoubleHalberdKillBehavior.java` — 繼承 `NormalActiveKillBehavior`，完全 override `playerAction()` + `doResponseToPlayerAction()`，用 `reactionPlayers` 列表 + `currentReactionPlayer` 做 sequential polling
- `HeavenlyDoubleHalberdKillTriggerEvent.java` — 通知前端方天畫戟發動 (含 attacker/cardId/targetPlayerIds)
- `Game.playerUseHeavenlyDoubleHalberdKill()` — 驗證 + 短路 + 推 behavior

### 既有檔案修改
- `DyingAskPeachBehavior.java`：
  - `JudgementIfRemoveBehavior` 排除 halberd（避免中間目標死亡時誤 pop 多目標 behavior）
  - 新增 `addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior` hook（瀕死解決後恢復下一目標的詢問）
- `EightDiagramTacticEquipmentEffectHandler.java`：新增 instanceof 分支，八卦陣成功後推進 halberd 到下一目標
- `BehaviorData.java`：新增 halberd deserialization case

### 瀕死中斷流程（重點！）
目標 C 在被殺時 HP=0 → 進入 DyingAskPeachBehavior → 所有人跳過桃 → C 永久死亡 → hook 恢復 halberd 並 emit AskDodgeEvent(D) → D 正常結算。**Domain test `testUseHalberdKill_MiddleTargetDying_DFlowStillResumes` 全程驗證此流程通過。**

## Test plan
- [x] `mvn test` in `domain/` — 353 tests pass (+18)
- [x] `mvn test` in `spring/` — 210 tests pass (+7)
- [x] `mvn install -DskipTests` from parent — 編譯全綠
- [x] 瀕死中斷 test 包含在 Phase 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)