### PR TITLE
fix: 青龍偃月刀 bug — 八卦陣擋下時未觸發效果 (#154)

### DIFF
--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/effect/EightDiagramTacticEquipmentEffectHandler.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/effect/EightDiagramTacticEquipmentEffectHandler.java
@@ -91,10 +91,6 @@ public class EightDiagramTacticEquipmentEffectHandler extends EquipmentEffectHan
     }
 
     /**
-     * 方天畫戟：當前目標用八卦陣成功抵擋後，依「目標列表順序」推進到下一位目標並詢問出閃/防具效果。
-     * 若當前目標已是最後一位，則將 behavior 標記為結束。
-     */
-    /**
      * 青龍偃月刀：八卦陣成功視為出閃。若攻擊者裝備青龍偃月刀，則等同「殺被閃擋下」，
      * 需詢問攻擊者是否再出一張殺。
      */
@@ -120,6 +116,10 @@ public class EightDiagramTacticEquipmentEffectHandler extends EquipmentEffectHan
         events.add(new AskGreenDragonCrescentBladeEffectEvent(attacker.getId(), targetPlayerId));
     }
 
+    /**
+     * 方天畫戟：當前目標用八卦陣成功抵擋後，依「目標列表順序」推進到下一位目標並詢問出閃/防具效果。
+     * 若當前目標已是最後一位，則將 behavior 標記為結束。
+     */
     private void addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(List<DomainEvent> events, String playerId) {
         Behavior topBehavior = game.peekTopBehavior();
         if (topBehavior instanceof HeavenlyDoubleHalberdKillBehavior halberdBehavior) {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/effect/EightDiagramTacticEquipmentEffectHandler.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/effect/EightDiagramTacticEquipmentEffectHandler.java
@@ -4,11 +4,15 @@ import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.behavior.Behavior;
 import com.gaas.threeKingdoms.behavior.behavior.ArrowBarrageBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.HeavenlyDoubleHalberdKillBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.WaitingGreenDragonCrescentBladeResponseBehavior;
 import com.gaas.threeKingdoms.events.*;
 import com.gaas.threeKingdoms.handcard.EquipmentPlayType;
 import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.ArmorCard;
 import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic;
+import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.GreenDragonCrescentBladeCard;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.round.Round;
 import com.gaas.threeKingdoms.round.Stage;
@@ -60,6 +64,7 @@ public class EightDiagramTacticEquipmentEffectHandler extends EquipmentEffectHan
         if (isEightDiagramTacticEffectSuccess) {
             addAskDodgeEventIfCurrentBehaviorIsArrowBarrageBehavior(domainEvents);
             addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(domainEvents, playerId);
+            addAskGreenDragonCrescentBladeEventIfAttackerHasGDCB(domainEvents);
         } else {
             domainEvents.add(new AskDodgeEvent(playerId));
         }
@@ -89,6 +94,32 @@ public class EightDiagramTacticEquipmentEffectHandler extends EquipmentEffectHan
      * 方天畫戟：當前目標用八卦陣成功抵擋後，依「目標列表順序」推進到下一位目標並詢問出閃/防具效果。
      * 若當前目標已是最後一位，則將 behavior 標記為結束。
      */
+    /**
+     * 青龍偃月刀：八卦陣成功視為出閃。若攻擊者裝備青龍偃月刀，則等同「殺被閃擋下」，
+     * 需詢問攻擊者是否再出一張殺。
+     */
+    private void addAskGreenDragonCrescentBladeEventIfAttackerHasGDCB(List<DomainEvent> events) {
+        Behavior topBehavior = game.peekTopBehavior();
+        if (!(topBehavior instanceof NormalActiveKillBehavior killBehavior)) {
+            return;
+        }
+        Player attacker = killBehavior.getBehaviorPlayer();
+        if (!(attacker.getEquipmentWeaponCard() instanceof GreenDragonCrescentBladeCard)) {
+            return;
+        }
+        String targetPlayerId = killBehavior.getReactionPlayers().get(0);
+
+        // 保留底下的 NormalActiveKillBehavior（不要被 pop）
+        killBehavior.setIsOneRound(false);
+        game.getCurrentRound().setActivePlayer(attacker);
+
+        game.updateTopBehavior(new WaitingGreenDragonCrescentBladeResponseBehavior(
+                game, attacker, List.of(targetPlayerId), attacker,
+                killBehavior.getCardId(), PlayType.ACTIVE.getPlayType(), killBehavior.getCard()));
+
+        events.add(new AskGreenDragonCrescentBladeEffectEvent(attacker.getId(), targetPlayerId));
+    }
+
     private void addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(List<DomainEvent> events, String playerId) {
         Behavior topBehavior = game.peekTopBehavior();
         if (topBehavior instanceof HeavenlyDoubleHalberdKillBehavior halberdBehavior) {

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/GreenDragonCrescentBladeTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/GreenDragonCrescentBladeTest.java
@@ -6,11 +6,16 @@ import com.gaas.threeKingdoms.events.*;
 import com.gaas.threeKingdoms.gamephase.Normal;
 import com.gaas.threeKingdoms.generalcard.General;
 import com.gaas.threeKingdoms.generalcard.GeneralCard;
+import com.gaas.threeKingdoms.handcard.Deck;
+import com.gaas.threeKingdoms.handcard.EquipmentPlayType;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic;
+import com.gaas.threeKingdoms.handcard.equipmentcard.mountscard.RedRabbitHorse;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.GreenDragonCrescentBladeCard;
+import com.gaas.threeKingdoms.handcard.scrollcard.Dismantle;
 import com.gaas.threeKingdoms.player.*;
 import com.gaas.threeKingdoms.rolecard.Role;
 import com.gaas.threeKingdoms.rolecard.RoleCard;
@@ -303,6 +308,118 @@ public class GreenDragonCrescentBladeTest {
         // B 進入瀕死（AskPeachEvent）
         assertTrue(events.stream().anyMatch(e -> e instanceof AskPeachEvent));
         assertEquals(0, playerB.getHP());
+    }
+
+    @DisplayName("A 裝備青龍偃月刀 + B 裝備八卦陣 → A 出殺 → B 發動八卦陣抽到紅色成功 → A 收到 AskGreenDragonCrescentBladeEffectEvent")
+    @Test
+    public void testEightDiagramTacticSuccess_TriggersGreenDragonCrescentBladeAsk() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+
+        // 八卦陣成功判定用：deck 頂放紅色卡
+        game.setDeck(new Deck(List.of(new RedRabbitHorse(BH3029))));
+
+        playerA.getEquipment().setWeapon(new GreenDragonCrescentBladeCard(ES5005));
+        playerA.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Kill(BS9009)));
+        playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
+
+        // A 出殺
+        game.playerPlayCard(playerA.getId(), BS8008.getCardId(), playerB.getId(), PlayType.ACTIVE.getPlayType());
+
+        // B 發動八卦陣（成功 → 視為出閃）
+        List<DomainEvent> events = game.playerUseEquipment(playerB.getId(), ES2015.getCardId(), playerB.getId(), EquipmentPlayType.ACTIVE);
+
+        // A 應收到 AskGreenDragonCrescentBladeEffectEvent
+        AskGreenDragonCrescentBladeEffectEvent askEvent = events.stream()
+                .filter(e -> e instanceof AskGreenDragonCrescentBladeEffectEvent)
+                .map(e -> (AskGreenDragonCrescentBladeEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("AskGreenDragonCrescentBladeEffectEvent should be emitted when 八卦陣 succeeds"));
+        assertEquals("player-a", askEvent.getAttackerPlayerId());
+        assertEquals("player-b", askEvent.getTargetPlayerId());
+
+        // activePlayer 應為 A（等待選擇）
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("A 裝備青龍偃月刀 + B 裝備八卦陣 → 八卦陣成功 → A 選 KILL → 因 B 仍有八卦陣，要求 B 再發動裝備")
+    @Test
+    public void testEightDiagramTacticSuccess_AttackerChoosesKill_TargetAskedEquipmentAgain() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+
+        game.setDeck(new Deck(List.of(new RedRabbitHorse(BH3029))));
+
+        playerA.getEquipment().setWeapon(new GreenDragonCrescentBladeCard(ES5005));
+        playerA.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Kill(BS9009)));
+        playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
+
+        game.playerPlayCard(playerA.getId(), BS8008.getCardId(), playerB.getId(), PlayType.ACTIVE.getPlayType());
+        game.playerUseEquipment(playerB.getId(), ES2015.getCardId(), playerB.getId(), EquipmentPlayType.ACTIVE);
+
+        // A 選 KILL
+        List<DomainEvent> events = game.playerUseGreenDragonCrescentBladeEffect(
+                playerA.getId(),
+                AskGreenDragonCrescentBladeEffectEvent.Choice.KILL,
+                BS9009.getCardId());
+
+        assertTrue(events.stream().anyMatch(e -> e instanceof GreenDragonCrescentBladeTriggerEvent));
+        // B 仍裝備八卦陣 → 應收到 AskPlayEquipmentEffectEvent（而非 AskDodgeEvent）
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskPlayEquipmentEffectEvent));
+        assertEquals("player-b", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("A 裝備青龍偃月刀 + B 裝備八卦陣 → 八卦陣成功 → A 選 SKIP → 殺被抵銷")
+    @Test
+    public void testEightDiagramTacticSuccess_AttackerChoosesSkip_KillCancelled() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+
+        game.setDeck(new Deck(List.of(new RedRabbitHorse(BH3029))));
+
+        playerA.getEquipment().setWeapon(new GreenDragonCrescentBladeCard(ES5005));
+        playerA.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Kill(BS9009)));
+        playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
+        int playerBHpBefore = playerB.getHP();
+
+        game.playerPlayCard(playerA.getId(), BS8008.getCardId(), playerB.getId(), PlayType.ACTIVE.getPlayType());
+        game.playerUseEquipment(playerB.getId(), ES2015.getCardId(), playerB.getId(), EquipmentPlayType.ACTIVE);
+
+        game.playerUseGreenDragonCrescentBladeEffect(playerA.getId(),
+                AskGreenDragonCrescentBladeEffectEvent.Choice.SKIP, "");
+
+        assertEquals(playerBHpBefore, playerB.getHP());
+        assertEquals(0, game.getTopBehavior().size());
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("A 裝備青龍偃月刀 + B 裝備八卦陣 → 八卦陣抽到黑色失敗 → B 仍用一般閃流程（對照組）")
+    @Test
+    public void testEightDiagramTacticFails_FallsBackToNormalDodgeFlow() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+
+        // 八卦陣失敗判定用：deck 頂放黑色卡
+        game.setDeck(new Deck(List.of(new Dismantle(SS3003))));
+
+        playerA.getEquipment().setWeapon(new GreenDragonCrescentBladeCard(ES5005));
+        playerA.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Kill(BS9009)));
+        playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
+        playerB.getHand().addCardToHand(new Dodge(BH2028));
+
+        game.playerPlayCard(playerA.getId(), BS8008.getCardId(), playerB.getId(), PlayType.ACTIVE.getPlayType());
+
+        // 八卦陣失敗後應問 B 出閃
+        List<DomainEvent> events = game.playerUseEquipment(playerB.getId(), ES2015.getCardId(), playerB.getId(), EquipmentPlayType.ACTIVE);
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent));
+
+        // B 實際出閃 → 走一般 GDCB 觸發路徑
+        List<DomainEvent> dodgeEvents = game.playerPlayCard(playerB.getId(), BH2028.getCardId(), playerA.getId(), PlayType.ACTIVE.getPlayType());
+        assertTrue(dodgeEvents.stream().anyMatch(e -> e instanceof AskGreenDragonCrescentBladeEffectEvent));
     }
 
     // Helper

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/equipment/GreenDragonCrescentBladeTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/equipment/GreenDragonCrescentBladeTest.java
@@ -6,9 +6,12 @@ import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest
 import com.gaas.threeKingdoms.generalcard.General;
 import com.gaas.threeKingdoms.handcard.Deck;
 import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.EquipmentPlayType;
 import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic;
+import com.gaas.threeKingdoms.handcard.equipmentcard.mountscard.RedRabbitHorse;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.GreenDragonCrescentBladeCard;
 import com.gaas.threeKingdoms.player.HealthStatus;
 import com.gaas.threeKingdoms.player.Player;
@@ -28,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class GreenDragonCrescentBladeTest extends AbstractBaseIntegrationTest {
+
+    // @Override protected boolean shouldRegenerateFixtures() { return true; }
 
     @Test
     public void testEquipGreenDragonCrescentBlade() throws Exception {
@@ -117,6 +122,37 @@ public class GreenDragonCrescentBladeTest extends AbstractBaseIntegrationTest {
             String expectedJson = Files.readString(path);
             assertEquals(expectedJson, testPlayerJson);
         }
+    }
+
+    @Test
+    public void testEightDiagramTacticSuccess_TriggersGreenDragonCrescentBladeAsk() throws Exception {
+        // Given A 裝備青龍偃月刀 + B 裝備八卦陣，deck 頂是紅色卡（八卦陣成功）
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008), new Kill(BS9009));
+        playerA.getEquipment().setWeapon(new GreenDragonCrescentBladeCard(ES5005));
+
+        Player playerB = createPlayer("player-b", 4, General.劉備, HealthStatus.ALIVE, Role.TRAITOR);
+        playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
+
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+
+        List<Player> players = Arrays.asList(playerA, playerB, playerC, playerD);
+        Game game = initGame(gameId, players, playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new RedRabbitHorse(BH3029)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // When A 出殺 → B 發動八卦陣（抽到紅色成功）
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+        mockMvcUtil.useEquipment(gameId, "player-b", "player-b", "ES2015", EquipmentPlayType.ACTIVE)
+                .andExpect(status().isOk()).andReturn();
+
+        // Then A 應收到 AskGreenDragonCrescentBladeEffectEvent
+        assertAllPlayerJson("src/test/resources/TestJsonFile/EquipmentTest/GreenDragonCrescentBlade/gdcb_ask_after_eight_diagram_success_for_%s.json");
     }
 
     private void givenPlayerAEquippedGreenDragonCrescentBlade() {

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/GreenDragonCrescentBlade/gdcb_ask_after_eight_diagram_success_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/GreenDragonCrescentBlade/gdcb_ask_after_eight_diagram_success_for_player_a.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "UseEquipmentEffectEvent",
+    "data" : {
+      "drawCardId" : "BH3029",
+      "success" : true
+    },
+    "message" : "發動效果 成功"
+  }, {
+    "event" : "AskGreenDragonCrescentBladeEffectEvent",
+    "data" : {
+      "attackerPlayerId" : "player-a",
+      "targetPlayerId" : "player-b"
+    },
+    "message" : "青龍偃月刀效果：是否要再出一張殺"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ "BS9009" ]
+      },
+      "equipments" : [ "ES5005", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "ES2015", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "發動八卦陣效果",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/GreenDragonCrescentBlade/gdcb_ask_after_eight_diagram_success_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/GreenDragonCrescentBlade/gdcb_ask_after_eight_diagram_success_for_player_b.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "UseEquipmentEffectEvent",
+    "data" : {
+      "drawCardId" : "BH3029",
+      "success" : true
+    },
+    "message" : "發動效果 成功"
+  }, {
+    "event" : "AskGreenDragonCrescentBladeEffectEvent",
+    "data" : {
+      "attackerPlayerId" : "player-a",
+      "targetPlayerId" : "player-b"
+    },
+    "message" : "青龍偃月刀效果：是否要再出一張殺"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ES5005", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "Traitor",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "ES2015", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "發動八卦陣效果",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/GreenDragonCrescentBlade/gdcb_ask_after_eight_diagram_success_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/GreenDragonCrescentBlade/gdcb_ask_after_eight_diagram_success_for_player_c.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "UseEquipmentEffectEvent",
+    "data" : {
+      "drawCardId" : "BH3029",
+      "success" : true
+    },
+    "message" : "發動效果 成功"
+  }, {
+    "event" : "AskGreenDragonCrescentBladeEffectEvent",
+    "data" : {
+      "attackerPlayerId" : "player-a",
+      "targetPlayerId" : "player-b"
+    },
+    "message" : "青龍偃月刀效果：是否要再出一張殺"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ES5005", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "ES2015", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "發動八卦陣效果",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/GreenDragonCrescentBlade/gdcb_ask_after_eight_diagram_success_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/GreenDragonCrescentBlade/gdcb_ask_after_eight_diagram_success_for_player_d.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "UseEquipmentEffectEvent",
+    "data" : {
+      "drawCardId" : "BH3029",
+      "success" : true
+    },
+    "message" : "發動效果 成功"
+  }, {
+    "event" : "AskGreenDragonCrescentBladeEffectEvent",
+    "data" : {
+      "attackerPlayerId" : "player-a",
+      "targetPlayerId" : "player-b"
+    },
+    "message" : "青龍偃月刀效果：是否要再出一張殺"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ES5005", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "ES2015", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "發動八卦陣效果",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}


### PR DESCRIPTION
## Summary
Fix [#154](https://github.com/Game-as-a-Service/Legends-of-The-Three-Kingdoms/issues/154): 青龍偃月刀被八卦陣擋下後，攻擊者應可立即再出一張殺，目前未觸發。

## Root Cause
`EightDiagramTacticEquipmentEffectHandler.doHandle()` 在八卦陣成功時只處理 `ArrowBarrageBehavior` 與 `HeavenlyDoubleHalberdKillBehavior`，沒處理 `NormalActiveKillBehavior` + GDCB 的情境 → `NormalActiveKillBehavior` 被 pop，`doResponseToPlayerAction` 中的 GDCB 觸發分支永遠不會執行。

## Fix
`EightDiagramTacticEquipmentEffectHandler.java`：新增 `addAskGreenDragonCrescentBladeEventIfAttackerHasGDCB()` helper，仿既有 pattern，在八卦陣成功分支檢查：
- Top behavior 為 `NormalActiveKillBehavior`
- 攻擊者裝備 `GreenDragonCrescentBladeCard`
- 成立則保留 NormalActiveKillBehavior、推入 `WaitingGreenDragonCrescentBladeResponseBehavior`、emit `AskGreenDragonCrescentBladeEffectEvent`

## Test plan
- [x] Domain: 新增 4 tests（成功→ask、選 KILL、選 SKIP、失敗→fallback），361/361 green
- [x] Spring e2e: 新增 1 test，220/220 green
- [x] 無其他 regression

## Out of Scope
- `StonePiercingAxeCard`（貫石斧）有同類問題；Issue #154 只提到 GDCB，留待後續處理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)