### PR TITLE
feat: 丈八蛇矛支援被動回應殺（南蠻 / 決鬥 / 借刀）

### DIFF
--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -859,37 +859,47 @@ public class Game {
 
     public List<DomainEvent> playerUseViperSpearKill(String playerId, String targetPlayerId, List<String> discardCardIds) {
         Player attacker = getPlayer(playerId);
-        Player target = getPlayer(targetPlayerId);
 
-        // 驗證：玩家是當前回合玩家且 activePlayer
+        // 驗證：玩家是當前 activePlayer（active = 自己回合; passive = 被詢問者）
         checkIsCurrentRoundValid(playerId);
-
-        // 驗證：目前沒有等待中的 behavior（Phase 1 只支援主動出殺）
-        if (!topBehavior.isEmpty()) {
-            throw new IllegalStateException("Cannot use ViperSpear kill while another behavior is pending (passive use not supported yet)");
-        }
 
         // 驗證：裝備丈八蛇矛
         if (!(attacker.getEquipmentWeaponCard() instanceof EighteenSpanViperSpearCard)) {
             throw new IllegalStateException("Player is not equipped with EighteenSpanViperSpear");
         }
 
-        // 驗證：exactly 2 cardIds
+        validateViperSpearDiscardCardIds(attacker, discardCardIds);
+
+        // 分流：top behavior 決定是 active 還是 passive
+        if (topBehavior.isEmpty()) {
+            return playerUseViperSpearKillActive(attacker, targetPlayerId, discardCardIds);
+        }
+        Behavior top = topBehavior.peek();
+        if (top instanceof BarbarianInvasionBehavior
+                || top instanceof DuelBehavior
+                || top instanceof BorrowedSwordBehavior) {
+            return playerUseViperSpearKillPassive(attacker, targetPlayerId, discardCardIds, top);
+        }
+        throw new IllegalStateException(
+                "Cannot use ViperSpear kill while behavior=" + top.getClass().getSimpleName() + " is pending");
+    }
+
+    private void validateViperSpearDiscardCardIds(Player attacker, List<String> discardCardIds) {
         if (discardCardIds == null || discardCardIds.size() != 2) {
             throw new IllegalArgumentException("ViperSpear kill requires exactly 2 discard cardIds");
         }
-
-        // 驗證：兩張 cardIds 都在攻擊者手牌
         for (String discardCardId : discardCardIds) {
             if (attacker.getHand().getCards().stream().noneMatch(c -> c.getId().equals(discardCardId))) {
                 throw new IllegalArgumentException("Attacker does not have card in hand: " + discardCardId);
             }
         }
-
-        // 驗證：兩張 cardIds 不重複
         if (discardCardIds.get(0).equals(discardCardIds.get(1))) {
             throw new IllegalArgumentException("Cannot discard the same card twice");
         }
+    }
+
+    private List<DomainEvent> playerUseViperSpearKillActive(Player attacker, String targetPlayerId, List<String> discardCardIds) {
+        Player target = getPlayer(targetPlayerId);
 
         // 驗證：目標在攻擊範圍
         if (!isInAttackRange(attacker, target)) {
@@ -920,6 +930,20 @@ public class Game {
         updateTopBehavior(behavior);
 
         List<DomainEvent> events = behavior.playerAction();
+        removeCompletedBehaviors();
+        return events;
+    }
+
+    private List<DomainEvent> playerUseViperSpearKillPassive(Player attacker, String targetPlayerId, List<String> discardCardIds, Behavior top) {
+        // 棄兩張手牌到墓地（被動使用不計入殺次數限制 — 這不是出牌階段的殺）
+        for (String discardCardId : discardCardIds) {
+            HandCard discardedCard = attacker.playCard(discardCardId);
+            graveyard.add(discardedCard);
+        }
+
+        // 交給對應 behavior 處理：advance reaction state / push ViperSpearKillBehavior（BorrowedSword）
+        VirtualKill virtualKill = new VirtualKill();
+        List<DomainEvent> events = top.acceptVirtualKillResponse(attacker.getId(), targetPlayerId, virtualKill, discardCardIds);
         removeCompletedBehaviors();
         return events;
     }
@@ -1050,8 +1074,10 @@ public class Game {
                 return events;
             }
 
-            //判斷B有沒有殺，若玩家B沒出殺，則玩家A取得玩家B當前的武器
-            if (borrowedPlayer.getHand().getCards().stream().noneMatch(card -> card instanceof Kill)) {
+            //判斷B有沒有殺（或可用丈八蛇矛當殺）；都沒有 → 玩家A取得玩家B當前的武器
+            boolean noKillInHand = borrowedPlayer.getHand().getCards().stream().noneMatch(card -> card instanceof Kill);
+            boolean canUseViperSpear = EighteenSpanViperSpearCard.canUseAsKill(borrowedPlayer);
+            if (noKillInHand && !canUseViperSpear) {
                 List<DomainEvent> acceptedEvent = behavior.responseToPlayerAction(borrowedPlayerId, currentPlayerId, "",  PlayType.SKIP.getPlayType());
                 removeCompletedBehaviors();
                 return acceptedEvent;

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -935,11 +935,8 @@ public class Game {
     }
 
     private List<DomainEvent> playerUseViperSpearKillPassive(Player attacker, String targetPlayerId, List<String> discardCardIds, Behavior top) {
-        // BorrowedSword 場景需 targetPlayerId — 必須在 discard 前驗證，避免 throw 後手牌已遺失
-        if (top instanceof BorrowedSwordBehavior
-                && (targetPlayerId == null || targetPlayerId.isEmpty())) {
-            throw new IllegalArgumentException("BorrowedSword virtual kill response requires targetPlayerId");
-        }
+        // 場景特定 pre-validation（必須在 discard 前，避免 invalid input 留下手牌已棄的部分狀態）
+        top.validateBeforeVirtualKillResponse(attacker.getId(), targetPlayerId);
 
         // 棄兩張手牌到墓地（被動使用不計入殺次數限制 — 這不是出牌階段的殺）
         for (String discardCardId : discardCardIds) {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -935,6 +935,12 @@ public class Game {
     }
 
     private List<DomainEvent> playerUseViperSpearKillPassive(Player attacker, String targetPlayerId, List<String> discardCardIds, Behavior top) {
+        // BorrowedSword 場景需 targetPlayerId — 必須在 discard 前驗證，避免 throw 後手牌已遺失
+        if (top instanceof BorrowedSwordBehavior
+                && (targetPlayerId == null || targetPlayerId.isEmpty())) {
+            throw new IllegalArgumentException("BorrowedSword virtual kill response requires targetPlayerId");
+        }
+
         // 棄兩張手牌到墓地（被動使用不計入殺次數限制 — 這不是出牌階段的殺）
         for (String discardCardId : discardCardIds) {
             HandCard discardedCard = attacker.playCard(discardCardId);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/Behavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/Behavior.java
@@ -61,6 +61,19 @@ public class Behavior {
         return null;
     }
 
+    /**
+     * hook: 被動 ViperSpear 虛擬殺回應。
+     * 由 BarbarianInvasion / Duel / BorrowedSword 等 ask-Kill behavior override。
+     * 棄牌已在 Game 層處理；implementation 只需推進 reaction 狀態。
+     * <p>
+     * targetPlayerId 在 BorrowedSword 場景下為玩家指定的攻擊目標；
+     * BarbarianInvasion / Duel 場景下可為 null（target 由 behavior state 決定）。
+     */
+    public List<DomainEvent> acceptVirtualKillResponse(String playerId, String targetPlayerId, HandCard virtualKill, List<String> discardedCardIds) {
+        throw new UnsupportedOperationException(
+                getClass().getSimpleName() + " does not accept ViperSpear virtual kill response");
+    }
+
     public List<DomainEvent> responseToPlayerAction(String playerId, String targetPlayerId, String cardId, String playType) {
         throwExceptionWhenPlayerIsNotInReactionPlayers(playerId);
         return doResponseToPlayerAction(playerId, targetPlayerId, cardId, playType);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/Behavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/Behavior.java
@@ -62,12 +62,24 @@ public class Behavior {
     }
 
     /**
+     * hook: 在執行 {@link #acceptVirtualKillResponse} 與棄牌之前的前置驗證。
+     * 由 behavior 自行決定該場景需要什麼參數（例如 BorrowedSword 需要 targetPlayerId）。
+     * <p>
+     * 必須在棄牌之前呼叫；任何驗證失敗應直接 throw，避免 state 在 invalid input 下被部分 mutate。
+     * default: no-op。
+     */
+    public void validateBeforeVirtualKillResponse(String playerId, String targetPlayerId) {
+        // default: no-op
+    }
+
+    /**
      * hook: 被動 ViperSpear 虛擬殺回應。
      * 由 BarbarianInvasion / Duel / BorrowedSword 等 ask-Kill behavior override。
      * 棄牌已在 Game 層處理；implementation 只需推進 reaction 狀態。
      * <p>
      * targetPlayerId 在 BorrowedSword 場景下為玩家指定的攻擊目標；
      * BarbarianInvasion / Duel 場景下可為 null（target 由 behavior state 決定）。
+     * 呼叫前 Game 層應已執行 {@link #validateBeforeVirtualKillResponse}。
      */
     public List<DomainEvent> acceptVirtualKillResponse(String playerId, String targetPlayerId, HandCard virtualKill, List<String> discardedCardIds) {
         throw new UnsupportedOperationException(

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
@@ -5,6 +5,7 @@ import com.gaas.threeKingdoms.behavior.Behavior;
 import com.gaas.threeKingdoms.events.AskKillEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
 import com.gaas.threeKingdoms.events.PlayCardEvent;
+import com.gaas.threeKingdoms.events.ViperSpearKillTriggerEvent;
 import com.gaas.threeKingdoms.handcard.HandCard;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.player.Player;
@@ -165,25 +166,40 @@ public class BarbarianInvasionBehavior extends Behavior {
             return events;
         } else if (isKillCard(cardId)) {
             playerPlayCardNotUpdateActivePlayer(game.getPlayer(playerId), cardId);
-            List<DomainEvent> events = new ArrayList<>();
-            currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
-            boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId);
-            if (isLastPlayer) {
-                isOneRound = true;
-                game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
-            } else {
-                game.getCurrentRound().setActivePlayer(currentReactionPlayer);
-            }
-            events.add(game.getGameStatusEvent(playerId + "出殺"));
-            events.add(new PlayCardEvent("出牌", playerId, targetPlayerId, cardId, playType));
-            if (!isLastPlayer) {
-                events.addAll(askNextPlayerOrWard());
-            }
-            return events;
+            return advanceAfterKillResponse(playerId,
+                    playerId + "出殺",
+                    List.of(new PlayCardEvent("出牌", playerId, targetPlayerId, cardId, playType)));
         } else {
             //TODO:怕有其他效果或殺的其他case
         }
         return null;
+    }
+
+    @Override
+    public List<DomainEvent> acceptVirtualKillResponse(String playerId, String targetPlayerId, HandCard virtualKill, List<String> discardedCardIds) {
+        // 棄牌已在 Game.playerUseViperSpearKill() 處理；此處僅推進 reaction 狀態
+        // BarbarianInvasion 不使用 targetPlayerId — 回應對象固定為入侵者 (behaviorPlayer)
+        return advanceAfterKillResponse(playerId,
+                playerId + "用丈八蛇矛出殺",
+                List.of(new ViperSpearKillTriggerEvent(playerId, behaviorPlayer.getId(), discardedCardIds)));
+    }
+
+    private List<DomainEvent> advanceAfterKillResponse(String playerId, String statusMessage, List<DomainEvent> insertEvents) {
+        List<DomainEvent> events = new ArrayList<>();
+        currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
+        boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId);
+        if (isLastPlayer) {
+            isOneRound = true;
+            game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
+        } else {
+            game.getCurrentRound().setActivePlayer(currentReactionPlayer);
+        }
+        events.add(game.getGameStatusEvent(statusMessage));
+        events.addAll(insertEvents);
+        if (!isLastPlayer) {
+            events.addAll(askNextPlayerOrWard());
+        }
+        return events;
     }
 
     public boolean isInReactionPlayers(String playerId) {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BorrowedSwordBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BorrowedSwordBehavior.java
@@ -63,15 +63,21 @@ public class BorrowedSwordBehavior extends Behavior {
     }
 
     @Override
-    public List<DomainEvent> acceptVirtualKillResponse(String playerId, String targetPlayerId, HandCard virtualKill, List<String> discardedCardIds) {
+    public void validateBeforeVirtualKillResponse(String playerId, String targetPlayerId) {
         // BorrowedSword 場景需要 targetPlayerId（攻擊目標 C）— 由請求帶入
         if (targetPlayerId == null || targetPlayerId.isEmpty()) {
             throw new IllegalArgumentException("BorrowedSword virtual kill response requires targetPlayerId");
         }
+    }
+
+    @Override
+    public List<DomainEvent> acceptVirtualKillResponse(String playerId, String targetPlayerId, HandCard virtualKill, List<String> discardedCardIds) {
+        // targetPlayerId 已由 validateBeforeVirtualKillResponse 驗證過
         Player attacker = game.getPlayer(playerId);
         Player target = game.getPlayer(targetPlayerId);
 
         // 棄牌已在 Game 處理；改 push ViperSpearKillBehavior，讓 C 進入閃 / 防具流程
+        // 與 active path 一致：BorrowedSword(oneRound=true) 留在底，等 ViperSpearKill 解析完畢一併 pop
         Behavior behavior = new ViperSpearKillBehavior(
                 game, attacker, List.of(targetPlayerId), target, virtualKill, discardedCardIds);
         isOneRound = true;

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BorrowedSwordBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BorrowedSwordBehavior.java
@@ -10,6 +10,7 @@ import com.gaas.threeKingdoms.events.WeaponUsurpationEvent;
 import com.gaas.threeKingdoms.handcard.HandCard;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.EighteenSpanViperSpearCard;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.WeaponCard;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.round.Round;
@@ -62,6 +63,23 @@ public class BorrowedSwordBehavior extends Behavior {
     }
 
     @Override
+    public List<DomainEvent> acceptVirtualKillResponse(String playerId, String targetPlayerId, HandCard virtualKill, List<String> discardedCardIds) {
+        // BorrowedSword 場景需要 targetPlayerId（攻擊目標 C）— 由請求帶入
+        if (targetPlayerId == null || targetPlayerId.isEmpty()) {
+            throw new IllegalArgumentException("BorrowedSword virtual kill response requires targetPlayerId");
+        }
+        Player attacker = game.getPlayer(playerId);
+        Player target = game.getPlayer(targetPlayerId);
+
+        // 棄牌已在 Game 處理；改 push ViperSpearKillBehavior，讓 C 進入閃 / 防具流程
+        Behavior behavior = new ViperSpearKillBehavior(
+                game, attacker, List.of(targetPlayerId), target, virtualKill, discardedCardIds);
+        isOneRound = true;
+        game.updateTopBehavior(behavior);
+        return behavior.playerAction();
+    }
+
+    @Override
     public List<DomainEvent> doBehaviorAction() {
         List<DomainEvent> events = new ArrayList<>();
         String currentPlayerId = (String) getParam(UserCommand.BORROWED_SWORD_PLAYER_ID.name());
@@ -70,8 +88,10 @@ public class BorrowedSwordBehavior extends Behavior {
 
         Player borrowedPlayer = game.getPlayer(borrowedPlayerId);
 
-        // B has no Kill → weapon usurpation
-        if (borrowedPlayer.getHand().getCards().stream().noneMatch(card -> card instanceof Kill)) {
+        // B has no Kill (and 不能用丈八蛇矛當殺) → weapon usurpation
+        boolean cannotProduceKill = borrowedPlayer.getHand().getCards().stream().noneMatch(card -> card instanceof Kill)
+                && !EighteenSpanViperSpearCard.canUseAsKill(borrowedPlayer);
+        if (cannotProduceKill) {
             WeaponCard targetWeaponCard = borrowedPlayer.getEquipmentWeaponCard();
             borrowedPlayer.getEquipment().setWeapon(null);
             behaviorPlayer.getHand().addCardToHand(targetWeaponCard);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DuelBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DuelBehavior.java
@@ -6,9 +6,11 @@ import com.gaas.threeKingdoms.events.AskKillEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
 import com.gaas.threeKingdoms.events.DuelEvent;
 import com.gaas.threeKingdoms.events.PlayCardEvent;
+import com.gaas.threeKingdoms.events.ViperSpearKillTriggerEvent;
 import com.gaas.threeKingdoms.handcard.HandCard;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.EighteenSpanViperSpearCard;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.round.Stage;
 
@@ -82,40 +84,9 @@ public class DuelBehavior extends Behavior {
             damagedEvent.add(game.getGameStatusEvent("扣血"));
             return damagedEvent;
         } else if (isKillCard(cardId)) {
-            List<DomainEvent> events = new ArrayList<>();
             playerPlayCardNotUpdateActivePlayer(game.getPlayer(playerId), cardId);
-
-            // 當前反應者出完殺後，就需要換另外一個人出
-            currentReactionPlayer = game.getPlayer(otherPlayerId);
-
-            game.getCurrentRound().setActivePlayer(currentReactionPlayer);
-            events.add(new PlayCardEvent("出牌", playerId, otherPlayerId, cardId, playType));
-
-            String gameMessage = "";
-            if (!currentReactionPlayer.getHand().hasTypeInHand(Kill.class)) {
-                int originalHp = currentReactionPlayer.getHP();
-                List<DomainEvent> damagedEvents = game.getDamagedEvent(
-                        otherPlayerId,
-                        playerId,
-                        "",
-                        card,
-                        PlayType.SKIP.getPlayType(),
-                        originalHp,
-                        currentReactionPlayer,
-                        game.getCurrentRound(),
-                        Optional.of(this));
-                events.addAll(damagedEvents);
-                isTargetPlayerNeedToResponse = false;
-                isOneRound = true;
-                System.out.println("1 currentReactionPlayer "+currentReactionPlayer.getId());
-                gameMessage = "扣血";
-            } else {
-                AskKillEvent askKillEvent = new AskKillEvent(currentReactionPlayer.getId());
-                events.add(askKillEvent);
-                gameMessage = playerId + "已出殺";
-            }
-            events.add(game.getGameStatusEvent(gameMessage));
-            return events;
+            return swapToOtherDuelist(playerId, otherPlayerId,
+                    new PlayCardEvent("出牌", playerId, otherPlayerId, cardId, playType));
         } else {
             //TODO:怕有其他效果或殺的其他case
         }
@@ -123,12 +94,58 @@ public class DuelBehavior extends Behavior {
     }
 
     @Override
+    public List<DomainEvent> acceptVirtualKillResponse(String playerId, String targetPlayerId, HandCard virtualKill, List<String> discardedCardIds) {
+        // 棄牌已在 Game.playerUseViperSpearKill() 處理
+        // Duel 不使用 targetPlayerId — 對手由 reactionPlayers 推導
+        String otherPlayerId = reactionPlayers.stream().filter(id -> !id.equals(playerId)).findFirst().get();
+        return swapToOtherDuelist(playerId, otherPlayerId,
+                new ViperSpearKillTriggerEvent(playerId, otherPlayerId, discardedCardIds));
+    }
+
+    private List<DomainEvent> swapToOtherDuelist(String playerId, String otherPlayerId, DomainEvent killEvent) {
+        List<DomainEvent> events = new ArrayList<>();
+        // 換另一位 duelist 為 currentReactionPlayer
+        currentReactionPlayer = game.getPlayer(otherPlayerId);
+        game.getCurrentRound().setActivePlayer(currentReactionPlayer);
+        events.add(killEvent);
+
+        String gameMessage;
+        if (!canRespondWithKill(currentReactionPlayer)) {
+            int originalHp = currentReactionPlayer.getHP();
+            List<DomainEvent> damagedEvents = game.getDamagedEvent(
+                    otherPlayerId,
+                    playerId,
+                    "",
+                    card,
+                    PlayType.SKIP.getPlayType(),
+                    originalHp,
+                    currentReactionPlayer,
+                    game.getCurrentRound(),
+                    Optional.of(this));
+            events.addAll(damagedEvents);
+            isTargetPlayerNeedToResponse = false;
+            isOneRound = true;
+            gameMessage = "扣血";
+        } else {
+            events.add(new AskKillEvent(currentReactionPlayer.getId()));
+            gameMessage = playerId + "已出殺";
+        }
+        events.add(game.getGameStatusEvent(gameMessage));
+        return events;
+    }
+
+    private boolean canRespondWithKill(Player player) {
+        return player.getHand().hasTypeInHand(Kill.class)
+                || EighteenSpanViperSpearCard.canUseAsKill(player);
+    }
+
+    @Override
     public List<DomainEvent> doBehaviorAction() {
         List<DomainEvent> events = new ArrayList<>();
         String currentReactionPlayerId = currentReactionPlayer.getId();
         events.add(new DuelEvent(behaviorPlayer.getId(), currentReactionPlayerId, cardId));
-        // 判斷 currentReactionPlayer 是否有殺
-        if (!currentReactionPlayer.getHand().hasTypeInHand(Kill.class)) {
+        // 判斷 currentReactionPlayer 是否有殺（或可用丈八蛇矛當殺）
+        if (!canRespondWithKill(currentReactionPlayer)) {
             int originalHp = currentReactionPlayer.getHP();
             List<DomainEvent> damagedEvents = game.getDamagedEvent(
                     currentReactionPlayerId,

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ViperSpearKillBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ViperSpearKillBehavior.java
@@ -20,8 +20,6 @@ import java.util.List;
  * 丈八蛇矛虛擬殺 Behavior
  * 玩家棄兩張手牌作為虛擬殺使用。繼承 NormalActiveKillBehavior，
  * override playerAction() 避免從手牌移除「殺卡」（因為丈八蛇矛用的是 VirtualKill，不在手牌中）。
- *
- * TODO: Phase 2 - 支援被動出殺場景（被決鬥、南蠻入侵、借刀殺人要求出殺時可用丈八蛇矛回應）
  */
 @Getter
 public class ViperSpearKillBehavior extends NormalActiveKillBehavior {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/handcard/equipmentcard/weaponcard/EighteenSpanViperSpearCard.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/handcard/equipmentcard/weaponcard/EighteenSpanViperSpearCard.java
@@ -3,6 +3,7 @@ package com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard;
 import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.events.DomainEvent;
 import com.gaas.threeKingdoms.handcard.PlayCard;
+import com.gaas.threeKingdoms.player.Player;
 
 import java.util.List;
 
@@ -19,5 +20,11 @@ public class EighteenSpanViperSpearCard extends WeaponCard {
     @Override
     public List<DomainEvent> equipmentEffect(Game game) {
         return null;
+    }
+
+    /** 玩家是否能將兩張手牌當殺使用/打出（裝備丈八蛇矛 + 手牌 ≥ 2）。 */
+    public static boolean canUseAsKill(Player player) {
+        return player.getEquipmentWeaponCard() instanceof EighteenSpanViperSpearCard
+                && player.getHand().getCards().size() >= 2;
     }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/EighteenSpanViperSpearTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/EighteenSpanViperSpearTest.java
@@ -364,6 +364,39 @@ public class EighteenSpanViperSpearTest {
         assertEquals("player-c", game.getActivePlayer().getId());
     }
 
+    @DisplayName("被借刀殺人時，B 用 ViperSpear 但未指定 targetPlayerId → 拋例外且手牌不變")
+    @Test
+    public void testPassiveViperSpear_BorrowedSword_MissingTargetPlayerId_ThrowsAndHandUnchanged() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+
+        playerB.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+        playerB.getHand().addCardToHand(asList(new Peach(BH3029), new Peach(BH4030)));
+        playerA.getHand().addCardToHand(new BorrowedSword(SCK065));
+
+        // A 出借刀殺人 → 借 B → C
+        game.playerPlayCard(playerA.getId(), SCK065.getCardId(), playerB.getId(), PlayType.ACTIVE.getPlayType());
+        game.useBorrowedSwordEffect(playerA.getId(), playerB.getId(), playerC.getId());
+
+        int bHandSizeBefore = playerB.getHandSize();
+
+        // B 漏傳 targetPlayerId（null）→ 應拋例外
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseViperSpearKill(playerB.getId(), null,
+                        List.of(BH3029.getCardId(), BH4030.getCardId())));
+        // 同一個 bug：empty string 也要 throw
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseViperSpearKill(playerB.getId(), "",
+                        List.of(BH3029.getCardId(), BH4030.getCardId())));
+
+        // 關鍵：手牌**沒有**被棄掉（discard 前已 throw）
+        assertEquals(bHandSizeBefore, playerB.getHandSize());
+        assertTrue(playerB.getHand().getCard(BH3029.getCardId()).isPresent());
+        assertTrue(playerB.getHand().getCard(BH4030.getCardId()).isPresent());
+    }
+
     @DisplayName("VirtualKill 有正確的 id 和 effect")
     @Test
     public void testVirtualKill_HasCorrectIdAndEffect() {

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/EighteenSpanViperSpearTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/EighteenSpanViperSpearTest.java
@@ -12,6 +12,9 @@ import com.gaas.threeKingdoms.handcard.basiccard.Peach;
 import com.gaas.threeKingdoms.handcard.basiccard.VirtualKill;
 import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.EighteenSpanViperSpearCard;
+import com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion;
+import com.gaas.threeKingdoms.handcard.scrollcard.BorrowedSword;
+import com.gaas.threeKingdoms.handcard.scrollcard.Duel;
 import com.gaas.threeKingdoms.player.*;
 import com.gaas.threeKingdoms.rolecard.Role;
 import com.gaas.threeKingdoms.rolecard.RoleCard;
@@ -237,6 +240,128 @@ public class EighteenSpanViperSpearTest {
         assertEquals(0, playerB.getHP());
         // DyingAskPeachBehavior on stack
         assertFalse(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("被南蠻入侵時，B 裝備丈八蛇矛 → 棄兩張當殺回應 → 推進至下一位被詢問者")
+    @Test
+    public void testPassiveViperSpear_RespondingBarbarianInvasion_NextPlayerAsked() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+
+        playerB.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+        playerB.getHand().addCardToHand(asList(new Peach(BH3029), new Dodge(BH2028)));
+
+        // A 出南蠻入侵 — 由 player-a 開始所以 player-b 是第一個被詢問
+        playerA.getHand().addCardToHand(new BarbarianInvasion(SS7007));
+        game.playerPlayCard(playerA.getId(), SS7007.getCardId(), "", PlayType.ACTIVE.getPlayType());
+
+        // B 是第一個被詢問者
+        assertEquals("player-b", game.getActivePlayer().getId());
+
+        // B 用丈八蛇矛棄兩張當殺
+        int bHandSizeBefore = playerB.getHandSize();
+        List<DomainEvent> events = game.playerUseViperSpearKill(
+                playerB.getId(), null,
+                List.of(BH3029.getCardId(), BH2028.getCardId()));
+
+        // ViperSpearKillTriggerEvent 應被觸發
+        ViperSpearKillTriggerEvent triggerEvent = events.stream()
+                .filter(e -> e instanceof ViperSpearKillTriggerEvent)
+                .map(e -> (ViperSpearKillTriggerEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("ViperSpearKillTriggerEvent should be emitted"));
+        assertEquals("player-b", triggerEvent.getAttackerPlayerId());
+        assertEquals(List.of(BH3029.getCardId(), BH2028.getCardId()), triggerEvent.getDiscardedCardIds());
+
+        // B 手牌 -2 / 未受傷
+        assertEquals(bHandSizeBefore - 2, playerB.getHandSize());
+        assertEquals(4, playerB.getHP());
+
+        // 下一個被詢問者 C 收到 AskKillEvent
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskKillEvent
+                && ((AskKillEvent) e).getPlayerId().equals("player-c")));
+        assertEquals("player-c", game.getActivePlayer().getId());
+    }
+
+    @DisplayName("被決鬥時，B 裝備丈八蛇矛 → 棄兩張當殺回應 → 換 A 被詢問出殺")
+    @Test
+    public void testPassiveViperSpear_RespondingDuel_OpponentAsked() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+
+        playerA.getHand().addCardToHand(asList(new Duel(SSA001), new Kill(BS8008)));
+        playerB.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+        playerB.getHand().addCardToHand(asList(new Peach(BH3029), new Peach(BH4030)));
+
+        // A 對 B 出決鬥 — B 是第一個被詢問出殺
+        game.playerPlayCard(playerA.getId(), SSA001.getCardId(), playerB.getId(), PlayType.ACTIVE.getPlayType());
+        assertEquals("player-b", game.getActivePlayer().getId());
+
+        // B 用丈八蛇矛棄兩張當殺回應
+        List<DomainEvent> events = game.playerUseViperSpearKill(
+                playerB.getId(), null,
+                List.of(BH3029.getCardId(), BH4030.getCardId()));
+
+        ViperSpearKillTriggerEvent triggerEvent = events.stream()
+                .filter(e -> e instanceof ViperSpearKillTriggerEvent)
+                .map(e -> (ViperSpearKillTriggerEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("ViperSpearKillTriggerEvent should be emitted"));
+        assertEquals("player-b", triggerEvent.getAttackerPlayerId());
+        assertEquals("player-a", triggerEvent.getTargetPlayerId());
+
+        // 換 A 被詢問出殺（A 手牌有殺）
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskKillEvent
+                && ((AskKillEvent) e).getPlayerId().equals("player-a")));
+        assertEquals("player-a", game.getActivePlayer().getId());
+        // 雙方都未扣血
+        assertEquals(4, playerA.getHP());
+        assertEquals(4, playerB.getHP());
+    }
+
+    @DisplayName("被借刀殺人時，B 裝備丈八蛇矛 → 棄兩張當殺攻擊 C → C 被詢問出閃")
+    @Test
+    public void testPassiveViperSpear_RespondingBorrowedSword_TargetAskedDodge() {
+        Game game = createGameWithPlayerAB();
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+
+        // B 必須裝備武器才能被借刀（借刀規則）— 這裡用丈八蛇矛
+        playerB.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+        playerB.getHand().addCardToHand(asList(new Peach(BH3029), new Peach(BH4030)));
+        playerA.getHand().addCardToHand(new BorrowedSword(SCK065));
+
+        // A 出借刀殺人 → 選 B 借、C 攻擊
+        game.playerPlayCard(playerA.getId(), SCK065.getCardId(), playerB.getId(), PlayType.ACTIVE.getPlayType());
+        game.useBorrowedSwordEffect(playerA.getId(), playerB.getId(), playerC.getId());
+
+        assertEquals("player-b", game.getActivePlayer().getId());
+
+        // B 用丈八蛇矛棄兩張當殺攻擊 C
+        int bHandSizeBefore = playerB.getHandSize();
+        List<DomainEvent> events = game.playerUseViperSpearKill(
+                playerB.getId(), playerC.getId(),
+                List.of(BH3029.getCardId(), BH4030.getCardId()));
+
+        ViperSpearKillTriggerEvent triggerEvent = events.stream()
+                .filter(e -> e instanceof ViperSpearKillTriggerEvent)
+                .map(e -> (ViperSpearKillTriggerEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("ViperSpearKillTriggerEvent should be emitted"));
+        assertEquals("player-b", triggerEvent.getAttackerPlayerId());
+        assertEquals("player-c", triggerEvent.getTargetPlayerId());
+
+        // B 手牌 -2、武器仍在 B 身上（沒被奪走）
+        assertEquals(bHandSizeBefore - 2, playerB.getHandSize());
+        assertNotNull(playerB.getEquipmentWeaponCard());
+
+        // C 被詢問出閃
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent));
+        assertEquals("player-c", game.getActivePlayer().getId());
     }
 
     @DisplayName("VirtualKill 有正確的 id 和 effect")

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/UseViperSpearKillRequest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/UseViperSpearKillRequest.java
@@ -10,6 +10,11 @@ import java.util.List;
 @NoArgsConstructor
 public class UseViperSpearKillRequest {
     private String playerId;
+    /**
+     * 攻擊目標。
+     * - Active（出牌階段）：必填
+     * - Passive 回應：BarbarianInvasion / Duel 不需要；BorrowedSword 必填（指定攻擊目標）
+     */
     private String targetPlayerId;
     private List<String> discardCardIds;
 

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/MockMvcUtil.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/MockMvcUtil.java
@@ -110,13 +110,14 @@ public class MockMvcUtil {
         String cardIdsJson = discardCardIds.stream()
                 .map(id -> "\"" + id + "\"")
                 .collect(java.util.stream.Collectors.joining(","));
+        String targetJson = targetPlayerId == null ? "null" : "\"" + targetPlayerId + "\"";
         return this.mockMvc.perform(post("/api/games/" + gameId + "/player:useViperSpearKill")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(String.format("""
                         { "playerId": "%s",
-                          "targetPlayerId": "%s",
+                          "targetPlayerId": %s,
                           "discardCardIds": [%s]
-                        }""", playerId, targetPlayerId, cardIdsJson)));
+                        }""", playerId, targetJson, cardIdsJson)));
     }
 
     public ResultActions useHeavenlyDoubleHalberdKill(String gameId, String playerId, String cardId,

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/equipment/EighteenSpanViperSpearTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/equipment/EighteenSpanViperSpearTest.java
@@ -10,6 +10,9 @@ import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.Peach;
 import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.EighteenSpanViperSpearCard;
+import com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion;
+import com.gaas.threeKingdoms.handcard.scrollcard.BorrowedSword;
+import com.gaas.threeKingdoms.handcard.scrollcard.Duel;
 import com.gaas.threeKingdoms.player.HealthStatus;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.rolecard.Role;
@@ -150,6 +153,103 @@ public class EighteenSpanViperSpearTest extends AbstractBaseIntegrationTest {
                 .andExpect(status().isOk()).andReturn();
 
         assertAllPlayerJson("src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/viper_spear_kill_dying_for_%s.json");
+    }
+
+    @Test
+    public void testPassiveViperSpear_RespondingBarbarianInvasion() throws Exception {
+        // A 出南蠻入侵；B 裝丈八蛇矛 + 兩張手牌
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new BarbarianInvasion(SS7007));
+        Player playerB = createPlayer("player-b", 4, General.劉備, HealthStatus.ALIVE, Role.TRAITOR,
+                new Peach(BH3029), new Peach(BH4030));
+        playerB.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL,
+                new Kill(BS8008));
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER,
+                new Kill(BS9009));
+
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Kill(BS0010), new Peach(BH6032), new Dodge(BH7033), new Kill(BS7020)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // A 出南蠻 → B 第一個被詢問
+        mockMvcUtil.playCard(gameId, "player-a", "", SS7007.getCardId(), PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B 用丈八蛇矛棄兩張當殺回應
+        mockMvcUtil.useViperSpearKill(gameId, "player-b", null,
+                        List.of(BH3029.getCardId(), BH4030.getCardId()))
+                .andExpect(status().isOk()).andReturn();
+
+        assertAllPlayerJson("src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_barbarian_for_%s.json");
+    }
+
+    @Test
+    public void testPassiveViperSpear_RespondingDuel() throws Exception {
+        // A 對 B 出決鬥；B 裝丈八蛇矛 + 兩張手牌
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Duel(SSA001), new Kill(BS8008));
+        Player playerB = createPlayer("player-b", 4, General.劉備, HealthStatus.ALIVE, Role.TRAITOR,
+                new Peach(BH3029), new Peach(BH4030));
+        playerB.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Kill(BS0010), new Peach(BH6032), new Dodge(BH7033), new Kill(BS7020)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // A 對 B 出決鬥 → B 第一個被詢問出殺
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", SSA001.getCardId(), PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B 用丈八蛇矛棄兩張當殺回應 → A 換被詢問出殺
+        mockMvcUtil.useViperSpearKill(gameId, "player-b", null,
+                        List.of(BH3029.getCardId(), BH4030.getCardId()))
+                .andExpect(status().isOk()).andReturn();
+
+        assertAllPlayerJson("src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_duel_for_%s.json");
+    }
+
+    @Test
+    public void testPassiveViperSpear_RespondingBorrowedSword() throws Exception {
+        // A 出借刀殺人，借 B 攻擊 C；B 裝丈八蛇矛 + 兩張手牌
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new BorrowedSword(SCK065));
+        Player playerB = createPlayer("player-b", 4, General.劉備, HealthStatus.ALIVE, Role.TRAITOR,
+                new Peach(BH3029), new Peach(BH4030));
+        playerB.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Kill(BS0010), new Peach(BH6032), new Dodge(BH7033), new Kill(BS7020)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // A 出借刀殺人 → 指定 B 借
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", SCK065.getCardId(), PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // A 完成借刀效果 → B 攻擊 C
+        mockMvcUtil.useBorrowedSwordEffect(gameId, "player-a", "player-b", "player-c")
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B 用丈八蛇矛棄兩張當殺攻擊 C → C 被詢問出閃
+        mockMvcUtil.useViperSpearKill(gameId, "player-b", "player-c",
+                        List.of(BH3029.getCardId(), BH4030.getCardId()))
+                .andExpect(status().isOk()).andReturn();
+
+        assertAllPlayerJson("src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_borrowed_sword_for_%s.json");
     }
 
     @Test

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_barbarian_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_barbarian_for_player_a.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "ViperSpearKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-b",
+      "targetPlayerId" : "player-a",
+      "discardedCardIds" : [ "BH3029", "BH4030" ]
+    },
+    "message" : "丈八蛇矛發動"
+  }, {
+    "event" : "AskKillEvent",
+    "data" : {
+      "playerId" : "player-c"
+    },
+    "message" : "請問 player-c 要否要出殺"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-c",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b用丈八蛇矛出殺",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_barbarian_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_barbarian_for_player_b.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "ViperSpearKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-b",
+      "targetPlayerId" : "player-a",
+      "discardedCardIds" : [ "BH3029", "BH4030" ]
+    },
+    "message" : "丈八蛇矛發動"
+  }, {
+    "event" : "AskKillEvent",
+    "data" : {
+      "playerId" : "player-c"
+    },
+    "message" : "請問 player-c 要否要出殺"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "Traitor",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-c",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b用丈八蛇矛出殺",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_barbarian_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_barbarian_for_player_c.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "ViperSpearKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-b",
+      "targetPlayerId" : "player-a",
+      "discardedCardIds" : [ "BH3029", "BH4030" ]
+    },
+    "message" : "丈八蛇矛發動"
+  }, {
+    "event" : "AskKillEvent",
+    "data" : {
+      "playerId" : "player-c"
+    },
+    "message" : "請問 player-c 要否要出殺"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ "BS8008" ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-c",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b用丈八蛇矛出殺",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_barbarian_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_barbarian_for_player_d.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "ViperSpearKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-b",
+      "targetPlayerId" : "player-a",
+      "discardedCardIds" : [ "BH3029", "BH4030" ]
+    },
+    "message" : "丈八蛇矛發動"
+  }, {
+    "event" : "AskKillEvent",
+    "data" : {
+      "playerId" : "player-c"
+    },
+    "message" : "請問 player-c 要否要出殺"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ "BS9009" ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-c",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b用丈八蛇矛出殺",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_borrowed_sword_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_borrowed_sword_for_player_a.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "ViperSpearKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-b",
+      "targetPlayerId" : "player-c",
+      "discardedCardIds" : [ "BH3029", "BH4030" ]
+    },
+    "message" : "丈八蛇矛發動"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-c"
+    },
+    "message" : "請問 player-c 要否要出閃"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-c",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "丈八蛇矛出殺",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_borrowed_sword_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_borrowed_sword_for_player_b.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "ViperSpearKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-b",
+      "targetPlayerId" : "player-c",
+      "discardedCardIds" : [ "BH3029", "BH4030" ]
+    },
+    "message" : "丈八蛇矛發動"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-c"
+    },
+    "message" : "請問 player-c 要否要出閃"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "Traitor",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-c",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "丈八蛇矛出殺",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_borrowed_sword_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_borrowed_sword_for_player_c.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "ViperSpearKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-b",
+      "targetPlayerId" : "player-c",
+      "discardedCardIds" : [ "BH3029", "BH4030" ]
+    },
+    "message" : "丈八蛇矛發動"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-c"
+    },
+    "message" : "請問 player-c 要否要出閃"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-c",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "丈八蛇矛出殺",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_borrowed_sword_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_borrowed_sword_for_player_d.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "ViperSpearKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-b",
+      "targetPlayerId" : "player-c",
+      "discardedCardIds" : [ "BH3029", "BH4030" ]
+    },
+    "message" : "丈八蛇矛發動"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-c"
+    },
+    "message" : "請問 player-c 要否要出閃"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-c",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "丈八蛇矛出殺",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_duel_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_duel_for_player_a.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "ViperSpearKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-b",
+      "targetPlayerId" : "player-a",
+      "discardedCardIds" : [ "BH3029", "BH4030" ]
+    },
+    "message" : "丈八蛇矛發動"
+  }, {
+    "event" : "AskKillEvent",
+    "data" : {
+      "playerId" : "player-a"
+    },
+    "message" : "請問 player-a 要否要出殺"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ "BS8008" ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b已出殺",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_duel_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_duel_for_player_b.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "ViperSpearKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-b",
+      "targetPlayerId" : "player-a",
+      "discardedCardIds" : [ "BH3029", "BH4030" ]
+    },
+    "message" : "丈八蛇矛發動"
+  }, {
+    "event" : "AskKillEvent",
+    "data" : {
+      "playerId" : "player-a"
+    },
+    "message" : "請問 player-a 要否要出殺"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "Traitor",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b已出殺",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_duel_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_duel_for_player_c.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "ViperSpearKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-b",
+      "targetPlayerId" : "player-a",
+      "discardedCardIds" : [ "BH3029", "BH4030" ]
+    },
+    "message" : "丈八蛇矛發動"
+  }, {
+    "event" : "AskKillEvent",
+    "data" : {
+      "playerId" : "player-a"
+    },
+    "message" : "請問 player-a 要否要出殺"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b已出殺",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_duel_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/EquipmentTest/EighteenSpanViperSpear/passive_duel_for_player_d.json
@@ -1,0 +1,75 @@
+{
+  "events" : [ {
+    "event" : "ViperSpearKillTriggerEvent",
+    "data" : {
+      "attackerPlayerId" : "player-b",
+      "targetPlayerId" : "player-a",
+      "discardedCardIds" : [ "BH3029", "BH4030" ]
+    },
+    "message" : "丈八蛇矛發動"
+  }, {
+    "event" : "AskKillEvent",
+    "data" : {
+      "playerId" : "player-a"
+    },
+    "message" : "請問 player-a 要否要出殺"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b已出殺",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}


### PR DESCRIPTION
## Summary

身份標準版規則：丈八蛇矛裝備者可將兩張手牌當殺**使用或打出**。此前只支援主動使用，本 PR 補上被動回應路徑。

涵蓋三個 ask-Kill 場景：
- 南蠻入侵 (BarbarianInvasion) — 被詢問者用 ViperSpear 棄兩張當殺回應
- 決鬥 (Duel) — 被詢問者用 ViperSpear 棄兩張當殺，輪到對手
- 借刀殺人 (BorrowedSword) — 被借者用 ViperSpear 棄兩張當殺攻擊指定目標

## 主要變更

- `Behavior.acceptVirtualKillResponse` 新 hook，三個 behavior override
- 三個 behavior 抽出共用 helper（`advanceAfterKillResponse` / `swapToOtherDuelist` / push `ViperSpearKillBehavior`）
- `Game.playerUseViperSpearKill` 依 top behavior 分流 active / passive
- Duel / BorrowedSword 「無殺即扣血/失武器」short-circuit 補上 ViperSpear capability 判斷
- `EighteenSpanViperSpearCard.canUseAsKill` static helper

## Test plan

- [x] 3 個 domain test（每場景 happy path）
- [x] 3 個 e2e test + 12 個 JSON fixture
- [x] 既有 369 domain + 229 spring 全綠（無 regression）

## Out of Scope
- 多人連環場景（首位用 ViperSpear 後，下位也用 ViperSpear）— 邏輯應天然支援，但測試 case 暫不加
- AOE / 多點傷害組合

🤖 Generated with [Claude Code](https://claude.com/claude-code)