### PR TITLE
fix: 貫石斧 bug — 八卦陣擋下時未觸發效果

### DIFF
--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/effect/EightDiagramTacticEquipmentEffectHandler.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/effect/EightDiagramTacticEquipmentEffectHandler.java
@@ -6,6 +6,7 @@ import com.gaas.threeKingdoms.behavior.behavior.ArrowBarrageBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.HeavenlyDoubleHalberdKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.WaitingGreenDragonCrescentBladeResponseBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.WaitingStonePiercingAxeResponseBehavior;
 import com.gaas.threeKingdoms.events.*;
 import com.gaas.threeKingdoms.handcard.EquipmentPlayType;
 import com.gaas.threeKingdoms.handcard.HandCard;
@@ -13,6 +14,7 @@ import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.ArmorCard;
 import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.GreenDragonCrescentBladeCard;
+import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.StonePiercingAxeCard;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.round.Round;
 import com.gaas.threeKingdoms.round.Stage;
@@ -65,6 +67,7 @@ public class EightDiagramTacticEquipmentEffectHandler extends EquipmentEffectHan
             addAskDodgeEventIfCurrentBehaviorIsArrowBarrageBehavior(domainEvents);
             addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(domainEvents, playerId);
             addAskGreenDragonCrescentBladeEventIfAttackerHasGDCB(domainEvents);
+            addAskStonePiercingAxeEventIfAttackerHasStonePiercingAxe(domainEvents);
         } else {
             domainEvents.add(new AskDodgeEvent(playerId));
         }
@@ -114,6 +117,36 @@ public class EightDiagramTacticEquipmentEffectHandler extends EquipmentEffectHan
                 killBehavior.getCardId(), PlayType.ACTIVE.getPlayType(), killBehavior.getCard()));
 
         events.add(new AskGreenDragonCrescentBladeEffectEvent(attacker.getId(), targetPlayerId));
+    }
+
+    /**
+     * 貫石斧：八卦陣成功視為出閃。若攻擊者裝備貫石斧且可棄牌 ≥ 2，
+     * 等同「殺被閃擋下」時可棄兩張牌強制命中，需詢問攻擊者是否發動。
+     */
+    private void addAskStonePiercingAxeEventIfAttackerHasStonePiercingAxe(List<DomainEvent> events) {
+        Behavior topBehavior = game.peekTopBehavior();
+        if (!(topBehavior instanceof NormalActiveKillBehavior killBehavior)) {
+            return;
+        }
+        Player attacker = killBehavior.getBehaviorPlayer();
+        if (!(attacker.getEquipmentWeaponCard() instanceof StonePiercingAxeCard)) {
+            return;
+        }
+        int discardable = attacker.getHand().getCards().size()
+                + attacker.getEquipment().getAllEquipmentCards().size();
+        if (discardable < 2) {
+            return;
+        }
+        String targetPlayerId = killBehavior.getReactionPlayers().get(0);
+
+        killBehavior.setIsOneRound(false);
+        game.getCurrentRound().setActivePlayer(attacker);
+
+        game.updateTopBehavior(new WaitingStonePiercingAxeResponseBehavior(
+                game, attacker, List.of(targetPlayerId), attacker,
+                killBehavior.getCardId(), PlayType.ACTIVE.getPlayType(), killBehavior.getCard()));
+
+        events.add(new AskStonePiercingAxeEffectEvent(attacker.getId(), targetPlayerId));
     }
 
     /**

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/StonePiercingAxeTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/StonePiercingAxeTest.java
@@ -5,12 +5,16 @@ import com.gaas.threeKingdoms.events.*;
 import com.gaas.threeKingdoms.gamephase.Normal;
 import com.gaas.threeKingdoms.generalcard.General;
 import com.gaas.threeKingdoms.generalcard.GeneralCard;
+import com.gaas.threeKingdoms.handcard.Deck;
+import com.gaas.threeKingdoms.handcard.EquipmentPlayType;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic;
 import com.gaas.threeKingdoms.handcard.equipmentcard.mountscard.RedRabbitHorse;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.StonePiercingAxeCard;
+import com.gaas.threeKingdoms.handcard.scrollcard.Dismantle;
 import com.gaas.threeKingdoms.player.*;
 import com.gaas.threeKingdoms.rolecard.Role;
 import com.gaas.threeKingdoms.rolecard.RoleCard;
@@ -289,6 +293,131 @@ public class StonePiercingAxeTest {
         assertEquals(0, playerB.getHP());
         // 瀕死 behavior 在 stack 上
         assertFalse(game.getTopBehavior().isEmpty(), "DyingAskPeachBehavior should be on the stack");
+    }
+
+    @DisplayName("A 裝備貫石斧 + B 裝備八卦陣 → A 出殺 → 八卦陣成功 → A 收到 AskStonePiercingAxeEffectEvent")
+    @Test
+    public void testEightDiagramTacticSuccess_TriggersStonePiercingAxeAsk() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+
+        // 八卦陣成功判定用：deck 頂放紅色卡
+        game.setDeck(new Deck(List.of(new RedRabbitHorse(BH3029))));
+
+        playerA.getEquipment().setWeapon(new StonePiercingAxeCard(ED5083));
+        // 出完殺後 A 還有 2 張可棄（Peach + 裝備），滿足 >= 2
+        playerA.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Peach(BH4030)));
+        playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
+
+        game.playerPlayCard(playerA.getId(), BS8008.getCardId(), playerB.getId(), PlayType.ACTIVE.getPlayType());
+        List<DomainEvent> events = game.playerUseEquipment(playerB.getId(), ES2015.getCardId(), playerB.getId(), EquipmentPlayType.ACTIVE);
+
+        AskStonePiercingAxeEffectEvent askEvent = events.stream()
+                .filter(e -> e instanceof AskStonePiercingAxeEffectEvent)
+                .map(e -> (AskStonePiercingAxeEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("AskStonePiercingAxeEffectEvent should be emitted when 八卦陣 succeeds"));
+        assertEquals("player-a", askEvent.getAttackerPlayerId());
+        assertEquals("player-b", askEvent.getTargetPlayerId());
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("A 裝備貫石斧 + B 裝備八卦陣 → 八卦陣成功 → A 選 DISCARD_TWO → B 強制扣血")
+    @Test
+    public void testEightDiagramTacticSuccess_AttackerChoosesDiscard_ForceHit() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+
+        game.setDeck(new Deck(List.of(new RedRabbitHorse(BH3029))));
+
+        playerA.getEquipment().setWeapon(new StonePiercingAxeCard(ED5083));
+        playerA.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Peach(BH4030), new Peach(BH3029)));
+        playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
+        int playerBHpBefore = playerB.getHP();
+
+        game.playerPlayCard(playerA.getId(), BS8008.getCardId(), playerB.getId(), PlayType.ACTIVE.getPlayType());
+        game.playerUseEquipment(playerB.getId(), ES2015.getCardId(), playerB.getId(), EquipmentPlayType.ACTIVE);
+
+        List<DomainEvent> events = game.playerUseStonePiercingAxeEffect(playerA.getId(),
+                AskStonePiercingAxeEffectEvent.Choice.DISCARD_TWO,
+                List.of(BH4030.getCardId(), BH3029.getCardId()));
+
+        assertTrue(events.stream().anyMatch(e -> e instanceof StonePiercingAxeTriggerEvent));
+        assertEquals(playerBHpBefore - 1, playerB.getHP());
+    }
+
+    @DisplayName("A 裝備貫石斧 + B 裝備八卦陣 → 八卦陣成功 → A 選 SKIP → 殺被抵銷")
+    @Test
+    public void testEightDiagramTacticSuccess_AttackerChoosesSkip_KillCancelled() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+
+        game.setDeck(new Deck(List.of(new RedRabbitHorse(BH3029))));
+
+        playerA.getEquipment().setWeapon(new StonePiercingAxeCard(ED5083));
+        playerA.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Peach(BH4030)));
+        playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
+        int playerBHpBefore = playerB.getHP();
+
+        game.playerPlayCard(playerA.getId(), BS8008.getCardId(), playerB.getId(), PlayType.ACTIVE.getPlayType());
+        game.playerUseEquipment(playerB.getId(), ES2015.getCardId(), playerB.getId(), EquipmentPlayType.ACTIVE);
+
+        game.playerUseStonePiercingAxeEffect(playerA.getId(),
+                AskStonePiercingAxeEffectEvent.Choice.SKIP, List.of());
+
+        assertEquals(playerBHpBefore, playerB.getHP());
+        assertEquals(0, game.getTopBehavior().size());
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("A 裝備貫石斧 + B 裝備八卦陣 → 八卦陣成功 + A 可棄牌數 < 2 → 不觸發貫石斧")
+    @Test
+    public void testEightDiagramTacticSuccess_InsufficientDiscardableCards_NotTriggered() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+
+        game.setDeck(new Deck(List.of(new RedRabbitHorse(BH3029))));
+
+        // A 裝備貫石斧，手牌只有 1 張殺。出殺後手牌 0 張 + 裝備 1 張 = 僅 1 張可棄
+        playerA.getEquipment().setWeapon(new StonePiercingAxeCard(ED5083));
+        playerA.getHand().addCardToHand(new Kill(BS8008));
+        playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
+        int playerBHpBefore = playerB.getHP();
+
+        game.playerPlayCard(playerA.getId(), BS8008.getCardId(), playerB.getId(), PlayType.ACTIVE.getPlayType());
+        List<DomainEvent> events = game.playerUseEquipment(playerB.getId(), ES2015.getCardId(), playerB.getId(), EquipmentPlayType.ACTIVE);
+
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskStonePiercingAxeEffectEvent));
+        assertEquals(playerBHpBefore, playerB.getHP());
+        assertEquals(0, game.getTopBehavior().size());
+    }
+
+    @DisplayName("A 裝備貫石斧 + B 裝備八卦陣 → 八卦陣失敗 → B 仍用一般閃流程（對照組）")
+    @Test
+    public void testEightDiagramTacticFails_FallsBackToNormalDodgeFlow() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+
+        // 八卦陣失敗判定用：deck 頂放黑色卡
+        game.setDeck(new Deck(List.of(new Dismantle(SS3003))));
+
+        playerA.getEquipment().setWeapon(new StonePiercingAxeCard(ED5083));
+        playerA.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Peach(BH4030)));
+        playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
+        playerB.getHand().addCardToHand(new Dodge(BH2028));
+
+        game.playerPlayCard(playerA.getId(), BS8008.getCardId(), playerB.getId(), PlayType.ACTIVE.getPlayType());
+        List<DomainEvent> askDodgeEvents = game.playerUseEquipment(playerB.getId(), ES2015.getCardId(), playerB.getId(), EquipmentPlayType.ACTIVE);
+        assertTrue(askDodgeEvents.stream().anyMatch(e -> e instanceof AskDodgeEvent));
+
+        // B 出閃 → 走一般 SPA 觸發路徑
+        List<DomainEvent> dodgeEvents = game.playerPlayCard(playerB.getId(), BH2028.getCardId(), playerA.getId(), PlayType.ACTIVE.getPlayType());
+        assertTrue(dodgeEvents.stream().anyMatch(e -> e instanceof AskStonePiercingAxeEffectEvent));
     }
 
     // Helper

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/equipment/StonePiercingAxeTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/equipment/StonePiercingAxeTest.java
@@ -5,10 +5,13 @@ import com.gaas.threeKingdoms.e2e.JsonFileWriterUtil;
 import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
 import com.gaas.threeKingdoms.generalcard.General;
 import com.gaas.threeKingdoms.handcard.Deck;
+import com.gaas.threeKingdoms.handcard.EquipmentPlayType;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic;
+import com.gaas.threeKingdoms.handcard.equipmentcard.mountscard.RedRabbitHorse;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.StonePiercingAxeCard;
 import com.gaas.threeKingdoms.player.HealthStatus;
 import com.gaas.threeKingdoms.player.Player;
@@ -28,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class StonePiercingAxeTest extends AbstractBaseIntegrationTest {
+
+    // @Override protected boolean shouldRegenerateFixtures() { return true; }
 
     @Test
     public void testEquipStonePiercingAxe() throws Exception {
@@ -110,6 +115,36 @@ public class StonePiercingAxeTest extends AbstractBaseIntegrationTest {
             String expectedJson = Files.readString(path);
             assertEquals(expectedJson, testPlayerJson);
         }
+    }
+
+    @Test
+    public void testEightDiagramTacticSuccess_TriggersStonePiercingAxeAsk() throws Exception {
+        // Given A 裝備貫石斧 + B 裝備八卦陣，deck 頂紅色（八卦陣成功）
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008), new Peach(BH3029), new Peach(BH4030));
+        playerA.getEquipment().setWeapon(new StonePiercingAxeCard(ED5083));
+
+        Player playerB = createPlayer("player-b", 4, General.劉備, HealthStatus.ALIVE, Role.TRAITOR);
+        playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
+
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new RedRabbitHorse(BH7033)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // When A 出殺 → B 發動八卦陣成功
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+        mockMvcUtil.useEquipment(gameId, "player-b", "player-b", "ES2015", EquipmentPlayType.ACTIVE)
+                .andExpect(status().isOk()).andReturn();
+
+        // Then A 應收到 AskStonePiercingAxeEffectEvent
+        assertAllPlayerJson("src/test/resources/TestJsonFile/EquipmentTest/StonePiercingAxe/spa_ask_after_eight_diagram_success_for_%s.json");
     }
 
     private void givenPlayerAEquippedStonePiercingAxe() {

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/StonePiercingAxe/spa_ask_after_eight_diagram_success_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/StonePiercingAxe/spa_ask_after_eight_diagram_success_for_player_a.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "UseEquipmentEffectEvent",
+    "data" : {
+      "drawCardId" : "BH7033",
+      "success" : true
+    },
+    "message" : "發動效果 成功"
+  }, {
+    "event" : "AskStonePiercingAxeEffectEvent",
+    "data" : {
+      "attackerPlayerId" : "player-a",
+      "targetPlayerId" : "player-b"
+    },
+    "message" : "貫石斧效果：是否棄兩張牌強制命中"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 2,
+        "cardIds" : [ "BH3029", "BH4030" ]
+      },
+      "equipments" : [ "ED5083", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "ES2015", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "發動八卦陣效果",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/StonePiercingAxe/spa_ask_after_eight_diagram_success_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/StonePiercingAxe/spa_ask_after_eight_diagram_success_for_player_b.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "UseEquipmentEffectEvent",
+    "data" : {
+      "drawCardId" : "BH7033",
+      "success" : true
+    },
+    "message" : "發動效果 成功"
+  }, {
+    "event" : "AskStonePiercingAxeEffectEvent",
+    "data" : {
+      "attackerPlayerId" : "player-a",
+      "targetPlayerId" : "player-b"
+    },
+    "message" : "貫石斧效果：是否棄兩張牌強制命中"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 2,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ED5083", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "Traitor",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "ES2015", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "發動八卦陣效果",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/StonePiercingAxe/spa_ask_after_eight_diagram_success_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/StonePiercingAxe/spa_ask_after_eight_diagram_success_for_player_c.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "UseEquipmentEffectEvent",
+    "data" : {
+      "drawCardId" : "BH7033",
+      "success" : true
+    },
+    "message" : "發動效果 成功"
+  }, {
+    "event" : "AskStonePiercingAxeEffectEvent",
+    "data" : {
+      "attackerPlayerId" : "player-a",
+      "targetPlayerId" : "player-b"
+    },
+    "message" : "貫石斧效果：是否棄兩張牌強制命中"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 2,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ED5083", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "ES2015", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "發動八卦陣效果",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/StonePiercingAxe/spa_ask_after_eight_diagram_success_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/StonePiercingAxe/spa_ask_after_eight_diagram_success_for_player_d.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "UseEquipmentEffectEvent",
+    "data" : {
+      "drawCardId" : "BH7033",
+      "success" : true
+    },
+    "message" : "發動效果 成功"
+  }, {
+    "event" : "AskStonePiercingAxeEffectEvent",
+    "data" : {
+      "attackerPlayerId" : "player-a",
+      "targetPlayerId" : "player-b"
+    },
+    "message" : "貫石斧效果：是否棄兩張牌強制命中"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 2,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ED5083", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "ES2015", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "發動八卦陣效果",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}


### PR DESCRIPTION
## Summary
延續 [#156](https://github.com/Game-as-a-Service/Legends-of-The-Three-Kingdoms/pull/156) 的修復模式，處理同類問題：貫石斧（StonePiercingAxe）被八卦陣擋下後，攻擊者也應收到「棄兩張牌強制命中」的詢問。

## 同源的 Bug
- GDCB：殺被閃擋 → 再出一張殺
- SPA：殺被閃擋 → 棄兩張牌強制命中

兩者都在 `NormalActiveKillBehavior.doResponseToPlayerAction` 的 `isDodgeCard` 分支觸發，而八卦陣成功時直接 pop kill behavior，都被繞過。

## Fix
在 #156 新增的 GDCB helper 旁再加一個 `addAskStonePiercingAxeEventIfAttackerHasStonePiercingAxe` helper，條件：
- Top 為 `NormalActiveKillBehavior`
- 攻擊者裝備 `StonePiercingAxeCard`
- 可棄牌（手牌+裝備）≥ 2（與既有 `NormalActiveKillBehavior.doResponseToPlayerAction` line 132 的條件一致）

## Base branch
Stacked on `fix/gdcb-eight-diagram-trigger`（PR #156）。待 #156 合併後再合此 PR。

## Test plan
- [x] Domain: +5 tests（success→ask、DISCARD_TWO→force hit、SKIP→cancel、discardable<2→no trigger、八卦陣 fail→fallback），366/366 green
- [x] Spring e2e: +1 test、+4 fixtures，221/221 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)