### PR TITLE
feat: 武將技骨架 + 奸雄（曹操 WEI001）

### DIFF
--- a/LegendsOfTheThreeKingdoms/app/src/main/java/com/gaas/threeKingdoms/usecase/UseJianXiongEffectUseCase.java
+++ b/LegendsOfTheThreeKingdoms/app/src/main/java/com/gaas/threeKingdoms/usecase/UseJianXiongEffectUseCase.java
@@ -1,0 +1,45 @@
+package com.gaas.threeKingdoms.usecase;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.events.AskJianXiongEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.exception.NotFoundException;
+import com.gaas.threeKingdoms.outport.GameRepository;
+import jakarta.inject.Named;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Named
+public class UseJianXiongEffectUseCase {
+    private final GameRepository gameRepository;
+
+    public void execute(String gameId, UseJianXiongEffectRequest request, UseJianXiongEffectPresenter presenter) {
+        Game game = gameRepository.findById(gameId)
+                .orElseThrow(() -> new NotFoundException("Game not found"));
+        List<DomainEvent> events = game.playerUseJianXiongEffect(
+                request.playerId,
+                AskJianXiongEffectEvent.Choice.valueOf(request.choice)
+        );
+        gameRepository.save(game);
+        presenter.renderEvents(events);
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UseJianXiongEffectRequest {
+        private String playerId;
+        private String choice; // "ACCEPT" or "SKIP"
+    }
+
+    public interface UseJianXiongEffectPresenter<T> {
+        void renderEvents(List<DomainEvent> events);
+
+        T present();
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -669,11 +669,21 @@ public class Game {
 
             if (getGamePhase() instanceof GeneralDying) {
                 // 為救回後的 SkillEngine replay 帶 pending context（FAQ：曹操救回後可發動奸雄）
-                // VirtualKill (e.g. ViperSpear) 不在 PlayCard factory，無法 reload → 不傳
-                String pendingSourceCardId = (card instanceof VirtualKill) ? null : card.getId();
+                // VirtualKill (e.g. ViperSpear) 不在 PlayCard factory：用 pendingViperSpearDiscardCardIds 帶兩張棄牌
+                String pendingSourceCardId;
+                List<String> pendingViperSpearDiscardCardIds = null;
+                if (card instanceof VirtualKill) {
+                    pendingSourceCardId = null;
+                    Behavior topAtDamage = behavior.orElse(null);
+                    if (topAtDamage instanceof ViperSpearKillBehavior viper) {
+                        pendingViperSpearDiscardCardIds = viper.getDiscardedCardIds();
+                    }
+                } else {
+                    pendingSourceCardId = card.getId();
+                }
                 updateTopBehavior(new DyingAskPeachBehavior(this, damagedPlayer, getPlayers().stream().map(Player::getId).toList(),
                         damagedPlayer, cardId, playType, null,
-                        pendingSourceCardId, attackerPlayerId));
+                        pendingSourceCardId, attackerPlayerId, pendingViperSpearDiscardCardIds));
             }
             events.addAll(List.of(playerDamagedEvent, playerDyingEvent, askPeachEvent));
             return events;

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -30,6 +30,8 @@ import com.gaas.threeKingdoms.rolecard.RoleCard;
 import com.gaas.threeKingdoms.round.Round;
 import com.gaas.threeKingdoms.round.RoundPhase;
 import com.gaas.threeKingdoms.round.Stage;
+import com.gaas.threeKingdoms.skill.context.DamageContext;
+import com.gaas.threeKingdoms.skill.registry.SkillEngine;
 import com.gaas.threeKingdoms.utils.ShuffleWrapper;
 import lombok.AllArgsConstructor;
 
@@ -642,6 +644,15 @@ public class Game {
             }
             behavior.ifPresent(b -> b.setIsOneRound(true));
             events.add(playerDamagedEvent);
+
+            // 武將技：受傷後觸發
+            Player attackerPlayer = (attackerPlayerId == null || attackerPlayerId.isEmpty())
+                    ? null
+                    : players.stream().filter(p -> attackerPlayerId.equals(p.getId())).findFirst().orElse(null);
+            int damagePoints = originalHp - damagedPlayer.getHP();
+            DamageContext damageContext = new DamageContext(damagedPlayer, attackerPlayer, card, damagePoints);
+            events.addAll(SkillEngine.onDamaged(this, damageContext));
+
             return events;
         } else {
             PlayerDyingEvent playerDyingEvent = createPlayerDyingEvent(damagedPlayer);
@@ -839,6 +850,20 @@ public class Game {
         }
         WaitingGreenDragonCrescentBladeResponseBehavior gdcbBehavior = (WaitingGreenDragonCrescentBladeResponseBehavior) behavior;
         List<DomainEvent> events = gdcbBehavior.resolveChoice(playerId, choice, killCardId);
+        removeCompletedBehaviors();
+        return events;
+    }
+
+    public List<DomainEvent> playerUseJianXiongEffect(String playerId, AskJianXiongEffectEvent.Choice choice) {
+        if (topBehavior.isEmpty()) {
+            throw new IllegalStateException("No active behavior waiting for JianXiong effect response");
+        }
+        Behavior behavior = topBehavior.peek();
+        if (!(behavior instanceof WaitingJianXiongResponseBehavior)) {
+            throw new IllegalStateException("Current behavior is not WaitingJianXiongResponseBehavior");
+        }
+        WaitingJianXiongResponseBehavior jxBehavior = (WaitingJianXiongResponseBehavior) behavior;
+        List<DomainEvent> events = jxBehavior.resolveChoice(playerId, choice);
         removeCompletedBehaviors();
         return events;
     }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -668,8 +668,12 @@ public class Game {
             behavior.ifPresent(b -> b.setIsOneRound(false));
 
             if (getGamePhase() instanceof GeneralDying) {
+                // 為救回後的 SkillEngine replay 帶 pending context（FAQ：曹操救回後可發動奸雄）
+                // VirtualKill (e.g. ViperSpear) 不在 PlayCard factory，無法 reload → 不傳
+                String pendingSourceCardId = (card instanceof VirtualKill) ? null : card.getId();
                 updateTopBehavior(new DyingAskPeachBehavior(this, damagedPlayer, getPlayers().stream().map(Player::getId).toList(),
-                        damagedPlayer, cardId, playType, null));
+                        damagedPlayer, cardId, playType, null,
+                        pendingSourceCardId, attackerPlayerId));
             }
             events.addAll(List.of(playerDamagedEvent, playerDyingEvent, askPeachEvent));
             return events;

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/JianXiongCompatibleTopBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/JianXiongCompatibleTopBehavior.java
@@ -1,0 +1,27 @@
+package com.gaas.threeKingdoms.behavior;
+
+/**
+ * Marker：top behavior 表示可以 host 奸雄（JianXiongSkill）介入。
+ * <p>
+ * 實作此介面代表：受傷流程結束時，把 WaitingJianXiongResponseBehavior 插在自己之上
+ * （或取代自己）不會破壞既有 stack / activePlayer / polling state。
+ * <p>
+ * 注意：未來其他 OnDamagedSkill（反饋、苦肉觸發等）若有類似需求，可考慮把此 marker
+ * 改名為 {@code OnDamagedSkillCompatibleTopBehavior} 並重用。
+ */
+public interface JianXiongCompatibleTopBehavior {
+
+    /**
+     * polling-style caller 在 damage 後仍需保留底層 behavior、等 WaitingJX 解決後 resume polling。
+     * caller 須自行：
+     *   1. 在 damage 後偵測 {@code WaitingJianXiongResponseBehavior} 在 stack 頂
+     *   2. 把 polling-advance 邏輯註冊為 {@code WaitingJianXiongResponseBehavior.setOnResolved(...)}
+     *   3. damage event 之外不立即 emit 後續 polling 事件
+     * <p>
+     * JianXiongSkill 看到此值為 true 時，不會呼叫 {@code removeCompletedBehaviors()}，
+     * 保留 polling behavior 等 callback resume。
+     */
+    default boolean isPollingCaller() {
+        return false;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
@@ -21,7 +21,13 @@ import static com.gaas.threeKingdoms.behavior.behavior.WardBehavior.WARD_TARGET_
 import static com.gaas.threeKingdoms.behavior.behavior.WardBehavior.WARD_TRIGGER_PLAYER_ID;
 import static com.gaas.threeKingdoms.handcard.PlayCard.*;
 
-public class ArrowBarrageBehavior extends Behavior {
+public class ArrowBarrageBehavior extends Behavior implements com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior {
+
+    @Override
+    public boolean isPollingCaller() {
+        return true;
+    }
+
     private boolean pollingStarted = false;
 
     public ArrowBarrageBehavior(Game game, Player player, List<String> reactivePlayers, Player currentReactionPlayer, String cardId, String playType, HandCard card) {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
@@ -149,32 +149,22 @@ public class ArrowBarrageBehavior extends Behavior {
         if (isSkip(playType)) {
             int originalHp = currentReactionPlayer.getHP();
             List<DomainEvent> damagedEvent = game.getDamagedEvent(playerId, targetPlayerId, cardId, card, playType, originalHp, currentReactionPlayer, game.getCurrentRound(), Optional.of(this));
-            // Remove the current player to next player
-            currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
 
-            List<DomainEvent> events = new ArrayList<>(damagedEvent);
-            if (!game.getGamePhase().getPhaseName().equals("GeneralDying")) { // 如果受到傷害且沒死亡
-                boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId);
-                if (isLastPlayer) {
-                    isOneRound = true;
-                    game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
-                } else {
-                    isOneRound = false;
-                    game.getCurrentRound().setActivePlayer(currentReactionPlayer);
-                }
-                events.add(game.getGameStatusEvent("扣血但還活著"));
-                if (!isLastPlayer) {
-                    events.addAll(askNextPlayerOrWard());
-                }
-            } else {
-                events.add(game.getGameStatusEvent("扣血已瀕臨死亡"));
-
-                // 最後一個人
-                if (reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId)) {
-                    isOneRound = true;
-                }
+            // 偵測 JianXiong 介入：若 WaitingJX 在 stack 頂，把 polling-advance 註冊為
+            // callback，等 JianXiong 解決後再執行（避免覆蓋 activePlayer 與打亂 stack）
+            if (!game.isTopBehaviorEmpty()
+                    && game.peekTopBehavior() instanceof WaitingJianXiongResponseBehavior wjx) {
+                wjx.setOnResolved(() -> advanceAfterDamage(playerId));
+                // 立即補上 GameStatusEvent — PlayCardPresenter 會 require；polling-advance 才 defer
+                List<DomainEvent> events = new ArrayList<>(damagedEvent);
+                String message = game.getGamePhase().getPhaseName().equals("GeneralDying")
+                        ? "扣血已瀕臨死亡" : "扣血但還活著";
+                events.add(game.getGameStatusEvent(message));
+                return events;
             }
 
+            List<DomainEvent> events = new ArrayList<>(damagedEvent);
+            events.addAll(advanceAfterDamage(playerId));
             return events;
         } else if (isDodgeCard(cardId)) {
             playerPlayCardNotUpdateActivePlayer(game.getPlayer(playerId), cardId);
@@ -201,5 +191,37 @@ public class ArrowBarrageBehavior extends Behavior {
 
     public boolean isInReactionPlayers(String playerId) {
         return reactionPlayers.contains(playerId);
+    }
+
+    /**
+     * 受傷後的 polling-advance 邏輯（推進到下個 reactor / 結束 polling）。
+     * 抽出以便 JianXiong 介入時 defer 為 callback；正常路徑直接在 doResponseToPlayerAction
+     * 內呼叫。
+     */
+    private List<DomainEvent> advanceAfterDamage(String playerId) {
+        currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
+
+        List<DomainEvent> events = new ArrayList<>();
+        if (!game.getGamePhase().getPhaseName().equals("GeneralDying")) {
+            boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId);
+            if (isLastPlayer) {
+                isOneRound = true;
+                game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
+            } else {
+                isOneRound = false;
+                game.getCurrentRound().setActivePlayer(currentReactionPlayer);
+            }
+            events.add(game.getGameStatusEvent("扣血但還活著"));
+            if (!isLastPlayer) {
+                events.addAll(askNextPlayerOrWard());
+            }
+        } else {
+            events.add(game.getGameStatusEvent("扣血已瀕臨死亡"));
+            // 最後一個人
+            if (reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId)) {
+                isOneRound = true;
+            }
+        }
+        return events;
     }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
@@ -20,7 +20,13 @@ import static com.gaas.threeKingdoms.behavior.behavior.WardBehavior.WARD_TRIGGER
 import static com.gaas.threeKingdoms.handcard.PlayCard.isKillCard;
 import static com.gaas.threeKingdoms.handcard.PlayCard.isSkip;
 
-public class BarbarianInvasionBehavior extends Behavior {
+public class BarbarianInvasionBehavior extends Behavior implements com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior {
+
+    @Override
+    public boolean isPollingCaller() {
+        return true;
+    }
+
     private boolean pollingStarted = false;
 
     public BarbarianInvasionBehavior(Game game, Player behaviorPlayer, List<String> reactionPlayers, Player currentReactionPlayer, String cardId, String playType, HandCard card) {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
@@ -136,32 +136,22 @@ public class BarbarianInvasionBehavior extends Behavior {
         if (isSkip(playType)) {
             int originalHp = currentReactionPlayer.getHP();
             List<DomainEvent> damagedEvent = game.getDamagedEvent(playerId, targetPlayerId, cardId, card, playType, originalHp, currentReactionPlayer, game.getCurrentRound(), Optional.of(this));
-            // Remove the current player to next player
-            currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
 
-            List<DomainEvent> events = new ArrayList<>(damagedEvent);
-            if (!game.getGamePhase().getPhaseName().equals("GeneralDying")) { // 如果受到傷害且沒死亡
-                boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId);
-                if (isLastPlayer) {
-                    isOneRound = true;
-                    game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
-                } else {
-                    isOneRound = false;
-                    game.getCurrentRound().setActivePlayer(currentReactionPlayer);
-                }
-                events.add(game.getGameStatusEvent("扣血但還活著"));
-                if (!isLastPlayer) {
-                    events.addAll(askNextPlayerOrWard());
-                }
-            } else {
-                events.add(game.getGameStatusEvent("扣血已瀕臨死亡"));
-
-                // 最後一個人
-                if (reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId)) {
-                    isOneRound = true;
-                }
+            // 偵測 JianXiong 介入：若 WaitingJX 在 stack 頂，把 polling-advance 註冊為
+            // callback，等 JianXiong 解決後再執行（避免覆蓋 activePlayer 與打亂 stack）
+            if (!game.isTopBehaviorEmpty()
+                    && game.peekTopBehavior() instanceof WaitingJianXiongResponseBehavior wjx) {
+                wjx.setOnResolved(() -> advanceAfterDamage(playerId));
+                // 立即補上 GameStatusEvent — PlayCardPresenter 會 require；polling-advance 才 defer
+                List<DomainEvent> events = new ArrayList<>(damagedEvent);
+                String message = game.getGamePhase().getPhaseName().equals("GeneralDying")
+                        ? "扣血已瀕臨死亡" : "扣血但還活著";
+                events.add(game.getGameStatusEvent(message));
+                return events;
             }
 
+            List<DomainEvent> events = new ArrayList<>(damagedEvent);
+            events.addAll(advanceAfterDamage(playerId));
             return events;
         } else if (isKillCard(cardId)) {
             playerPlayCardNotUpdateActivePlayer(game.getPlayer(playerId), cardId);
@@ -188,6 +178,38 @@ public class BarbarianInvasionBehavior extends Behavior {
 
     public boolean isInReactionPlayers(String playerId) {
         return reactionPlayers.contains(playerId);
+    }
+
+    /**
+     * 受傷後的 polling-advance 邏輯（推進到下個 reactor / 結束 polling）。
+     * 抽出以便 JianXiong 介入時 defer 為 callback；正常路徑直接在 doResponseToPlayerAction
+     * 內呼叫。
+     */
+    private List<DomainEvent> advanceAfterDamage(String playerId) {
+        currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
+
+        List<DomainEvent> events = new ArrayList<>();
+        if (!game.getGamePhase().getPhaseName().equals("GeneralDying")) {
+            boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId);
+            if (isLastPlayer) {
+                isOneRound = true;
+                game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
+            } else {
+                isOneRound = false;
+                game.getCurrentRound().setActivePlayer(currentReactionPlayer);
+            }
+            events.add(game.getGameStatusEvent("扣血但還活著"));
+            if (!isLastPlayer) {
+                events.addAll(askNextPlayerOrWard());
+            }
+        } else {
+            events.add(game.getGameStatusEvent("扣血已瀕臨死亡"));
+            // 最後一個人
+            if (reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId)) {
+                isOneRound = true;
+            }
+        }
+        return events;
     }
 
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DuelBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DuelBehavior.java
@@ -22,7 +22,7 @@ import static com.gaas.threeKingdoms.behavior.behavior.WardBehavior.WARD_TRIGGER
 import static com.gaas.threeKingdoms.handcard.PlayCard.isKillCard;
 import static com.gaas.threeKingdoms.handcard.PlayCard.isSkip;
 
-public class DuelBehavior extends Behavior {
+public class DuelBehavior extends Behavior implements com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior {
 
     public DuelBehavior(Game game, Player behaviorPlayer, List<String> reactionPlayers, Player currentReactionPlayer, String cardId, String playType, HandCard card) {
         super(game, behaviorPlayer, reactionPlayers, currentReactionPlayer, cardId, playType, card, true, false, false);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DyingAskPeachBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DyingAskPeachBehavior.java
@@ -8,6 +8,7 @@ import com.gaas.threeKingdoms.gamephase.Normal;
 import com.gaas.threeKingdoms.handcard.HandCard;
 import com.gaas.threeKingdoms.handcard.PlayCard;
 import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.VirtualKill;
 import com.gaas.threeKingdoms.handcard.equipmentcard.EquipmentCard;
 import com.gaas.threeKingdoms.handcard.scrollcard.Lightning;
 import com.gaas.threeKingdoms.player.HealthStatus;
@@ -33,20 +34,28 @@ public class DyingAskPeachBehavior extends Behavior {
     /**
      * 致命傷的 sourceCard.id 與 attackerPlayerId — 在 revival branch 用來 replay
      * SkillEngine.onDamaged（FAQ：曹操瀕死被救回後仍可發動奸雄）。null 表示
-     * 不適合 replay（VirtualKill 不在 PlayCard.factory 或非殺類傷害）。
+     * 不適合 replay（一般情況下 VirtualKill 不在 PlayCard.factory 或非殺類傷害）。
+     * <p>
+     * 若致命傷源自丈八蛇矛（VirtualKill），改用 pendingViperSpearDiscardCardIds
+     * 持有兩張棄牌 id，replay 時 JianXiongSkill 透過 DyingAskPeachBehavior 取得。
      */
     private final String pendingSourceCardId;
     private final String pendingAttackerPlayerId;
+    private final List<String> pendingViperSpearDiscardCardIds;
 
     public DyingAskPeachBehavior(Game game, Player behaviorPlayer, List<String> reactionPlayers, Player currentReactionPlayer, String cardId, String playType, HandCard card) {
-        this(game, behaviorPlayer, reactionPlayers, currentReactionPlayer, cardId, playType, card, null, null);
+        this(game, behaviorPlayer, reactionPlayers, currentReactionPlayer, cardId, playType, card, null, null, null);
     }
 
     public DyingAskPeachBehavior(Game game, Player behaviorPlayer, List<String> reactionPlayers, Player currentReactionPlayer, String cardId, String playType, HandCard card,
-                                  String pendingSourceCardId, String pendingAttackerPlayerId) {
+                                  String pendingSourceCardId, String pendingAttackerPlayerId,
+                                  List<String> pendingViperSpearDiscardCardIds) {
         super(game, behaviorPlayer, reactionPlayers, currentReactionPlayer, cardId, playType, card, true, false, false);
         this.pendingSourceCardId = pendingSourceCardId;
         this.pendingAttackerPlayerId = pendingAttackerPlayerId;
+        this.pendingViperSpearDiscardCardIds = pendingViperSpearDiscardCardIds == null
+                ? null
+                : List.copyOf(pendingViperSpearDiscardCardIds);
         List<Player> players = game.getSeatingChart().getPlayers();
         int damagedPlayerIndex = players.indexOf(behaviorPlayer);
         List<Player> reorderedPlayerList = new ArrayList<>();
@@ -304,22 +313,25 @@ public class DyingAskPeachBehavior extends Behavior {
     }
 
     private void replayOnDamagedAfterRevival(Player dyingPlayer, List<DomainEvent> events) {
-        if (pendingSourceCardId == null) {
-            return;
-        }
-        HandCard sourceCard;
-        try {
-            sourceCard = PlayCard.findById(pendingSourceCardId);
-        } catch (RuntimeException e) {
-            // VirtualKill 等不在 factory 的 sourceCard — 不 replay（v1 不支援）
-            return;
+        Player attacker = (pendingAttackerPlayerId != null && !pendingAttackerPlayerId.isEmpty())
+                ? game.getPlayer(pendingAttackerPlayerId)
+                : null;
+
+        HandCard sourceCard = null;
+        if (pendingViperSpearDiscardCardIds != null && !pendingViperSpearDiscardCardIds.isEmpty()) {
+            // 丈八蛇矛致命攻擊：sourceCard 是 VirtualKill；JianXiongSkill 會透過
+            // DyingAskPeachBehavior 取得 pending 的兩張棄牌 id
+            sourceCard = new VirtualKill();
+        } else if (pendingSourceCardId != null) {
+            try {
+                sourceCard = PlayCard.findById(pendingSourceCardId);
+            } catch (RuntimeException e) {
+                return;
+            }
         }
         if (sourceCard == null) {
             return;
         }
-        Player attacker = (pendingAttackerPlayerId != null && !pendingAttackerPlayerId.isEmpty())
-                ? game.getPlayer(pendingAttackerPlayerId)
-                : null;
         DamageContext ctx = new DamageContext(dyingPlayer, attacker, sourceCard, 1);
         events.addAll(SkillEngine.onDamaged(game, ctx));
     }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DyingAskPeachBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DyingAskPeachBehavior.java
@@ -6,6 +6,7 @@ import com.gaas.threeKingdoms.events.*;
 import com.gaas.threeKingdoms.gamephase.GameOver;
 import com.gaas.threeKingdoms.gamephase.Normal;
 import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.PlayCard;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.equipmentcard.EquipmentCard;
 import com.gaas.threeKingdoms.handcard.scrollcard.Lightning;
@@ -14,6 +15,9 @@ import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.rolecard.Role;
 import com.gaas.threeKingdoms.round.Round;
 import com.gaas.threeKingdoms.round.RoundPhase;
+import com.gaas.threeKingdoms.skill.context.DamageContext;
+import com.gaas.threeKingdoms.skill.registry.SkillEngine;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,9 +27,26 @@ import java.util.stream.IntStream;
 
 import static com.gaas.threeKingdoms.handcard.PlayCard.isPeachCard;
 
+@Getter
 public class DyingAskPeachBehavior extends Behavior {
+
+    /**
+     * 致命傷的 sourceCard.id 與 attackerPlayerId — 在 revival branch 用來 replay
+     * SkillEngine.onDamaged（FAQ：曹操瀕死被救回後仍可發動奸雄）。null 表示
+     * 不適合 replay（VirtualKill 不在 PlayCard.factory 或非殺類傷害）。
+     */
+    private final String pendingSourceCardId;
+    private final String pendingAttackerPlayerId;
+
     public DyingAskPeachBehavior(Game game, Player behaviorPlayer, List<String> reactionPlayers, Player currentReactionPlayer, String cardId, String playType, HandCard card) {
+        this(game, behaviorPlayer, reactionPlayers, currentReactionPlayer, cardId, playType, card, null, null);
+    }
+
+    public DyingAskPeachBehavior(Game game, Player behaviorPlayer, List<String> reactionPlayers, Player currentReactionPlayer, String cardId, String playType, HandCard card,
+                                  String pendingSourceCardId, String pendingAttackerPlayerId) {
         super(game, behaviorPlayer, reactionPlayers, currentReactionPlayer, cardId, playType, card, true, false, false);
+        this.pendingSourceCardId = pendingSourceCardId;
+        this.pendingAttackerPlayerId = pendingAttackerPlayerId;
         List<Player> players = game.getSeatingChart().getPlayers();
         int damagedPlayerIndex = players.indexOf(behaviorPlayer);
         List<Player> reorderedPlayerList = new ArrayList<>();
@@ -161,6 +182,9 @@ public class DyingAskPeachBehavior extends Behavior {
                     addAskDodgeEventIfCurrentBehaviorIsArrowBarrageBehavior(events);
                     addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(events);
                 }
+
+                // 致命傷被救回 → replay SkillEngine.onDamaged（FAQ: 曹操可發動奸雄收造成傷害的牌）
+                replayOnDamagedAfterRevival(dyingPlayer, events);
             } else {
                 events.add(createAskPeachEvent(currentPlayer, dyingPlayer));
             }
@@ -277,5 +301,26 @@ public class DyingAskPeachBehavior extends Behavior {
 
     private boolean isSkip(String playType) {
         return PlayType.SKIP.getPlayType().equals(playType);
+    }
+
+    private void replayOnDamagedAfterRevival(Player dyingPlayer, List<DomainEvent> events) {
+        if (pendingSourceCardId == null) {
+            return;
+        }
+        HandCard sourceCard;
+        try {
+            sourceCard = PlayCard.findById(pendingSourceCardId);
+        } catch (RuntimeException e) {
+            // VirtualKill 等不在 factory 的 sourceCard — 不 replay（v1 不支援）
+            return;
+        }
+        if (sourceCard == null) {
+            return;
+        }
+        Player attacker = (pendingAttackerPlayerId != null && !pendingAttackerPlayerId.isEmpty())
+                ? game.getPlayer(pendingAttackerPlayerId)
+                : null;
+        DamageContext ctx = new DamageContext(dyingPlayer, attacker, sourceCard, 1);
+        events.addAll(SkillEngine.onDamaged(game, ctx));
     }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DyingAskPeachBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DyingAskPeachBehavior.java
@@ -184,16 +184,33 @@ public class DyingAskPeachBehavior extends Behavior implements com.gaas.threeKin
                 isOneRound = true;
 
                 if (currentRound.getCurrentCard() instanceof Lightning && currentRound.getRoundPhase().equals(RoundPhase.Judgement)) {
-                    // 如果閃電讓玩家死亡，而且玩家被桃救活，需要回到判該玩家的判定階段
+                    // 閃電讓玩家死亡 → 被桃救回 → 回到該玩家判定階段繼續流程
                     events.addAll(game.playerTakeTurnStartInJudgement(currentRound.getCurrentRoundPlayer()));
+                    // Lightning 路徑下也可能有 JianXiong replay；交由 replay 接續
+                    replayOnDamagedAfterRevival(dyingPlayer, events);
                 } else {
-                    addAskKillEventIfCurrentBehaviorIsBarbarianInvasionBehavior(events);
-                    addAskDodgeEventIfCurrentBehaviorIsArrowBarrageBehavior(events);
-                    addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(events);
-                }
+                    // 致命傷被救回 → replay SkillEngine.onDamaged（FAQ: 曹操可發動奸雄收造成傷害的牌）
+                    // 順序：先 replay，若 JianXiong 觸發（push WaitingJX）則把 polling-resume defer
+                    // 進 WaitingJX.onResolved；否則立即 emit polling-resume 事件。
+                    replayOnDamagedAfterRevival(dyingPlayer, events);
 
-                // 致命傷被救回 → replay SkillEngine.onDamaged（FAQ: 曹操可發動奸雄收造成傷害的牌）
-                replayOnDamagedAfterRevival(dyingPlayer, events);
+                    if (!game.isTopBehaviorEmpty()
+                            && game.peekTopBehavior() instanceof WaitingJianXiongResponseBehavior wjx) {
+                        // JianXiong 介入：polling caller (BI / AB / Halberd) 的 resume 推到 WaitingJX 解決後
+                        wjx.setOnResolved(() -> {
+                            List<DomainEvent> resumeEvents = new ArrayList<>();
+                            addAskKillEventIfCurrentBehaviorIsBarbarianInvasionBehavior(resumeEvents);
+                            addAskDodgeEventIfCurrentBehaviorIsArrowBarrageBehavior(resumeEvents);
+                            addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(resumeEvents);
+                            return resumeEvents;
+                        });
+                    } else {
+                        // 一般情況（非曹操，或 JianXiong 沒觸發）— 立即 emit polling resume
+                        addAskKillEventIfCurrentBehaviorIsBarbarianInvasionBehavior(events);
+                        addAskDodgeEventIfCurrentBehaviorIsArrowBarrageBehavior(events);
+                        addAskDodgeEventIfCurrentBehaviorIsHeavenlyDoubleHalberdKillBehavior(events);
+                    }
+                }
             } else {
                 events.add(createAskPeachEvent(currentPlayer, dyingPlayer));
             }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DyingAskPeachBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/DyingAskPeachBehavior.java
@@ -29,7 +29,7 @@ import java.util.stream.IntStream;
 import static com.gaas.threeKingdoms.handcard.PlayCard.isPeachCard;
 
 @Getter
-public class DyingAskPeachBehavior extends Behavior {
+public class DyingAskPeachBehavior extends Behavior implements com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior {
 
     /**
      * 致命傷的 sourceCard.id 與 attackerPlayerId — 在 revival branch 用來 replay
@@ -323,11 +323,8 @@ public class DyingAskPeachBehavior extends Behavior {
             // DyingAskPeachBehavior 取得 pending 的兩張棄牌 id
             sourceCard = new VirtualKill();
         } else if (pendingSourceCardId != null) {
-            try {
-                sourceCard = PlayCard.findById(pendingSourceCardId);
-            } catch (RuntimeException e) {
-                return;
-            }
+            // PlayCard.findById 找不到時返 null（非 throw），用 null check 處理
+            sourceCard = PlayCard.findById(pendingSourceCardId);
         }
         if (sourceCard == null) {
             return;

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/LightningJudgementBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/LightningJudgementBehavior.java
@@ -23,7 +23,7 @@ import static com.gaas.threeKingdoms.behavior.behavior.WardBehavior.WARD_TRIGGER
  * - Ward cancelled (odd): Lightning is NOT discarded, instead transferred to next player
  * - Ward proceeds (even) / all skip: Normal Lightning judgement executes
  */
-public class LightningJudgementBehavior extends Behavior {
+public class LightningJudgementBehavior extends Behavior implements com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior {
 
     public LightningJudgementBehavior(Game game, Player affectedPlayer, List<String> reactionPlayers,
                                        Player currentReactionPlayer, String cardId, String playType, HandCard card) {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
@@ -31,7 +31,7 @@ import static com.gaas.threeKingdoms.handcard.PlayCard.isDodgeCard;
 import static com.gaas.threeKingdoms.handcard.PlayCard.isSkip;
 
 
-public class NormalActiveKillBehavior extends Behavior {
+public class NormalActiveKillBehavior extends Behavior implements com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior {
 
     public NormalActiveKillBehavior(Game game, Player behaviorPlayer, List<String> reactionPlayers, Player currentReactionPlayer, String cardId, String playType, HandCard card) {
         super(game, behaviorPlayer, reactionPlayers, currentReactionPlayer, cardId, playType, card, true, false, false);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingJianXiongResponseBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingJianXiongResponseBehavior.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * 奸雄等待回應 — 受傷者可選擇 ACCEPT（取得造成傷害的牌）或 SKIP。
@@ -29,6 +30,17 @@ import java.util.Optional;
 public class WaitingJianXiongResponseBehavior extends Behavior {
 
     private final List<String> sourceCardIds;
+
+    /**
+     * polling-aware caller（如 BarbarianInvasion / ArrowBarrage）在偵測 JianXiong 介入時，
+     * 透過此 callback 把 polling-advance 邏輯 defer 到 resolveChoice 內、isOneRound=true 之前執行。
+     * 不需要 polling resume 的 caller（NormalActiveKill / Duel / Lightning）保持 null。
+     */
+    private transient Supplier<List<DomainEvent>> onResolved;
+
+    public void setOnResolved(Supplier<List<DomainEvent>> onResolved) {
+        this.onResolved = onResolved;
+    }
 
     public WaitingJianXiongResponseBehavior(Game game, Player damagedPlayer, List<String> sourceCardIds) {
         super(game,
@@ -69,6 +81,13 @@ public class WaitingJianXiongResponseBehavior extends Behavior {
             events.add(game.getGameStatusEvent("放棄奸雄"));
         } else {
             throw new IllegalArgumentException("Invalid JianXiong choice: " + choice);
+        }
+
+        // 在 isOneRound=true 之前先跑 polling resume callback —
+        // 因為 callback 內可能會把底層 polling behavior 的 isOneRound 改回 false（mid-poll），
+        // 必須先於本 behavior 標記完成、避免 removeCompletedBehaviors 誤 pop polling behavior。
+        if (onResolved != null) {
+            events.addAll(onResolved.get());
         }
 
         isOneRound = true;

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingJianXiongResponseBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingJianXiongResponseBehavior.java
@@ -9,6 +9,7 @@ import com.gaas.threeKingdoms.handcard.HandCard;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.round.Round;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,25 +17,31 @@ import java.util.Optional;
 
 /**
  * 奸雄等待回應 — 受傷者可選擇 ACCEPT（取得造成傷害的牌）或 SKIP。
- * behaviorPlayer = 受傷者；sourceCardId 為造成傷害的牌的 ID（牌物件在 ACCEPT 時從 graveyard 取）。
+ * behaviorPlayer = 受傷者；sourceCardIds 為造成傷害的牌的 ID 列表
+ *   - 普通殺 / 錦囊：1 張（殺 / 閃電 / 南蠻 / 萬箭 / 決鬥 等）
+ *   - 丈八蛇矛攻擊：2 張棄牌（標準版 FAQ 規則）
  *
  * 注意：故意只儲存 cardId 而不存 HandCard 物件 — 因為 VirtualKill（如丈八蛇矛）
  * 不在 PlayCard.CARD_FACTORY_MAP 中，reload 時 PlayCard.findById 會回 null。
  * 所有實際的牌操作（移到手牌）都在 resolveChoice 時透過 graveyard.removeCard(cardId) 完成。
  */
+@Getter
 public class WaitingJianXiongResponseBehavior extends Behavior {
 
-    public WaitingJianXiongResponseBehavior(Game game, Player damagedPlayer, String sourceCardId) {
+    private final List<String> sourceCardIds;
+
+    public WaitingJianXiongResponseBehavior(Game game, Player damagedPlayer, List<String> sourceCardIds) {
         super(game,
                 damagedPlayer,
                 List.of(damagedPlayer.getId()),
                 damagedPlayer,
-                sourceCardId,
+                sourceCardIds.isEmpty() ? null : sourceCardIds.get(0),
                 PlayType.SYSTEM_INTERNAL.getPlayType(),
                 null,
                 false,
                 false,
                 true);
+        this.sourceCardIds = List.copyOf(sourceCardIds);
     }
 
     public List<DomainEvent> resolveChoice(String respondingPlayerId, AskJianXiongEffectEvent.Choice choice) {
@@ -48,15 +55,17 @@ public class WaitingJianXiongResponseBehavior extends Behavior {
         round.setActivePlayer(round.getCurrentRoundPlayer());
 
         if (choice == AskJianXiongEffectEvent.Choice.ACCEPT) {
-            Optional<HandCard> taken = game.getGraveyard().removeCard(cardId);
-            if (taken.isEmpty()) {
-                throw new IllegalStateException("Source card no longer in graveyard: " + cardId);
+            for (String id : sourceCardIds) {
+                Optional<HandCard> taken = game.getGraveyard().removeCard(id);
+                if (taken.isEmpty()) {
+                    throw new IllegalStateException("Source card no longer in graveyard: " + id);
+                }
+                behaviorPlayer.getHand().addCardToHand(taken.get());
             }
-            behaviorPlayer.getHand().addCardToHand(taken.get());
-            events.add(new JianXiongEffectEvent(behaviorPlayer.getId(), cardId, true));
+            events.add(new JianXiongEffectEvent(behaviorPlayer.getId(), sourceCardIds, true));
             events.add(game.getGameStatusEvent(behaviorPlayer.getId() + " 發動奸雄"));
         } else if (choice == AskJianXiongEffectEvent.Choice.SKIP) {
-            events.add(new JianXiongEffectEvent(behaviorPlayer.getId(), cardId, false));
+            events.add(new JianXiongEffectEvent(behaviorPlayer.getId(), sourceCardIds, false));
             events.add(game.getGameStatusEvent("放棄奸雄"));
         } else {
             throw new IllegalArgumentException("Invalid JianXiong choice: " + choice);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingJianXiongResponseBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingJianXiongResponseBehavior.java
@@ -16,18 +16,22 @@ import java.util.Optional;
 
 /**
  * 奸雄等待回應 — 受傷者可選擇 ACCEPT（取得造成傷害的牌）或 SKIP。
- * behaviorPlayer = 受傷者；sourceCard 為造成傷害的牌。
+ * behaviorPlayer = 受傷者；sourceCardId 為造成傷害的牌的 ID（牌物件在 ACCEPT 時從 graveyard 取）。
+ *
+ * 注意：故意只儲存 cardId 而不存 HandCard 物件 — 因為 VirtualKill（如丈八蛇矛）
+ * 不在 PlayCard.CARD_FACTORY_MAP 中，reload 時 PlayCard.findById 會回 null。
+ * 所有實際的牌操作（移到手牌）都在 resolveChoice 時透過 graveyard.removeCard(cardId) 完成。
  */
 public class WaitingJianXiongResponseBehavior extends Behavior {
 
-    public WaitingJianXiongResponseBehavior(Game game, Player damagedPlayer, HandCard sourceCard) {
+    public WaitingJianXiongResponseBehavior(Game game, Player damagedPlayer, String sourceCardId) {
         super(game,
                 damagedPlayer,
                 List.of(damagedPlayer.getId()),
                 damagedPlayer,
-                sourceCard.getId(),
+                sourceCardId,
                 PlayType.SYSTEM_INTERNAL.getPlayType(),
-                sourceCard,
+                null,
                 false,
                 false,
                 true);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingJianXiongResponseBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingJianXiongResponseBehavior.java
@@ -1,0 +1,64 @@
+package com.gaas.threeKingdoms.behavior.behavior;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.behavior.Behavior;
+import com.gaas.threeKingdoms.events.AskJianXiongEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.JianXiongEffectEvent;
+import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.round.Round;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 奸雄等待回應 — 受傷者可選擇 ACCEPT（取得造成傷害的牌）或 SKIP。
+ * behaviorPlayer = 受傷者；sourceCard 為造成傷害的牌。
+ */
+public class WaitingJianXiongResponseBehavior extends Behavior {
+
+    public WaitingJianXiongResponseBehavior(Game game, Player damagedPlayer, HandCard sourceCard) {
+        super(game,
+                damagedPlayer,
+                List.of(damagedPlayer.getId()),
+                damagedPlayer,
+                sourceCard.getId(),
+                PlayType.SYSTEM_INTERNAL.getPlayType(),
+                sourceCard,
+                false,
+                false,
+                true);
+    }
+
+    public List<DomainEvent> resolveChoice(String respondingPlayerId, AskJianXiongEffectEvent.Choice choice) {
+        if (!behaviorPlayer.getId().equals(respondingPlayerId)) {
+            throw new IllegalStateException(
+                    String.format("player %s is not the damaged player who should respond to JianXiong", respondingPlayerId));
+        }
+
+        List<DomainEvent> events = new ArrayList<>();
+        Round round = game.getCurrentRound();
+        round.setActivePlayer(round.getCurrentRoundPlayer());
+
+        if (choice == AskJianXiongEffectEvent.Choice.ACCEPT) {
+            Optional<HandCard> taken = game.getGraveyard().removeCard(cardId);
+            if (taken.isEmpty()) {
+                throw new IllegalStateException("Source card no longer in graveyard: " + cardId);
+            }
+            behaviorPlayer.getHand().addCardToHand(taken.get());
+            events.add(new JianXiongEffectEvent(behaviorPlayer.getId(), cardId, true));
+            events.add(game.getGameStatusEvent(behaviorPlayer.getId() + " 發動奸雄"));
+        } else if (choice == AskJianXiongEffectEvent.Choice.SKIP) {
+            events.add(new JianXiongEffectEvent(behaviorPlayer.getId(), cardId, false));
+            events.add(game.getGameStatusEvent("放棄奸雄"));
+        } else {
+            throw new IllegalArgumentException("Invalid JianXiong choice: " + choice);
+        }
+
+        isOneRound = true;
+        return events;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/AskJianXiongEffectEvent.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/AskJianXiongEffectEvent.java
@@ -1,0 +1,22 @@
+package com.gaas.threeKingdoms.events;
+
+import lombok.Getter;
+
+@Getter
+public class AskJianXiongEffectEvent extends DomainEvent {
+
+    private final String playerId;
+    private final String sourceCardId;
+
+    public AskJianXiongEffectEvent(String playerId, String sourceCardId) {
+        super("AskJianXiongEffectEvent",
+                String.format("奸雄：%s 是否獲得造成傷害的牌 %s", playerId, sourceCardId));
+        this.playerId = playerId;
+        this.sourceCardId = sourceCardId;
+    }
+
+    public enum Choice {
+        ACCEPT,
+        SKIP
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/AskJianXiongEffectEvent.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/AskJianXiongEffectEvent.java
@@ -2,17 +2,19 @@ package com.gaas.threeKingdoms.events;
 
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 public class AskJianXiongEffectEvent extends DomainEvent {
 
     private final String playerId;
-    private final String sourceCardId;
+    private final List<String> sourceCardIds;
 
-    public AskJianXiongEffectEvent(String playerId, String sourceCardId) {
+    public AskJianXiongEffectEvent(String playerId, List<String> sourceCardIds) {
         super("AskJianXiongEffectEvent",
-                String.format("奸雄：%s 是否獲得造成傷害的牌 %s", playerId, sourceCardId));
+                String.format("奸雄：%s 是否獲得造成傷害的牌 %s", playerId, sourceCardIds));
         this.playerId = playerId;
-        this.sourceCardId = sourceCardId;
+        this.sourceCardIds = sourceCardIds;
     }
 
     public enum Choice {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/JianXiongEffectEvent.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/JianXiongEffectEvent.java
@@ -1,0 +1,21 @@
+package com.gaas.threeKingdoms.events;
+
+import lombok.Getter;
+
+@Getter
+public class JianXiongEffectEvent extends DomainEvent {
+
+    private final String playerId;
+    private final String sourceCardId;
+    private final boolean taken;
+
+    public JianXiongEffectEvent(String playerId, String sourceCardId, boolean taken) {
+        super("JianXiongEffectEvent",
+                taken
+                        ? String.format("奸雄：%s 獲得 %s", playerId, sourceCardId)
+                        : String.format("奸雄：%s 放棄 %s", playerId, sourceCardId));
+        this.playerId = playerId;
+        this.sourceCardId = sourceCardId;
+        this.taken = taken;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/JianXiongEffectEvent.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/JianXiongEffectEvent.java
@@ -2,20 +2,22 @@ package com.gaas.threeKingdoms.events;
 
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 public class JianXiongEffectEvent extends DomainEvent {
 
     private final String playerId;
-    private final String sourceCardId;
+    private final List<String> sourceCardIds;
     private final boolean taken;
 
-    public JianXiongEffectEvent(String playerId, String sourceCardId, boolean taken) {
+    public JianXiongEffectEvent(String playerId, List<String> sourceCardIds, boolean taken) {
         super("JianXiongEffectEvent",
                 taken
-                        ? String.format("奸雄：%s 獲得 %s", playerId, sourceCardId)
-                        : String.format("奸雄：%s 放棄 %s", playerId, sourceCardId));
+                        ? String.format("奸雄：%s 獲得 %s", playerId, sourceCardIds)
+                        : String.format("奸雄：%s 放棄 %s", playerId, sourceCardIds));
         this.playerId = playerId;
-        this.sourceCardId = sourceCardId;
+        this.sourceCardIds = sourceCardIds;
         this.taken = taken;
     }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/handcard/Graveyard.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/handcard/Graveyard.java
@@ -6,6 +6,7 @@ import lombok.Data;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Stack;
 
 @Data
@@ -48,14 +49,14 @@ public class Graveyard {
         return graveYardDeck.stream().anyMatch(card -> card.getId().equals(cardId));
     }
 
-    public java.util.Optional<HandCard> removeCard(String cardId) {
+    public Optional<HandCard> removeCard(String cardId) {
         for (int i = graveYardDeck.size() - 1; i >= 0; i--) {
             HandCard card = graveYardDeck.get(i);
             if (card.getId().equals(cardId)) {
                 graveYardDeck.remove(i);
-                return java.util.Optional.of(card);
+                return Optional.of(card);
             }
         }
-        return java.util.Optional.empty();
+        return Optional.empty();
     }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/handcard/Graveyard.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/handcard/Graveyard.java
@@ -43,4 +43,19 @@ public class Graveyard {
     public int size(){
         return graveYardDeck.size();
     }
+
+    public boolean contains(String cardId) {
+        return graveYardDeck.stream().anyMatch(card -> card.getId().equals(cardId));
+    }
+
+    public java.util.Optional<HandCard> removeCard(String cardId) {
+        for (int i = graveYardDeck.size() - 1; i >= 0; i--) {
+            HandCard card = graveYardDeck.get(i);
+            if (card.getId().equals(cardId)) {
+                graveYardDeck.remove(i);
+                return java.util.Optional.of(card);
+            }
+        }
+        return java.util.Optional.empty();
+    }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/Skill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/Skill.java
@@ -1,0 +1,7 @@
+package com.gaas.threeKingdoms.skill;
+
+public interface Skill {
+    String getGeneralId();
+
+    String getSkillName();
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/context/DamageContext.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/context/DamageContext.java
@@ -1,0 +1,12 @@
+package com.gaas.threeKingdoms.skill.context;
+
+import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.player.Player;
+
+public record DamageContext(
+        Player damagedPlayer,
+        Player sourcePlayer,
+        HandCard sourceCard,
+        int points
+) {
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillEngine.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillEngine.java
@@ -1,0 +1,36 @@
+package com.gaas.threeKingdoms.skill.registry;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.generalcard.GeneralCard;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.skill.Skill;
+import com.gaas.threeKingdoms.skill.context.DamageContext;
+import com.gaas.threeKingdoms.skill.trigger.OnDamagedSkill;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class SkillEngine {
+
+    private SkillEngine() {
+    }
+
+    public static List<DomainEvent> onDamaged(Game game, DamageContext ctx) {
+        Player damaged = ctx.damagedPlayer();
+        if (damaged == null) {
+            return List.of();
+        }
+        GeneralCard general = damaged.getGeneralCard();
+        if (general == null) {
+            return List.of();
+        }
+        List<DomainEvent> events = new ArrayList<>();
+        for (Skill skill : SkillRegistry.of(general.getGeneralId())) {
+            if (skill instanceof OnDamagedSkill onDamaged) {
+                events.addAll(onDamaged.onDamaged(game, ctx));
+            }
+        }
+        return events;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillRegistry.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillRegistry.java
@@ -1,0 +1,28 @@
+package com.gaas.threeKingdoms.skill.registry;
+
+import com.gaas.threeKingdoms.skill.Skill;
+import com.gaas.threeKingdoms.skill.wei.JianXiongSkill;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class SkillRegistry {
+    private static final Map<String, List<Skill>> BY_GENERAL = new HashMap<>();
+
+    static {
+        register(new JianXiongSkill());
+    }
+
+    private SkillRegistry() {
+    }
+
+    public static List<Skill> of(String generalId) {
+        return BY_GENERAL.getOrDefault(generalId, List.of());
+    }
+
+    private static void register(Skill skill) {
+        BY_GENERAL.computeIfAbsent(skill.getGeneralId(), k -> new ArrayList<>()).add(skill);
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/trigger/OnDamagedSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/trigger/OnDamagedSkill.java
@@ -1,0 +1,16 @@
+package com.gaas.threeKingdoms.skill.trigger;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.skill.Skill;
+import com.gaas.threeKingdoms.skill.context.DamageContext;
+
+import java.util.List;
+
+public interface OnDamagedSkill extends Skill {
+    /**
+     * 玩家受到傷害後觸發。回傳要 append 到 events 的 DomainEvent 列表。
+     * 若需要互動（ASK），由 skill 自行 push WaitingXxxBehavior 到 game.behaviorStack。
+     */
+    List<DomainEvent> onDamaged(Game game, DamageContext ctx);
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
@@ -2,12 +2,8 @@ package com.gaas.threeKingdoms.skill.wei;
 
 import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.behavior.Behavior;
-import com.gaas.threeKingdoms.behavior.behavior.ArrowBarrageBehavior;
-import com.gaas.threeKingdoms.behavior.behavior.BarbarianInvasionBehavior;
-import com.gaas.threeKingdoms.behavior.behavior.DuelBehavior;
+import com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.DyingAskPeachBehavior;
-import com.gaas.threeKingdoms.behavior.behavior.LightningJudgementBehavior;
-import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.ViperSpearKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.WaitingJianXiongResponseBehavior;
 import com.gaas.threeKingdoms.events.AskJianXiongEffectEvent;
@@ -27,21 +23,18 @@ import java.util.List;
  *
  * 觸發範圍：
  *   - sourceCard != null（武將技直接傷害如 剛烈 / 離間 / 雷擊 sourceCard 為 null，不觸發）
- *   - 受傷者仍存活（HP > 0；瀕死或死亡不觸發）
- *   - top behavior 屬於白名單：NormalActiveKill / Duel / LightningJudgement /
- *     BarbarianInvasion / ArrowBarrage / 空 stack
+ *   - 受傷者仍存活（HP > 0；瀕死流程結束後若被救回會 replay）
+ *   - top behavior 實作 {@link JianXiongCompatibleTopBehavior}（或為空 stack）
  *
  * 取牌規則（FAQ）：
  *   - 一般殺 / 武器觸發殺 / 決鬥 / 閃電判定 / 南蠻入侵 / 萬箭齊發 → 獲得 sourceCard 本身
  *   - 丈八蛇矛攻擊 → 獲得攻擊者棄掉的兩張手牌（VirtualKill 不算）
+ *   - 致命傷被救回 → DyingAskPeachBehavior revival 分支 replay；ViperSpear 致命走兩張棄牌特例
  *   - 多點傷害整次只觸發 1 次
  *
- * AOE polling 整合機制：BarbarianInvasion / ArrowBarrage 在 doResponseToPlayerAction
- * 會偵測 WaitingJianXiongResponseBehavior 在 stack 頂，並把 polling-advance 註冊為
- * onResolved callback。等 JianXiong 解決後再 resume，避免 activePlayer 衝突。
- *
- * TODO（不在 v1）：
- *   - 致命傷被救回後仍可發動（dying flow 重構）
+ * AOE polling 整合機制：caller {@link JianXiongCompatibleTopBehavior#isPollingCaller()}
+ * 為 true 時（BarbarianInvasion / ArrowBarrage），caller 端會偵測 WaitingJianXiongResponseBehavior
+ * 在 stack 頂並把 polling-advance 註冊為 onResolved callback，避免 activePlayer 衝突。
  */
 public class JianXiongSkill implements OnDamagedSkill {
 
@@ -71,24 +64,10 @@ public class JianXiongSkill implements OnDamagedSkill {
             return List.of();
         }
 
-        // 守門：白名單 + 空 stack（Lightning 無 Ward 時 stack 空）
-        //   - NormalActiveKillBehavior（含子類 ViperSpearKill / HeavenlyDoubleHalberd）：殺 / 武器觸發殺
-        //   - DuelBehavior：決鬥輸給對手（Path A skip 與 Path B swap 都安全）
-        //   - LightningJudgementBehavior：閃電判定打中（Ward 路徑）
-        //   - BarbarianInvasionBehavior / ArrowBarrageBehavior：AOE polling
-        //     （caller 偵測 WaitingJX 並把 polling-advance defer 為 callback，避免 activePlayer 衝突）
-        //   - DyingAskPeachBehavior：致命傷被救回後 replay（FAQ）— DyingBehavior 在 revival
-        //     branch 已 set isOneRound=true 才呼叫 SkillEngine，安全 pop
-        //   - 空 stack：閃電判定無 Ward 路徑
+        // 守門：top 必須是 JianXiongCompatibleTopBehavior 或空 stack（Lightning 無 Ward 時 stack 空）。
+        // 各 behavior 自己聲明能否 host JianXiong；新增 behavior 不需回頭改本檔。
         Behavior top = game.isTopBehaviorEmpty() ? null : game.peekTopBehavior();
-        boolean topIsAllowed = top == null
-                || top instanceof NormalActiveKillBehavior
-                || top instanceof DuelBehavior
-                || top instanceof LightningJudgementBehavior
-                || top instanceof BarbarianInvasionBehavior
-                || top instanceof ArrowBarrageBehavior
-                || top instanceof DyingAskPeachBehavior;
-        if (!topIsAllowed) {
+        if (top != null && !(top instanceof JianXiongCompatibleTopBehavior)) {
             return List.of();
         }
 
@@ -116,11 +95,9 @@ public class JianXiongSkill implements OnDamagedSkill {
             return List.of();
         }
 
-        // 對 polling caller（BI / AB）保留底層 behavior — 等 WaitingJX 解決後 callback 會
-        // resume polling。對其他 caller（Kill / Duel / Lightning）把 line 645 標的 isOneRound=true
-        // 先 pop 掉，讓 WaitingJX 成為 stack 頂端。
-        boolean isPollingCaller = top instanceof BarbarianInvasionBehavior
-                || top instanceof ArrowBarrageBehavior;
+        // polling caller（BI / AB）需保留底層 behavior 等 callback resume；其他 caller 可直接
+        // pop（getDamagedEvent line 645 已標 isOneRound=true）。由 marker 上的方法決定。
+        boolean isPollingCaller = top instanceof JianXiongCompatibleTopBehavior c && c.isPollingCaller();
         if (!isPollingCaller) {
             game.removeCompletedBehaviors();
         }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
@@ -93,11 +93,19 @@ public class JianXiongSkill implements OnDamagedSkill {
         }
 
         // 決定要拿哪些牌：
-        //   - 丈八蛇矛 (VirtualKill + ViperSpearKillBehavior) → 兩張棄牌（FAQ 特例）
+        //   - 丈八蛇矛 alive (VirtualKill + ViperSpearKillBehavior) → 兩張棄牌
+        //   - 丈八蛇矛 致命 + revive (VirtualKill + DyingAskPeachBehavior) → 兩張棄牌（從 pending 取）
         //   - 其他（普通殺 / 錦囊 / 一般武器觸發殺）→ sourceCard 本身
         List<String> takeIds;
-        if (sourceCard instanceof VirtualKill && top instanceof ViperSpearKillBehavior viper) {
-            takeIds = viper.getDiscardedCardIds();
+        if (sourceCard instanceof VirtualKill) {
+            if (top instanceof ViperSpearKillBehavior viper) {
+                takeIds = viper.getDiscardedCardIds();
+            } else if (top instanceof DyingAskPeachBehavior dying
+                    && dying.getPendingViperSpearDiscardCardIds() != null) {
+                takeIds = dying.getPendingViperSpearDiscardCardIds();
+            } else {
+                return List.of();
+            }
             // 全有或全無：兩張都要還在墓地（中途被別的效果拿走時整體跳過）
             if (takeIds.isEmpty() || !takeIds.stream().allMatch(id -> game.getGraveyard().contains(id))) {
                 return List.of();

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
@@ -1,9 +1,11 @@
 package com.gaas.threeKingdoms.skill.wei;
 
 import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.WaitingJianXiongResponseBehavior;
 import com.gaas.threeKingdoms.events.AskJianXiongEffectEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.generalcard.General;
 import com.gaas.threeKingdoms.handcard.HandCard;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.player.Player;
@@ -30,7 +32,7 @@ import java.util.List;
  */
 public class JianXiongSkill implements OnDamagedSkill {
 
-    public static final String GENERAL_ID = "WEI001";
+    public static final String GENERAL_ID = General.曹操.getGeneralId();
     public static final String SKILL_NAME = "奸雄";
 
     @Override
@@ -61,10 +63,18 @@ public class JianXiongSkill implements OnDamagedSkill {
             return List.of();
         }
 
+        // 守門：v1 只支援 NormalActiveKillBehavior（含子類 ViperSpearKill / HeavenlyDoubleHalberd）
+        // 上的單體 Kill 傷害觸發。對 AOE polling behavior（BarbarianInvasion / ArrowBarrage）
+        // 或 Duel 等 caller，雖然 v1 因 sourceCard 過濾而不會走到這裡，但加守門防止未來
+        // 加新 OnDamagedSkill 時誤把 polling 中的 behavior pop 掉。
+        if (!(game.peekTopBehavior() instanceof NormalActiveKillBehavior)) {
+            return List.of();
+        }
+
         // 把 setIsOneRound(true) 的 kill behavior 先彈出，讓奸雄 behavior 成為 stack 頂端
         game.removeCompletedBehaviors();
 
-        WaitingJianXiongResponseBehavior waiting = new WaitingJianXiongResponseBehavior(game, damaged, sourceCard);
+        WaitingJianXiongResponseBehavior waiting = new WaitingJianXiongResponseBehavior(game, damaged, sourceCard.getId());
         game.updateTopBehavior(waiting);
         game.getCurrentRound().setActivePlayer(damaged);
 

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
@@ -2,6 +2,8 @@ package com.gaas.threeKingdoms.skill.wei;
 
 import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.behavior.Behavior;
+import com.gaas.threeKingdoms.behavior.behavior.DuelBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.LightningJudgementBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.ViperSpearKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.WaitingJianXiongResponseBehavior;
@@ -23,14 +25,15 @@ import java.util.List;
  * 觸發範圍：
  *   - sourceCard != null（武將技直接傷害如 剛烈 / 離間 / 雷擊 sourceCard 為 null，不觸發）
  *   - 受傷者仍存活（HP > 0；瀕死或死亡不觸發）
- *   - top behavior 為 NormalActiveKillBehavior（含子類 ViperSpearKill / HeavenlyDoubleHalberdKill）
+ *   - top behavior 屬於白名單：NormalActiveKill / Duel / LightningJudgement / 空 stack
  *
  * 取牌規則（FAQ）：
- *   - 一般殺 / 錦囊（閃電 / 南蠻 / 萬箭 / 決鬥）/ 武器觸發殺 → 獲得 sourceCard 本身
+ *   - 一般殺 / 武器觸發殺 / 決鬥 / 閃電判定 → 獲得 sourceCard 本身
  *   - 丈八蛇矛攻擊 → 獲得攻擊者棄掉的兩張手牌（VirtualKill 不算）
  *   - 多點傷害整次只觸發 1 次
  *
  * TODO（不在 v1）：
+ *   - AOE polling（南蠻入侵 / 萬箭齊發） — 需 polling state-machine refactor
  *   - 致命傷被救回後仍可發動（dying flow 重構）
  */
 public class JianXiongSkill implements OnDamagedSkill {
@@ -61,12 +64,20 @@ public class JianXiongSkill implements OnDamagedSkill {
             return List.of();
         }
 
-        // 守門：v1 只支援 NormalActiveKillBehavior（含子類 ViperSpearKill / HeavenlyDoubleHalberd）
-        // 上的單體 Kill 傷害觸發。對 AOE polling behavior（BarbarianInvasion / ArrowBarrage）
-        // 或 Duel 等 caller，因 polling 中不會走到這裡，加守門防止未來
-        // 加新 OnDamagedSkill 時誤把 polling 中的 behavior pop 掉。
-        Behavior top = game.peekTopBehavior();
-        if (!(top instanceof NormalActiveKillBehavior)) {
+        // 守門：白名單 + 空 stack（Lightning 無 Ward 時 stack 空）
+        //   - NormalActiveKillBehavior（含子類 ViperSpearKill / HeavenlyDoubleHalberd）：殺 / 武器觸發殺
+        //   - DuelBehavior：決鬥輸給對手（Path A skip 與 Path B swap 都安全）
+        //   - LightningJudgementBehavior：閃電判定打中（Ward 路徑）
+        //   - 空 stack：閃電判定無 Ward 路徑
+        //
+        // 不支援（會被 polling caller 覆蓋 activePlayer）：
+        //   - BarbarianInvasionBehavior / ArrowBarrageBehavior — 需 polling state-machine refactor，留 follow-up
+        Behavior top = game.isTopBehaviorEmpty() ? null : game.peekTopBehavior();
+        boolean topIsAllowed = top == null
+                || top instanceof NormalActiveKillBehavior
+                || top instanceof DuelBehavior
+                || top instanceof LightningJudgementBehavior;
+        if (!topIsAllowed) {
             return List.of();
         }
 

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
@@ -2,6 +2,8 @@ package com.gaas.threeKingdoms.skill.wei;
 
 import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.behavior.Behavior;
+import com.gaas.threeKingdoms.behavior.behavior.ArrowBarrageBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.BarbarianInvasionBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.DuelBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.LightningJudgementBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
@@ -25,15 +27,19 @@ import java.util.List;
  * 觸發範圍：
  *   - sourceCard != null（武將技直接傷害如 剛烈 / 離間 / 雷擊 sourceCard 為 null，不觸發）
  *   - 受傷者仍存活（HP > 0；瀕死或死亡不觸發）
- *   - top behavior 屬於白名單：NormalActiveKill / Duel / LightningJudgement / 空 stack
+ *   - top behavior 屬於白名單：NormalActiveKill / Duel / LightningJudgement /
+ *     BarbarianInvasion / ArrowBarrage / 空 stack
  *
  * 取牌規則（FAQ）：
- *   - 一般殺 / 武器觸發殺 / 決鬥 / 閃電判定 → 獲得 sourceCard 本身
+ *   - 一般殺 / 武器觸發殺 / 決鬥 / 閃電判定 / 南蠻入侵 / 萬箭齊發 → 獲得 sourceCard 本身
  *   - 丈八蛇矛攻擊 → 獲得攻擊者棄掉的兩張手牌（VirtualKill 不算）
  *   - 多點傷害整次只觸發 1 次
  *
+ * AOE polling 整合機制：BarbarianInvasion / ArrowBarrage 在 doResponseToPlayerAction
+ * 會偵測 WaitingJianXiongResponseBehavior 在 stack 頂，並把 polling-advance 註冊為
+ * onResolved callback。等 JianXiong 解決後再 resume，避免 activePlayer 衝突。
+ *
  * TODO（不在 v1）：
- *   - AOE polling（南蠻入侵 / 萬箭齊發） — 需 polling state-machine refactor
  *   - 致命傷被救回後仍可發動（dying flow 重構）
  */
 public class JianXiongSkill implements OnDamagedSkill {
@@ -68,15 +74,16 @@ public class JianXiongSkill implements OnDamagedSkill {
         //   - NormalActiveKillBehavior（含子類 ViperSpearKill / HeavenlyDoubleHalberd）：殺 / 武器觸發殺
         //   - DuelBehavior：決鬥輸給對手（Path A skip 與 Path B swap 都安全）
         //   - LightningJudgementBehavior：閃電判定打中（Ward 路徑）
+        //   - BarbarianInvasionBehavior / ArrowBarrageBehavior：AOE polling
+        //     （caller 偵測 WaitingJX 並把 polling-advance defer 為 callback，避免 activePlayer 衝突）
         //   - 空 stack：閃電判定無 Ward 路徑
-        //
-        // 不支援（會被 polling caller 覆蓋 activePlayer）：
-        //   - BarbarianInvasionBehavior / ArrowBarrageBehavior — 需 polling state-machine refactor，留 follow-up
         Behavior top = game.isTopBehaviorEmpty() ? null : game.peekTopBehavior();
         boolean topIsAllowed = top == null
                 || top instanceof NormalActiveKillBehavior
                 || top instanceof DuelBehavior
-                || top instanceof LightningJudgementBehavior;
+                || top instanceof LightningJudgementBehavior
+                || top instanceof BarbarianInvasionBehavior
+                || top instanceof ArrowBarrageBehavior;
         if (!topIsAllowed) {
             return List.of();
         }
@@ -97,8 +104,14 @@ public class JianXiongSkill implements OnDamagedSkill {
             return List.of();
         }
 
-        // 把 setIsOneRound(true) 的 kill behavior 先彈出，讓奸雄 behavior 成為 stack 頂端
-        game.removeCompletedBehaviors();
+        // 對 polling caller（BI / AB）保留底層 behavior — 等 WaitingJX 解決後 callback 會
+        // resume polling。對其他 caller（Kill / Duel / Lightning）把 line 645 標的 isOneRound=true
+        // 先 pop 掉，讓 WaitingJX 成為 stack 頂端。
+        boolean isPollingCaller = top instanceof BarbarianInvasionBehavior
+                || top instanceof ArrowBarrageBehavior;
+        if (!isPollingCaller) {
+            game.removeCompletedBehaviors();
+        }
 
         WaitingJianXiongResponseBehavior waiting = new WaitingJianXiongResponseBehavior(game, damaged, takeIds);
         game.updateTopBehavior(waiting);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
@@ -1,0 +1,73 @@
+package com.gaas.threeKingdoms.skill.wei;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.behavior.behavior.WaitingJianXiongResponseBehavior;
+import com.gaas.threeKingdoms.events.AskJianXiongEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.skill.context.DamageContext;
+import com.gaas.threeKingdoms.skill.trigger.OnDamagedSkill;
+
+import java.util.List;
+
+/**
+ * 曹操 (WEI001) 奸雄
+ * 身份標準版：當你受到 1 點傷害後，你可以獲得造成此傷害的牌。
+ *
+ * v1 範圍：
+ *   - 只接受 sourceCard instanceof Kill（普通殺、虛擬殺、火攻轉殺等）
+ *   - 多點傷害整次只觸發 1 次
+ *   - 受傷者瀕死或非存活狀態時不觸發
+ *   - sourceCard 已不在棄牌堆（被其他效果先取走）時不觸發
+ *
+ * TODO: 後續擴充
+ *   - 決鬥傷害 (sourceCard 是 Duel scroll)
+ *   - AOE 傷害（南蠻入侵 / 萬箭齊發 — sourceCard 是 scroll）
+ *   - 雷殺 / 火殺 等 special Kill
+ *   - 多點傷害多次觸發
+ */
+public class JianXiongSkill implements OnDamagedSkill {
+
+    public static final String GENERAL_ID = "WEI001";
+    public static final String SKILL_NAME = "奸雄";
+
+    @Override
+    public String getGeneralId() {
+        return GENERAL_ID;
+    }
+
+    @Override
+    public String getSkillName() {
+        return SKILL_NAME;
+    }
+
+    @Override
+    public List<DomainEvent> onDamaged(Game game, DamageContext ctx) {
+        HandCard sourceCard = ctx.sourceCard();
+        if (sourceCard == null) {
+            return List.of();
+        }
+        if (!(sourceCard instanceof Kill)) {
+            return List.of();
+        }
+
+        Player damaged = ctx.damagedPlayer();
+        if (!damaged.isHPGreaterThanZero()) {
+            return List.of();
+        }
+        if (!game.getGraveyard().contains(sourceCard.getId())) {
+            return List.of();
+        }
+
+        // 把 setIsOneRound(true) 的 kill behavior 先彈出，讓奸雄 behavior 成為 stack 頂端
+        game.removeCompletedBehaviors();
+
+        WaitingJianXiongResponseBehavior waiting = new WaitingJianXiongResponseBehavior(game, damaged, sourceCard);
+        game.updateTopBehavior(waiting);
+        game.getCurrentRound().setActivePlayer(damaged);
+
+        return List.of(new AskJianXiongEffectEvent(damaged.getId(), sourceCard.getId()));
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
@@ -5,6 +5,7 @@ import com.gaas.threeKingdoms.behavior.Behavior;
 import com.gaas.threeKingdoms.behavior.behavior.ArrowBarrageBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.BarbarianInvasionBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.DuelBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.DyingAskPeachBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.LightningJudgementBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.ViperSpearKillBehavior;
@@ -76,6 +77,8 @@ public class JianXiongSkill implements OnDamagedSkill {
         //   - LightningJudgementBehavior：閃電判定打中（Ward 路徑）
         //   - BarbarianInvasionBehavior / ArrowBarrageBehavior：AOE polling
         //     （caller 偵測 WaitingJX 並把 polling-advance defer 為 callback，避免 activePlayer 衝突）
+        //   - DyingAskPeachBehavior：致命傷被救回後 replay（FAQ）— DyingBehavior 在 revival
+        //     branch 已 set isOneRound=true 才呼叫 SkillEngine，安全 pop
         //   - 空 stack：閃電判定無 Ward 路徑
         Behavior top = game.isTopBehaviorEmpty() ? null : game.peekTopBehavior();
         boolean topIsAllowed = top == null
@@ -83,7 +86,8 @@ public class JianXiongSkill implements OnDamagedSkill {
                 || top instanceof DuelBehavior
                 || top instanceof LightningJudgementBehavior
                 || top instanceof BarbarianInvasionBehavior
-                || top instanceof ArrowBarrageBehavior;
+                || top instanceof ArrowBarrageBehavior
+                || top instanceof DyingAskPeachBehavior;
         if (!topIsAllowed) {
             return List.of();
         }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/JianXiongSkill.java
@@ -1,13 +1,15 @@
 package com.gaas.threeKingdoms.skill.wei;
 
 import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.behavior.Behavior;
 import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.ViperSpearKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.WaitingJianXiongResponseBehavior;
 import com.gaas.threeKingdoms.events.AskJianXiongEffectEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
 import com.gaas.threeKingdoms.generalcard.General;
 import com.gaas.threeKingdoms.handcard.HandCard;
-import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.basiccard.VirtualKill;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.skill.context.DamageContext;
 import com.gaas.threeKingdoms.skill.trigger.OnDamagedSkill;
@@ -18,17 +20,18 @@ import java.util.List;
  * 曹操 (WEI001) 奸雄
  * 身份標準版：當你受到 1 點傷害後，你可以獲得造成此傷害的牌。
  *
- * v1 範圍：
- *   - 只接受 sourceCard instanceof Kill（普通殺、虛擬殺、火攻轉殺等）
- *   - 多點傷害整次只觸發 1 次
- *   - 受傷者瀕死或非存活狀態時不觸發
- *   - sourceCard 已不在棄牌堆（被其他效果先取走）時不觸發
+ * 觸發範圍：
+ *   - sourceCard != null（武將技直接傷害如 剛烈 / 離間 / 雷擊 sourceCard 為 null，不觸發）
+ *   - 受傷者仍存活（HP > 0；瀕死或死亡不觸發）
+ *   - top behavior 為 NormalActiveKillBehavior（含子類 ViperSpearKill / HeavenlyDoubleHalberdKill）
  *
- * TODO: 後續擴充
- *   - 決鬥傷害 (sourceCard 是 Duel scroll)
- *   - AOE 傷害（南蠻入侵 / 萬箭齊發 — sourceCard 是 scroll）
- *   - 雷殺 / 火殺 等 special Kill
- *   - 多點傷害多次觸發
+ * 取牌規則（FAQ）：
+ *   - 一般殺 / 錦囊（閃電 / 南蠻 / 萬箭 / 決鬥）/ 武器觸發殺 → 獲得 sourceCard 本身
+ *   - 丈八蛇矛攻擊 → 獲得攻擊者棄掉的兩張手牌（VirtualKill 不算）
+ *   - 多點傷害整次只觸發 1 次
+ *
+ * TODO（不在 v1）：
+ *   - 致命傷被救回後仍可發動（dying flow 重構）
  */
 public class JianXiongSkill implements OnDamagedSkill {
 
@@ -49,9 +52,7 @@ public class JianXiongSkill implements OnDamagedSkill {
     public List<DomainEvent> onDamaged(Game game, DamageContext ctx) {
         HandCard sourceCard = ctx.sourceCard();
         if (sourceCard == null) {
-            return List.of();
-        }
-        if (!(sourceCard instanceof Kill)) {
+            // 武將技直接傷害（剛烈 / 離間 / 雷擊 等）— 規則：不獲得任何牌
             return List.of();
         }
 
@@ -59,25 +60,39 @@ public class JianXiongSkill implements OnDamagedSkill {
         if (!damaged.isHPGreaterThanZero()) {
             return List.of();
         }
-        if (!game.getGraveyard().contains(sourceCard.getId())) {
-            return List.of();
-        }
 
         // 守門：v1 只支援 NormalActiveKillBehavior（含子類 ViperSpearKill / HeavenlyDoubleHalberd）
         // 上的單體 Kill 傷害觸發。對 AOE polling behavior（BarbarianInvasion / ArrowBarrage）
-        // 或 Duel 等 caller，雖然 v1 因 sourceCard 過濾而不會走到這裡，但加守門防止未來
+        // 或 Duel 等 caller，因 polling 中不會走到這裡，加守門防止未來
         // 加新 OnDamagedSkill 時誤把 polling 中的 behavior pop 掉。
-        if (!(game.peekTopBehavior() instanceof NormalActiveKillBehavior)) {
+        Behavior top = game.peekTopBehavior();
+        if (!(top instanceof NormalActiveKillBehavior)) {
+            return List.of();
+        }
+
+        // 決定要拿哪些牌：
+        //   - 丈八蛇矛 (VirtualKill + ViperSpearKillBehavior) → 兩張棄牌（FAQ 特例）
+        //   - 其他（普通殺 / 錦囊 / 一般武器觸發殺）→ sourceCard 本身
+        List<String> takeIds;
+        if (sourceCard instanceof VirtualKill && top instanceof ViperSpearKillBehavior viper) {
+            takeIds = viper.getDiscardedCardIds();
+            // 全有或全無：兩張都要還在墓地（中途被別的效果拿走時整體跳過）
+            if (takeIds.isEmpty() || !takeIds.stream().allMatch(id -> game.getGraveyard().contains(id))) {
+                return List.of();
+            }
+        } else if (game.getGraveyard().contains(sourceCard.getId())) {
+            takeIds = List.of(sourceCard.getId());
+        } else {
             return List.of();
         }
 
         // 把 setIsOneRound(true) 的 kill behavior 先彈出，讓奸雄 behavior 成為 stack 頂端
         game.removeCompletedBehaviors();
 
-        WaitingJianXiongResponseBehavior waiting = new WaitingJianXiongResponseBehavior(game, damaged, sourceCard.getId());
+        WaitingJianXiongResponseBehavior waiting = new WaitingJianXiongResponseBehavior(game, damaged, takeIds);
         game.updateTopBehavior(waiting);
         game.getCurrentRound().setActivePlayer(damaged);
 
-        return List.of(new AskJianXiongEffectEvent(damaged.getId(), sourceCard.getId()));
+        return List.of(new AskJianXiongEffectEvent(damaged.getId(), takeIds));
     }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
@@ -187,4 +187,52 @@ public class JianXiongSkillTest {
         assertFalse(events.stream().anyMatch(e -> e instanceof AskJianXiongEffectEvent));
         assertTrue(game.getTopBehavior().isEmpty());
     }
+
+    @DisplayName("""
+            Given
+            B 為曹操、HP=1
+            A 對 B 出殺
+
+            When
+            B 不出閃 → HP→0 進入 dying
+
+            Then
+            不觸發奸雄 ask（dying flow 跟奸雄不互鎖）
+            """)
+    @Test
+    public void givenCaoCaoDyingFromKill_NoJianXiongTrigger() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        game.getPlayer("player-b").getBloodCard().setHp(1);
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        List<DomainEvent> events = game.playerPlayCard("player-b", "", "player-a", "skip");
+
+        assertEquals(0, game.getPlayer("player-b").getBloodCard().getHp());
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskJianXiongEffectEvent),
+                "JianXiong should not trigger during dying");
+    }
+
+    @DisplayName("""
+            Given
+            B 為曹操，受到殺造成的傷害 → AskJianXiongEffectEvent
+            sourceCard 在 ACCEPT 之前被其他效果從 graveyard 移走
+
+            When
+            B 選 ACCEPT
+
+            Then
+            throws IllegalStateException（防禦既有 race condition）
+            """)
+    @Test
+    public void givenSourceCardRemovedFromGraveyard_AcceptThrows() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerPlayCard("player-b", "", "player-a", "skip");
+
+        // Simulate another effect taking the source card from graveyard before B responds
+        game.getGraveyard().removeCard(BS8008.getCardId());
+
+        assertThrows(IllegalStateException.class,
+                () -> game.playerUseJianXiongEffect("player-b", AskJianXiongEffectEvent.Choice.ACCEPT));
+    }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
@@ -721,6 +721,90 @@ public class JianXiongSkillTest {
 
     @DisplayName("""
             Given
+            B (曹操) HP=1，A 出殺打 B → B 不出閃 → HP=0 進瀕死
+            C 出桃救 B → B HP=1
+
+            Then
+            事件中含 AskJianXiongEffectEvent，sourceCardIds=[殺.id]
+            （FAQ：致命傷被救回後仍可發動奸雄）
+            """)
+    @Test
+    public void givenCaoCaoLethalDamageThenRevived_AskJianXiongEffectEmitted() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+        playerB.setBloodCard(new BloodCard(1));
+        playerC.getHand().addCardToHand(new Peach(BH3029));
+
+        // A 出殺打 B（HP=1）→ B 不出閃 → 進瀕死
+        game.playerPlayCard(playerA.getId(), BS8008.getCardId(), playerB.getId(), "active");
+        game.playerPlayCard(playerB.getId(), "", playerA.getId(), "skip");
+
+        // 確認進入瀕死流程
+        assertEquals(0, playerB.getBloodCard().getHp());
+        assertTrue(game.getTopBehavior().peek() instanceof DyingAskPeachBehavior);
+
+        // B 自己沒桃，跳過 → C 被詢問
+        game.playerPlayCard(playerB.getId(), "", playerB.getId(), "skip");
+
+        // C 出桃救 B
+        List<DomainEvent> events = game.playerPlayCard(playerC.getId(), BH3029.getCardId(), playerB.getId(), "active");
+
+        // B 已救回（HP=1）
+        assertEquals(1, playerB.getBloodCard().getHp());
+
+        // 預期：events 含 AskJianXiongEffectEvent
+        AskJianXiongEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskJianXiongEffectEvent)
+                .map(e -> (AskJianXiongEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskJianXiongEffectEvent after revival"));
+        assertEquals("player-b", ask.getPlayerId());
+        assertEquals(List.of(BS8008.getCardId()), ask.getSourceCardIds());
+        // stack 頂為 WaitingJX
+        assertTrue(game.getTopBehavior().peek() instanceof WaitingJianXiongResponseBehavior);
+
+        // ACCEPT → 殺進手牌
+        game.playerUseJianXiongEffect(playerB.getId(), AskJianXiongEffectEvent.Choice.ACCEPT);
+        assertFalse(game.getGraveyard().contains(BS8008.getCardId()));
+        assertTrue(playerB.getHand().getCards().stream().anyMatch(c -> c.getId().equals(BS8008.getCardId())));
+    }
+
+    @DisplayName("""
+            Given
+            B (曹操) HP=1，A 出殺打 B → B 不出閃 → HP=0 進瀕死
+            其他玩家都不出桃 → B 死亡
+
+            Then
+            events 不含 AskJianXiongEffectEvent（FAQ：除非曹操被救回）
+            """)
+    @Test
+    public void givenCaoCaoLethalDamageNoRevival_NoJianXiongTrigger() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+        Player playerD = game.getPlayer("player-d");
+        playerB.setBloodCard(new BloodCard(1));
+
+        // A 出殺打 B → B 不出閃 → 進瀕死
+        game.playerPlayCard(playerA.getId(), BS8008.getCardId(), playerB.getId(), "active");
+        game.playerPlayCard(playerB.getId(), "", playerA.getId(), "skip");
+
+        // B / C / D 依序不出桃
+        game.playerPlayCard(playerB.getId(), "", playerB.getId(), "skip");
+        game.playerPlayCard(playerC.getId(), "", playerB.getId(), "skip");
+        List<DomainEvent> events = game.playerPlayCard(playerD.getId(), "", playerB.getId(), "skip");
+
+        // B 死亡 — 不觸發奸雄
+        assertEquals(0, playerB.getBloodCard().getHp());
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskJianXiongEffectEvent),
+                "JianXiong should not trigger when player actually dies");
+    }
+
+    @DisplayName("""
+            Given
             B 為曹操（WEI001）
             stack 頂為非 NormalActiveKillBehavior（用一個 anonymous Behavior 模擬）
             graveyard 含一張 Kill

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
@@ -805,6 +805,59 @@ public class JianXiongSkillTest {
 
     @DisplayName("""
             Given
+            B (曹操) HP=1，A 裝丈八蛇矛 + 兩張手牌
+            A 用丈八蛇矛攻擊 B → B 不出閃 → HP=0 進瀕死
+            C 出桃救 B → B HP=1
+
+            Then
+            事件中含 AskJianXiongEffectEvent，sourceCardIds = A 棄的兩張牌
+            （FAQ + 丈八蛇矛特例：致命傷被救回後仍可發動，並取兩張棄牌）
+            ACCEPT 後兩張棄牌進 B 手牌
+            """)
+    @Test
+    public void givenCaoCaoLethalDamageFromViperSpearThenRevived_AskJianXiongEffectEmitted() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+        playerB.setBloodCard(new BloodCard(1));
+        playerA.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+        playerC.getHand().addCardToHand(new Peach(BH4030));
+
+        // A 用丈八蛇矛棄兩張殺攻擊 B（HP=1）
+        game.playerUseViperSpearKill(playerA.getId(), playerB.getId(),
+                List.of(BS8008.getCardId(), BH3029.getCardId()));
+        // B 不出閃 → HP=0 進瀕死
+        game.playerPlayCard(playerB.getId(), "", playerA.getId(), "skip");
+
+        assertEquals(0, playerB.getBloodCard().getHp());
+        assertTrue(game.getTopBehavior().peek() instanceof DyingAskPeachBehavior);
+
+        // B 自己沒桃 → 跳過 → C 被詢問
+        game.playerPlayCard(playerB.getId(), "", playerB.getId(), "skip");
+        // C 出桃救 B
+        List<DomainEvent> events = game.playerPlayCard(playerC.getId(), BH4030.getCardId(), playerB.getId(), "active");
+
+        assertEquals(1, playerB.getBloodCard().getHp());
+
+        // 預期：events 含 AskJianXiongEffectEvent，sourceCardIds 為兩張棄牌
+        AskJianXiongEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskJianXiongEffectEvent)
+                .map(e -> (AskJianXiongEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskJianXiongEffectEvent for ViperSpear lethal revival"));
+        assertEquals(List.of(BS8008.getCardId(), BH3029.getCardId()), ask.getSourceCardIds());
+
+        // ACCEPT → 兩張棄牌進 B 手牌
+        game.playerUseJianXiongEffect(playerB.getId(), AskJianXiongEffectEvent.Choice.ACCEPT);
+        assertFalse(game.getGraveyard().contains(BS8008.getCardId()));
+        assertFalse(game.getGraveyard().contains(BH3029.getCardId()));
+        assertTrue(playerB.getHand().getCards().stream().anyMatch(c -> c.getId().equals(BS8008.getCardId())));
+        assertTrue(playerB.getHand().getCards().stream().anyMatch(c -> c.getId().equals(BH3029.getCardId())));
+    }
+
+    @DisplayName("""
+            Given
             B 為曹操（WEI001）
             stack 頂為非 NormalActiveKillBehavior（用一個 anonymous Behavior 模擬）
             graveyard 含一張 Kill

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
@@ -1,0 +1,190 @@
+package com.gaas.threeKingdoms;
+
+import com.gaas.threeKingdoms.behavior.behavior.WaitingJianXiongResponseBehavior;
+import com.gaas.threeKingdoms.builders.PlayerBuilder;
+import com.gaas.threeKingdoms.events.AskJianXiongEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.JianXiongEffectEvent;
+import com.gaas.threeKingdoms.gamephase.Normal;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.generalcard.GeneralCard;
+import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.player.*;
+import com.gaas.threeKingdoms.rolecard.Role;
+import com.gaas.threeKingdoms.rolecard.RoleCard;
+import com.gaas.threeKingdoms.round.Round;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JianXiongSkillTest {
+
+    private Game setupGameCaoCaoB(General playerBGeneral) {
+        Game game = new Game();
+        game.initDeck();
+
+        Player playerA = PlayerBuilder.construct()
+                .withId("player-a")
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(General.劉備))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(Role.MONARCH))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .build();
+        playerA.getHand().addCardToHand(Arrays.asList(
+                new Kill(BS8008), new Peach(BH3029), new Peach(BH4030), new Dodge(BH2028), new Dodge(BHK039)));
+
+        Player playerB = PlayerBuilder.construct()
+                .withId("player-b")
+                .withBloodCard(new BloodCard(4))
+                .withHand(new Hand())
+                .withRoleCard(new RoleCard(Role.MINISTER))
+                .withGeneralCard(new GeneralCard(playerBGeneral))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withEquipment(new Equipment())
+                .build();
+
+        Player playerC = PlayerBuilder.construct()
+                .withId("player-c")
+                .withBloodCard(new BloodCard(4))
+                .withHand(new Hand())
+                .withRoleCard(new RoleCard(Role.MINISTER))
+                .withGeneralCard(new GeneralCard(General.劉備))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withEquipment(new Equipment())
+                .build();
+
+        Player playerD = PlayerBuilder.construct()
+                .withId("player-d")
+                .withBloodCard(new BloodCard(4))
+                .withHand(new Hand())
+                .withRoleCard(new RoleCard(Role.MINISTER))
+                .withGeneralCard(new GeneralCard(General.劉備))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withEquipment(new Equipment())
+                .build();
+
+        List<Player> players = asList(playerA, playerB, playerC, playerD);
+        game.setPlayers(players);
+        game.setCurrentRound(new Round(playerA));
+        game.enterPhase(new Normal(game));
+        return game;
+    }
+
+    @DisplayName("""
+            Given
+            B 玩家為曹操（WEI001），無閃，HP 4
+            A 對 B 出殺
+
+            When
+            B 不出閃 → 受到 1 點傷害
+
+            Then
+            事件中含 AskJianXiongEffectEvent
+            stack 頂端為 WaitingJianXiongResponseBehavior
+            B 仍為 3 HP，殺仍在棄牌堆
+            """)
+    @Test
+    public void givenCaoCaoTakeDamageFromKill_AskJianXiongEffectEmitted() {
+        Game game = setupGameCaoCaoB(General.曹操);
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        List<DomainEvent> events = game.playerPlayCard("player-b", "", "player-a", "skip");
+
+        assertEquals(3, game.getPlayer("player-b").getBloodCard().getHp());
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskJianXiongEffectEvent),
+                "expected AskJianXiongEffectEvent in events");
+        AskJianXiongEffectEvent ask = (AskJianXiongEffectEvent) events.stream()
+                .filter(e -> e instanceof AskJianXiongEffectEvent).findFirst().orElseThrow();
+        assertEquals("player-b", ask.getPlayerId());
+        assertEquals(BS8008.getCardId(), ask.getSourceCardId());
+
+        assertFalse(game.getTopBehavior().isEmpty());
+        assertTrue(game.getTopBehavior().peek() instanceof WaitingJianXiongResponseBehavior);
+        assertTrue(game.getGraveyard().contains(BS8008.getCardId()));
+    }
+
+    @DisplayName("""
+            Given
+            B 為曹操，受到殺造成的傷害 → AskJianXiongEffectEvent
+
+            When
+            B 選 ACCEPT
+
+            Then
+            殺從棄牌堆進入 B 手牌
+            事件中含 JianXiongEffectEvent(taken=true)
+            stack 為空
+            """)
+    @Test
+    public void givenJianXiongAsk_AcceptChoice_KillReturnsToHand() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerPlayCard("player-b", "", "player-a", "skip");
+
+        List<DomainEvent> events = game.playerUseJianXiongEffect("player-b", AskJianXiongEffectEvent.Choice.ACCEPT);
+
+        assertFalse(game.getGraveyard().contains(BS8008.getCardId()));
+        assertTrue(game.getPlayer("player-b").getHand().getCards().stream()
+                .anyMatch(c -> c.getId().equals(BS8008.getCardId())));
+        assertTrue(events.stream().anyMatch(e -> e instanceof JianXiongEffectEvent
+                && ((JianXiongEffectEvent) e).isTaken()));
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("""
+            Given
+            B 為曹操，受到殺造成的傷害 → AskJianXiongEffectEvent
+
+            When
+            B 選 SKIP
+
+            Then
+            殺仍在棄牌堆，B 手牌不變
+            事件中含 JianXiongEffectEvent(taken=false)
+            stack 為空
+            """)
+    @Test
+    public void givenJianXiongAsk_SkipChoice_NoChange() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerPlayCard("player-b", "", "player-a", "skip");
+
+        int handSizeBefore = game.getPlayer("player-b").getHand().size();
+        List<DomainEvent> events = game.playerUseJianXiongEffect("player-b", AskJianXiongEffectEvent.Choice.SKIP);
+
+        assertTrue(game.getGraveyard().contains(BS8008.getCardId()));
+        assertEquals(handSizeBefore, game.getPlayer("player-b").getHand().size());
+        assertTrue(events.stream().anyMatch(e -> e instanceof JianXiongEffectEvent
+                && !((JianXiongEffectEvent) e).isTaken()));
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("""
+            Given
+            B 為劉備（非曹操），受到殺造成的傷害
+
+            Then
+            不觸發奸雄 — 沒有 AskJianXiongEffectEvent
+            stack 為空
+            """)
+    @Test
+    public void givenNonCaoCao_NoJianXiongTrigger() {
+        Game game = setupGameCaoCaoB(General.劉備);
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        List<DomainEvent> events = game.playerPlayCard("player-b", "", "player-a", "skip");
+
+        assertEquals(3, game.getPlayer("player-b").getBloodCard().getHp());
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskJianXiongEffectEvent));
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
@@ -858,6 +858,136 @@ public class JianXiongSkillTest {
 
     @DisplayName("""
             Given
+            B (曹操) HP=1 為 AOE 第一個 reactor
+            A 出南蠻入侵 → B 不出殺 → HP=0 進瀕死
+            D 出桃救 B → B HP=1
+
+            Then
+            JianXiong 觸發（sourceCardIds=[南蠻]）
+            B ACCEPT → 南蠻進手牌
+            polling resume → 下一個 reactor C 收 AskKillEvent
+            activePlayer = C
+            """)
+    @Test
+    public void givenCaoCaoInBarbarianInvasionPolling_LethalDamageThenRevived_AcceptThenPollingResumes() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+        Player playerD = game.getPlayer("player-d");
+        playerB.setBloodCard(new BloodCard(1));
+
+        playerA.getHand().addCardToHand(new BarbarianInvasion(SS7007));
+        playerD.getHand().addCardToHand(new Peach(BH4030));
+
+        // A 出南蠻 → B 第一個被詢問
+        game.playerPlayCard(playerA.getId(), SS7007.getCardId(), "", "active");
+        // B 不出殺 → HP=0 進瀕死
+        game.playerPlayCard(playerB.getId(), "", playerA.getId(), "skip");
+        assertEquals(0, playerB.getBloodCard().getHp());
+        assertTrue(game.getTopBehavior().peek() instanceof DyingAskPeachBehavior);
+
+        // 順序：B 自己沒桃 → C 沒桃 → D 出桃救
+        game.playerPlayCard(playerB.getId(), "", playerB.getId(), "skip");
+        game.playerPlayCard(playerC.getId(), "", playerB.getId(), "skip");
+        List<DomainEvent> events = game.playerPlayCard(playerD.getId(), BH4030.getCardId(), playerB.getId(), "active");
+
+        // B 被救回 + JianXiong 觸發
+        assertEquals(1, playerB.getBloodCard().getHp());
+        AskJianXiongEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskJianXiongEffectEvent)
+                .map(e -> (AskJianXiongEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskJianXiongEffectEvent after AOE revival"));
+        assertEquals(List.of(SS7007.getCardId()), ask.getSourceCardIds());
+
+        // B ACCEPT → 南蠻進手牌、polling 應 resume 到 C
+        List<DomainEvent> acceptEvents = game.playerUseJianXiongEffect(playerB.getId(), AskJianXiongEffectEvent.Choice.ACCEPT);
+        assertTrue(playerB.getHand().getCards().stream().anyMatch(c -> c.getId().equals(SS7007.getCardId())));
+
+        // polling resume：C 應收 AskKillEvent
+        AskKillEvent askKill = acceptEvents.stream()
+                .filter(e -> e instanceof AskKillEvent)
+                .map(e -> (AskKillEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskKillEvent for next reactor after revival ACCEPT"));
+        assertEquals("player-c", askKill.getPlayerId(), "polling should resume to next reactor C");
+        assertEquals("player-c", game.getActivePlayer().getId(), "activePlayer should be next reactor");
+    }
+
+    @DisplayName("""
+            Given
+            B (曹操) HP=1，受到 3 點傷害（閃電）→ HP=-2 進瀕死
+            需 3 張桃才救回（C/D/A 各出 1 張）
+
+            Then
+            JianXiong 事件在 events 中恰出現 1 次（FAQ：一次傷害只能觸發 1 次奸雄）
+            ACCEPT 後閃電進 B 手牌
+            """)
+    @Test
+    public void givenCaoCaoLethalFromLightning_MultiPeachRevival_JianXiongFiresOnce() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+        Player playerD = game.getPlayer("player-d");
+        playerB.setBloodCard(new BloodCard(1));
+
+        // 3 個非曹操玩家各持 1 桃
+        playerC.getHand().addCardToHand(new Peach(BH3029));
+        playerD.getHand().addCardToHand(new Peach(BH4030));
+        playerA.getHand().addCardToHand(new Peach(BH6032));
+
+        // 閃電在墓地 — JianXiong 之後 graveyard.contains check 需要
+        Lightning lightning = new Lightning(SSA014);
+        game.getGraveyard().add(lightning);
+
+        // 直接觸發 Lightning damage（HP 1 → -2）
+        game.getDamagedEvent(
+                playerB.getId(),
+                playerA.getId(),
+                lightning.getId(),
+                lightning,
+                "inactive",
+                1,
+                playerB,
+                game.getCurrentRound(),
+                java.util.Optional.empty()
+        );
+
+        assertEquals(-2, playerB.getBloodCard().getHp());
+        assertTrue(game.getTopBehavior().peek() instanceof DyingAskPeachBehavior);
+
+        // B 自己沒桃 → 跳過
+        game.playerPlayCard(playerB.getId(), "", playerB.getId(), "skip");
+        // C 出 1 桃（HP -2 → -1，still dying，C 再被詢問）
+        game.playerPlayCard(playerC.getId(), BH3029.getCardId(), playerB.getId(), "active");
+        // C 沒桃 → skip
+        game.playerPlayCard(playerC.getId(), "", playerB.getId(), "skip");
+        // D 出 1 桃（HP -1 → 0，still dying）
+        game.playerPlayCard(playerD.getId(), BH4030.getCardId(), playerB.getId(), "active");
+        // D 沒桃 → skip
+        game.playerPlayCard(playerD.getId(), "", playerB.getId(), "skip");
+        // A 出 1 桃 → HP 0 → 1，revival！
+        List<DomainEvent> finalEvents = game.playerPlayCard(playerA.getId(), BH6032.getCardId(), playerB.getId(), "active");
+
+        assertEquals(1, playerB.getBloodCard().getHp());
+
+        // 關鍵：JianXiong 只觸發 1 次
+        long jianXiongCount = finalEvents.stream().filter(e -> e instanceof AskJianXiongEffectEvent).count();
+        assertEquals(1, jianXiongCount, "JianXiong should fire exactly once even after multi-peach revival");
+
+        AskJianXiongEffectEvent ask = (AskJianXiongEffectEvent) finalEvents.stream()
+                .filter(e -> e instanceof AskJianXiongEffectEvent).findFirst().orElseThrow();
+        assertEquals(List.of(lightning.getId()), ask.getSourceCardIds());
+
+        // ACCEPT → 閃電進手牌
+        game.playerUseJianXiongEffect(playerB.getId(), AskJianXiongEffectEvent.Choice.ACCEPT);
+        assertTrue(playerB.getHand().getCards().stream().anyMatch(c -> c.getId().equals(lightning.getId())));
+    }
+
+    @DisplayName("""
+            Given
             B 為曹操（WEI001）
             stack 頂為非 NormalActiveKillBehavior（用一個 anonymous Behavior 模擬）
             graveyard 含一張 Kill

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
@@ -15,6 +15,7 @@ import com.gaas.threeKingdoms.generalcard.GeneralCard;
 import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.EighteenSpanViperSpearCard;
 import com.gaas.threeKingdoms.player.*;
 import com.gaas.threeKingdoms.rolecard.Role;
 import com.gaas.threeKingdoms.rolecard.RoleCard;
@@ -110,7 +111,7 @@ public class JianXiongSkillTest {
         AskJianXiongEffectEvent ask = (AskJianXiongEffectEvent) events.stream()
                 .filter(e -> e instanceof AskJianXiongEffectEvent).findFirst().orElseThrow();
         assertEquals("player-b", ask.getPlayerId());
-        assertEquals(BS8008.getCardId(), ask.getSourceCardId());
+        assertEquals(List.of(BS8008.getCardId()), ask.getSourceCardIds());
 
         assertFalse(game.getTopBehavior().isEmpty());
         assertTrue(game.getTopBehavior().peek() instanceof WaitingJianXiongResponseBehavior);
@@ -260,6 +261,107 @@ public class JianXiongSkillTest {
 
         long count = events.stream().filter(e -> e instanceof AskJianXiongEffectEvent).count();
         assertEquals(1, count, "JianXiong should trigger exactly once per DamageEvent");
+    }
+
+    @DisplayName("""
+            Given
+            B 為曹操，受到丈八蛇矛攻擊（A 棄兩張當虛擬殺）
+            B 不出閃 → 受傷
+
+            Then
+            事件中含 AskJianXiongEffectEvent，sourceCardIds 為 A 棄的兩張牌
+            （標準版 FAQ：丈八蛇矛攻擊曹操，奸雄獲得攻擊者打出的兩張手牌）
+            """)
+    @Test
+    public void givenViperSpearAttack_AskJianXiongEffectEmittedWithTwoDiscards() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        playerA.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+
+        // A 用丈八蛇矛棄兩張殺攻擊 B
+        game.playerUseViperSpearKill(playerA.getId(), "player-b",
+                List.of(BS8008.getCardId(), BH3029.getCardId()));
+        // B 不出閃
+        List<DomainEvent> events = game.playerPlayCard("player-b", "", playerA.getId(), "skip");
+
+        assertEquals(3, game.getPlayer("player-b").getBloodCard().getHp());
+        AskJianXiongEffectEvent ask = (AskJianXiongEffectEvent) events.stream()
+                .filter(e -> e instanceof AskJianXiongEffectEvent).findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskJianXiongEffectEvent"));
+        assertEquals("player-b", ask.getPlayerId());
+        assertEquals(List.of(BS8008.getCardId(), BH3029.getCardId()), ask.getSourceCardIds());
+        assertTrue(game.getGraveyard().contains(BS8008.getCardId()));
+        assertTrue(game.getGraveyard().contains(BH3029.getCardId()));
+        assertTrue(game.getTopBehavior().peek() instanceof WaitingJianXiongResponseBehavior);
+    }
+
+    @DisplayName("""
+            Given
+            B 為曹操，受到丈八蛇矛攻擊 → AskJianXiongEffectEvent
+
+            When
+            B 選 ACCEPT
+
+            Then
+            兩張棄牌都從棄牌堆進入 B 手牌
+            JianXiongEffectEvent(taken=true)
+            """)
+    @Test
+    public void givenViperSpearAsk_AcceptChoice_TwoDiscardsReturnToHand() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        playerA.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+
+        game.playerUseViperSpearKill(playerA.getId(), "player-b",
+                List.of(BS8008.getCardId(), BH3029.getCardId()));
+        game.playerPlayCard("player-b", "", playerA.getId(), "skip");
+
+        int handSizeBefore = game.getPlayer("player-b").getHand().size();
+        List<DomainEvent> events = game.playerUseJianXiongEffect("player-b", AskJianXiongEffectEvent.Choice.ACCEPT);
+
+        assertFalse(game.getGraveyard().contains(BS8008.getCardId()));
+        assertFalse(game.getGraveyard().contains(BH3029.getCardId()));
+        assertEquals(handSizeBefore + 2, game.getPlayer("player-b").getHand().size());
+        assertTrue(game.getPlayer("player-b").getHand().getCards().stream()
+                .anyMatch(c -> c.getId().equals(BS8008.getCardId())));
+        assertTrue(game.getPlayer("player-b").getHand().getCards().stream()
+                .anyMatch(c -> c.getId().equals(BH3029.getCardId())));
+        assertTrue(events.stream().anyMatch(e -> e instanceof JianXiongEffectEvent
+                && ((JianXiongEffectEvent) e).isTaken()
+                && ((JianXiongEffectEvent) e).getSourceCardIds().equals(List.of(BS8008.getCardId(), BH3029.getCardId()))));
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("""
+            Given
+            B 為曹操，受到丈八蛇矛攻擊 → AskJianXiongEffectEvent
+
+            When
+            B 選 SKIP
+
+            Then
+            兩張棄牌都留在棄牌堆，B 手牌不變
+            JianXiongEffectEvent(taken=false)
+            """)
+    @Test
+    public void givenViperSpearAsk_SkipChoice_NoChange() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        playerA.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+
+        game.playerUseViperSpearKill(playerA.getId(), "player-b",
+                List.of(BS8008.getCardId(), BH3029.getCardId()));
+        game.playerPlayCard("player-b", "", playerA.getId(), "skip");
+
+        int handSizeBefore = game.getPlayer("player-b").getHand().size();
+        List<DomainEvent> events = game.playerUseJianXiongEffect("player-b", AskJianXiongEffectEvent.Choice.SKIP);
+
+        assertTrue(game.getGraveyard().contains(BS8008.getCardId()));
+        assertTrue(game.getGraveyard().contains(BH3029.getCardId()));
+        assertEquals(handSizeBefore, game.getPlayer("player-b").getHand().size());
+        assertTrue(events.stream().anyMatch(e -> e instanceof JianXiongEffectEvent
+                && !((JianXiongEffectEvent) e).isTaken()));
+        assertTrue(game.getTopBehavior().isEmpty());
     }
 
     @DisplayName("""

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
@@ -18,7 +18,13 @@ import com.gaas.threeKingdoms.handcard.basiccard.Peach;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.EighteenSpanViperSpearCard;
 import com.gaas.threeKingdoms.handcard.scrollcard.Duel;
 import com.gaas.threeKingdoms.handcard.scrollcard.Lightning;
+import com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion;
+import com.gaas.threeKingdoms.handcard.scrollcard.ArrowBarrage;
 import com.gaas.threeKingdoms.behavior.behavior.LightningJudgementBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.BarbarianInvasionBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.ArrowBarrageBehavior;
+import com.gaas.threeKingdoms.events.AskKillEvent;
+import com.gaas.threeKingdoms.events.AskDodgeEvent;
 import com.gaas.threeKingdoms.player.*;
 import com.gaas.threeKingdoms.rolecard.Role;
 import com.gaas.threeKingdoms.rolecard.RoleCard;
@@ -549,6 +555,168 @@ public class JianXiongSkillTest {
                 .orElseThrow(() -> new AssertionError("expected AskJianXiongEffectEvent for empty stack"));
         assertEquals(List.of(lightning.getId()), ask.getSourceCardIds());
         assertTrue(game.getTopBehavior().peek() instanceof WaitingJianXiongResponseBehavior);
+    }
+
+    @DisplayName("""
+            Given
+            A 出南蠻入侵；B (曹操) 是第一個被詢問的 reactor、無殺
+            B 不出殺 → 受傷
+
+            Then
+            事件中含 AskJianXiongEffectEvent，sourceCardIds = [BarbarianInvasion]
+            stack 頂為 WaitingJianXiongResponseBehavior（BI 還在底）
+            （AOE polling 整合：JianXiong 介入時先 defer polling-advance）
+            """)
+    @Test
+    public void givenCaoCaoLosesBarbarianInvasion_MidPolling_AskJianXiongEffectEmitted() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+
+        // A 加南蠻入侵；B 維持沒殺
+        playerA.getHand().addCardToHand(new BarbarianInvasion(SS7007));
+
+        // A 出南蠻，B 第一個被詢問
+        game.playerPlayCard(playerA.getId(), SS7007.getCardId(), "", "active");
+        // B 不出殺 → 受傷觸發奸雄
+        List<DomainEvent> events = game.playerPlayCard(playerB.getId(), "", playerA.getId(), "skip");
+
+        assertEquals(3, playerB.getBloodCard().getHp());
+        AskJianXiongEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskJianXiongEffectEvent)
+                .map(e -> (AskJianXiongEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskJianXiongEffectEvent for BI mid-polling"));
+        assertEquals(List.of(SS7007.getCardId()), ask.getSourceCardIds());
+        assertTrue(game.getTopBehavior().peek() instanceof WaitingJianXiongResponseBehavior);
+        // BI 還在 stack 底（polling 未結束）
+        assertEquals(2, game.getTopBehavior().size());
+        assertTrue(game.getTopBehavior().get(0) instanceof BarbarianInvasionBehavior);
+    }
+
+    @DisplayName("""
+            Given
+            BI 中段觸發奸雄（接續上面情境）
+
+            When
+            B 選 ACCEPT
+
+            Then
+            南蠻牌進入 B 手牌
+            BI polling resume：C 收到 AskKillEvent、activePlayer = C
+            stack 只剩 BI（WaitingJX 已 pop）
+            """)
+    @Test
+    public void givenBIMidPolling_AcceptJianXiong_PollingResumesToNextReactor() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        playerA.getHand().addCardToHand(new BarbarianInvasion(SS7007));
+
+        game.playerPlayCard(playerA.getId(), SS7007.getCardId(), "", "active");
+        game.playerPlayCard(playerB.getId(), "", playerA.getId(), "skip");
+
+        List<DomainEvent> events = game.playerUseJianXiongEffect(playerB.getId(), AskJianXiongEffectEvent.Choice.ACCEPT);
+
+        // 南蠻進手牌、graveyard 移除
+        assertFalse(game.getGraveyard().contains(SS7007.getCardId()));
+        assertTrue(playerB.getHand().getCards().stream().anyMatch(c -> c.getId().equals(SS7007.getCardId())));
+        // C 被詢問出殺
+        AskKillEvent ask = events.stream()
+                .filter(e -> e instanceof AskKillEvent)
+                .map(e -> (AskKillEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskKillEvent for next reactor (C)"));
+        assertEquals("player-c", ask.getPlayerId());
+        assertEquals("player-c", game.getActivePlayer().getId());
+        // stack 只剩 BI（WaitingJX 已 pop，BI mid-poll isOneRound=false）
+        assertEquals(1, game.getTopBehavior().size());
+        assertTrue(game.getTopBehavior().peek() instanceof BarbarianInvasionBehavior);
+    }
+
+    @DisplayName("""
+            Given
+            A 出南蠻；B/C 都出殺、D (曹操) 為最後 reactor、無殺
+            D 不出殺 → 受傷觸發奸雄
+
+            When
+            D 選 ACCEPT
+
+            Then
+            南蠻進入 D 手牌、stack 空、activePlayer 回到 A（roundPlayer）
+            """)
+    @Test
+    public void givenCaoCaoIsLastReactor_AcceptJianXiong_PollingEnds() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        // 改成 D 為曹操；B/C/D 順序倒過來才方便讓曹操是 last
+        // 簡化：直接讓 player-d 是曹操即可
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+        Player playerD = game.getPlayer("player-d");
+        // 把 D 設成曹操，B 設回非曹操
+        playerD.setGeneralCard(new GeneralCard(General.曹操));
+        playerB.setGeneralCard(new GeneralCard(General.劉備));
+
+        playerA.getHand().addCardToHand(new BarbarianInvasion(SS7007));
+        playerB.getHand().addCardToHand(new Kill(BHJ037));
+        playerC.getHand().addCardToHand(new Kill(BS9009));
+
+        // A 出南蠻 → B 出殺 → C 出殺 → D 不出殺
+        game.playerPlayCard(playerA.getId(), SS7007.getCardId(), "", "active");
+        game.playerPlayCard(playerB.getId(), BHJ037.getCardId(), playerA.getId(), "active");
+        game.playerPlayCard(playerC.getId(), BS9009.getCardId(), playerA.getId(), "active");
+        game.playerPlayCard(playerD.getId(), "", playerA.getId(), "skip");
+
+        // D 為曹操，受傷觸發奸雄；ACCEPT
+        List<DomainEvent> events = game.playerUseJianXiongEffect(playerD.getId(), AskJianXiongEffectEvent.Choice.ACCEPT);
+
+        assertFalse(game.getGraveyard().contains(SS7007.getCardId()));
+        assertTrue(playerD.getHand().getCards().stream().anyMatch(c -> c.getId().equals(SS7007.getCardId())));
+        assertTrue(game.getTopBehavior().isEmpty(), "stack should be empty after last reactor + JianXiong resolved");
+        assertEquals("player-a", game.getActivePlayer().getId(), "activePlayer back to round player");
+    }
+
+    @DisplayName("""
+            Given
+            A 出萬箭齊發；B (曹操) 第一個被詢問、無閃
+            B 不出閃 → 受傷觸發奸雄
+
+            When
+            B 選 ACCEPT
+
+            Then
+            萬箭進入 B 手牌、polling resume 到 C（C 被詢問出閃）
+            """)
+    @Test
+    public void givenCaoCaoLosesArrowBarrage_MidPolling_AcceptJianXiong_PollingResumes() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        playerA.getHand().addCardToHand(new ArrowBarrage(SHA040));
+
+        // A 出萬箭，B 第一個被詢問
+        game.playerPlayCard(playerA.getId(), SHA040.getCardId(), "", "active");
+        // B 不出閃 → 受傷觸發奸雄
+        game.playerPlayCard(playerB.getId(), "", playerA.getId(), "skip");
+
+        // 受傷後 stack 頂應為 WaitingJX（AB 仍在底等 callback resume）
+        assertTrue(game.getTopBehavior().peek() instanceof WaitingJianXiongResponseBehavior);
+
+        List<DomainEvent> events = game.playerUseJianXiongEffect(playerB.getId(), AskJianXiongEffectEvent.Choice.ACCEPT);
+
+        assertFalse(game.getGraveyard().contains(SHA040.getCardId()));
+        assertTrue(playerB.getHand().getCards().stream().anyMatch(c -> c.getId().equals(SHA040.getCardId())));
+        // C 被詢問出閃
+        AskDodgeEvent askDodge = events.stream()
+                .filter(e -> e instanceof AskDodgeEvent)
+                .map(e -> (AskDodgeEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskDodgeEvent for C"));
+        assertEquals("player-c", askDodge.getPlayerId());
+        assertEquals("player-c", game.getActivePlayer().getId());
+        assertEquals(1, game.getTopBehavior().size());
+        assertTrue(game.getTopBehavior().peek() instanceof ArrowBarrageBehavior);
     }
 
     @DisplayName("""

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
@@ -1,10 +1,14 @@
 package com.gaas.threeKingdoms;
 
+import com.gaas.threeKingdoms.behavior.Behavior;
+import com.gaas.threeKingdoms.behavior.behavior.DyingAskPeachBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.WaitingJianXiongResponseBehavior;
 import com.gaas.threeKingdoms.builders.PlayerBuilder;
 import com.gaas.threeKingdoms.events.AskJianXiongEffectEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
 import com.gaas.threeKingdoms.events.JianXiongEffectEvent;
+import com.gaas.threeKingdoms.skill.context.DamageContext;
+import com.gaas.threeKingdoms.skill.wei.JianXiongSkill;
 import com.gaas.threeKingdoms.gamephase.Normal;
 import com.gaas.threeKingdoms.generalcard.General;
 import com.gaas.threeKingdoms.generalcard.GeneralCard;
@@ -198,6 +202,7 @@ public class JianXiongSkillTest {
 
             Then
             不觸發奸雄 ask（dying flow 跟奸雄不互鎖）
+            stack 頂為 DyingAskPeachBehavior（dying flow 正常進）
             """)
     @Test
     public void givenCaoCaoDyingFromKill_NoJianXiongTrigger() {
@@ -210,6 +215,9 @@ public class JianXiongSkillTest {
         assertEquals(0, game.getPlayer("player-b").getBloodCard().getHp());
         assertFalse(events.stream().anyMatch(e -> e instanceof AskJianXiongEffectEvent),
                 "JianXiong should not trigger during dying");
+        assertFalse(game.getTopBehavior().isEmpty(), "dying flow should keep behavior stack non-empty");
+        assertTrue(game.getTopBehavior().peek() instanceof DyingAskPeachBehavior,
+                "expected DyingAskPeachBehavior on top, JianXiong should not have inserted itself");
     }
 
     @DisplayName("""
@@ -229,10 +237,66 @@ public class JianXiongSkillTest {
         game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
         game.playerPlayCard("player-b", "", "player-a", "skip");
 
-        // Simulate another effect taking the source card from graveyard before B responds
-        game.getGraveyard().removeCard(BS8008.getCardId());
+        // Setup precondition: source card 應該在 graveyard
+        assertTrue(game.getGraveyard().removeCard(BS8008.getCardId()).isPresent(),
+                "setup precondition: source card should be in graveyard before manual removal");
 
         assertThrows(IllegalStateException.class,
                 () -> game.playerUseJianXiongEffect("player-b", AskJianXiongEffectEvent.Choice.ACCEPT));
+    }
+
+    @DisplayName("""
+            Given
+            B 為曹操，受到殺造成的傷害 → 觸發奸雄
+
+            Then
+            事件中只有 1 個 AskJianXiongEffectEvent（鎖定 v1 spec：一次 DamageEvent 只觸發 1 次）
+            """)
+    @Test
+    public void givenSingleDamageEvent_OnlyOneAskJianXiongEffectEventEmitted() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        List<DomainEvent> events = game.playerPlayCard("player-b", "", "player-a", "skip");
+
+        long count = events.stream().filter(e -> e instanceof AskJianXiongEffectEvent).count();
+        assertEquals(1, count, "JianXiong should trigger exactly once per DamageEvent");
+    }
+
+    @DisplayName("""
+            Given
+            B 為曹操（WEI001）
+            stack 頂為非 NormalActiveKillBehavior（用一個 anonymous Behavior 模擬）
+            graveyard 含一張 Kill
+
+            When
+            直接呼叫 JianXiongSkill.onDamaged with Kill source
+
+            Then
+            守門路徑生效：返回空 events，stack 不被改動
+            （這個情境在 v1 不會自然發生 — sourceCard 是 Kill 而 top 不是 NormalActiveKill —
+            但守門是針對未來新加的 OnDamagedSkill 防禦；此 test 鎖定守門行為）
+            """)
+    @Test
+    public void givenJianXiongSkill_NonNormalActiveKillBehaviorOnStack_NoTrigger() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player caoCao = game.getPlayer("player-b");
+        Player attacker = game.getPlayer("player-a");
+
+        // Push a non-NormalActiveKillBehavior to stack
+        Behavior fakeBehavior = new Behavior(game, caoCao, List.of("player-b"), caoCao,
+                "", "active", null, true, false, false);
+        game.updateTopBehavior(fakeBehavior);
+
+        // Add a Kill to graveyard so contains() check passes
+        Kill kill = new Kill(BS8008);
+        game.getGraveyard().add(kill);
+
+        // Direct invoke: stack 頂為 fakeBehavior（非 NormalActiveKillBehavior），sourceCard 是 Kill
+        DamageContext ctx = new DamageContext(caoCao, attacker, kill, 1);
+        List<DomainEvent> events = new JianXiongSkill().onDamaged(game, ctx);
+
+        assertTrue(events.isEmpty(), "JianXiong should not trigger when top behavior is not NormalActiveKillBehavior");
+        assertSame(fakeBehavior, game.getTopBehavior().peek(),
+                "fake behavior should remain on stack untouched (not popped, no WaitingJX pushed)");
     }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
@@ -16,6 +16,9 @@ import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.Peach;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.EighteenSpanViperSpearCard;
+import com.gaas.threeKingdoms.handcard.scrollcard.Duel;
+import com.gaas.threeKingdoms.handcard.scrollcard.Lightning;
+import com.gaas.threeKingdoms.behavior.behavior.LightningJudgementBehavior;
 import com.gaas.threeKingdoms.player.*;
 import com.gaas.threeKingdoms.rolecard.Role;
 import com.gaas.threeKingdoms.rolecard.RoleCard;
@@ -362,6 +365,190 @@ public class JianXiongSkillTest {
         assertTrue(events.stream().anyMatch(e -> e instanceof JianXiongEffectEvent
                 && !((JianXiongEffectEvent) e).isTaken()));
         assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("""
+            Given
+            A 對 B (曹操) 出決鬥；B 無殺
+            DuelBehavior on top；A 的決鬥牌進入棄牌堆
+
+            When
+            DuelBehavior.doBehaviorAction 觸發 → B 受到 1 點傷害
+
+            Then
+            事件中含 AskJianXiongEffectEvent，sourceCardIds = [Duel]
+            （FAQ：錦囊牌對曹操造成傷害也可獲得錦囊本身）
+            """)
+    @Test
+    public void givenCaoCaoLosesDuel_AskJianXiongEffectEmitted() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        // A 加一張決鬥；B 維持沒殺（setupGameCaoCaoB 預設 B 手牌空）
+        playerA.getHand().addCardToHand(new Duel(SSA001));
+
+        // A 對 B 出決鬥（B 沒有殺 → DuelBehavior.doBehaviorAction 直接扣血給 B）
+        List<DomainEvent> events = game.playerPlayCard(playerA.getId(), SSA001.getCardId(),
+                playerB.getId(), "active");
+
+        assertEquals(3, playerB.getBloodCard().getHp());
+        AskJianXiongEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskJianXiongEffectEvent)
+                .map(e -> (AskJianXiongEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskJianXiongEffectEvent"));
+        assertEquals("player-b", ask.getPlayerId());
+        assertEquals(List.of(SSA001.getCardId()), ask.getSourceCardIds());
+        assertTrue(game.getGraveyard().contains(SSA001.getCardId()));
+        assertTrue(game.getTopBehavior().peek() instanceof WaitingJianXiongResponseBehavior);
+    }
+
+    @DisplayName("""
+            Given
+            A 對 B (曹操) 出決鬥；B 有 1 張殺；A 之後也有 1 張殺
+            B 出殺 → A 反殺 → B 沒殺 → 受傷
+
+            Then
+            事件中含 AskJianXiongEffectEvent，sourceCardIds = [Duel]
+            """)
+    @Test
+    public void givenCaoCaoLosesDuelAfterSwap_AskJianXiongEffectEmitted() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        // A 已有 BS8008 殺 (預設 setup)；加決鬥
+        playerA.getHand().addCardToHand(new Duel(SSA001));
+        // B 加一張殺 BHJ037（B 第一個出，剩下沒殺）
+        playerB.getHand().addCardToHand(new Kill(BHJ037));
+
+        // A 對 B 出決鬥
+        game.playerPlayCard(playerA.getId(), SSA001.getCardId(), playerB.getId(), "active");
+        // B 先出殺 → 換 A 出殺
+        game.playerPlayCard(playerB.getId(), BHJ037.getCardId(), playerA.getId(), "active");
+        // A 再出殺 → B 沒殺 → 受傷
+        List<DomainEvent> events = game.playerPlayCard(playerA.getId(), BS8008.getCardId(),
+                playerB.getId(), "active");
+
+        assertEquals(3, playerB.getBloodCard().getHp());
+        AskJianXiongEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskJianXiongEffectEvent)
+                .map(e -> (AskJianXiongEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskJianXiongEffectEvent"));
+        assertEquals(List.of(SSA001.getCardId()), ask.getSourceCardIds(),
+                "曹操決鬥輸應拿到決鬥本身（不是反殺的殺）");
+    }
+
+    @DisplayName("""
+            Given
+            B (曹操) 為發起方對 A 出決鬥；A 出殺 → B 沒殺反擊 → B 受傷
+
+            Then
+            事件中含 AskJianXiongEffectEvent，sourceCardIds = [Duel]
+            """)
+    @Test
+    public void givenCaoCaoIsDuelInitiator_LosesDuel_AskJianXiongEffectEmitted() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player playerA = game.getPlayer("player-a");
+        Player playerB = game.getPlayer("player-b");
+        // 改成 B 為當前回合
+        game.setCurrentRound(new com.gaas.threeKingdoms.round.Round(playerB));
+        // B (曹操) 加決鬥
+        playerB.getHand().addCardToHand(new Duel(SSA001));
+        // A 已有 BS8008 殺；B 沒殺
+
+        // B 對 A 出決鬥
+        game.playerPlayCard(playerB.getId(), SSA001.getCardId(), playerA.getId(), "active");
+        // A 出殺 → B 沒殺 → B 受傷
+        List<DomainEvent> events = game.playerPlayCard(playerA.getId(), BS8008.getCardId(),
+                playerB.getId(), "active");
+
+        assertEquals(3, playerB.getBloodCard().getHp());
+        AskJianXiongEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskJianXiongEffectEvent)
+                .map(e -> (AskJianXiongEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskJianXiongEffectEvent for Duel initiator"));
+        assertEquals(List.of(SSA001.getCardId()), ask.getSourceCardIds());
+    }
+
+    @DisplayName("""
+            Given
+            B 為曹操（WEI001）
+            stack 頂為 LightningJudgementBehavior（直接模擬 Lightning 判定情境）
+            graveyard 含 Lightning scroll（card.effect 結束後 scroll 已進墓地）
+
+            When
+            直接呼叫 JianXiongSkill.onDamaged with Lightning sourceCard
+
+            Then
+            事件中含 AskJianXiongEffectEvent，sourceCardIds = [Lightning]
+            stack 頂被換成 WaitingJianXiongResponseBehavior
+            （FAQ：曹操判定閃電受到傷害，可以將閃電收入手牌）
+            """)
+    @Test
+    public void givenLightningJudgementOnStack_OnDamaged_AskJianXiongEffectEmitted() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player caoCao = game.getPlayer("player-b");
+        Player attacker = game.getPlayer("player-a");
+
+        // 模擬 Lightning Ward 路徑：LJB 在 stack 頂
+        Lightning lightning = new Lightning(SSA014);
+        LightningJudgementBehavior ljb = new LightningJudgementBehavior(
+                game, caoCao, List.of(caoCao.getId()), null,
+                lightning.getId(), "inactive", lightning);
+        ljb.setIsOneRound(true); // 模擬 line 645 已標 待 pop
+        game.updateTopBehavior(ljb);
+        game.getGraveyard().add(lightning);
+
+        DamageContext ctx = new DamageContext(caoCao, attacker, lightning, 1);
+        List<DomainEvent> events = new JianXiongSkill().onDamaged(game, ctx);
+
+        AskJianXiongEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskJianXiongEffectEvent)
+                .map(e -> (AskJianXiongEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskJianXiongEffectEvent for Lightning"));
+        assertEquals("player-b", ask.getPlayerId());
+        assertEquals(List.of(lightning.getId()), ask.getSourceCardIds());
+        assertTrue(game.getTopBehavior().peek() instanceof WaitingJianXiongResponseBehavior);
+    }
+
+    @DisplayName("""
+            Given
+            B 為曹操（WEI001）
+            stack 為空（Lightning 無 Ward 路徑）
+            graveyard 含 Lightning scroll
+
+            When
+            直接呼叫 JianXiongSkill.onDamaged with Lightning sourceCard
+
+            Then
+            事件中含 AskJianXiongEffectEvent，sourceCardIds = [Lightning]
+            （白名單允許空 stack 觸發奸雄）
+            """)
+    @Test
+    public void givenEmptyStack_OnDamagedByLightning_AskJianXiongEffectEmitted() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player caoCao = game.getPlayer("player-b");
+        Player attacker = game.getPlayer("player-a");
+
+        Lightning lightning = new Lightning(SSA014);
+        game.getGraveyard().add(lightning);
+
+        // stack 是空的
+        assertTrue(game.getTopBehavior().isEmpty());
+
+        DamageContext ctx = new DamageContext(caoCao, attacker, lightning, 1);
+        List<DomainEvent> events = new JianXiongSkill().onDamaged(game, ctx);
+
+        AskJianXiongEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskJianXiongEffectEvent)
+                .map(e -> (AskJianXiongEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskJianXiongEffectEvent for empty stack"));
+        assertEquals(List.of(lightning.getId()), ask.getSourceCardIds());
+        assertTrue(game.getTopBehavior().peek() instanceof WaitingJianXiongResponseBehavior);
     }
 
     @DisplayName("""

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/JianXiongSkillTest.java
@@ -23,6 +23,7 @@ import com.gaas.threeKingdoms.handcard.scrollcard.ArrowBarrage;
 import com.gaas.threeKingdoms.behavior.behavior.LightningJudgementBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.BarbarianInvasionBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.ArrowBarrageBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
 import com.gaas.threeKingdoms.events.AskKillEvent;
 import com.gaas.threeKingdoms.events.AskDodgeEvent;
 import com.gaas.threeKingdoms.player.*;
@@ -270,6 +271,42 @@ public class JianXiongSkillTest {
 
         long count = events.stream().filter(e -> e instanceof AskJianXiongEffectEvent).count();
         assertEquals(1, count, "JianXiong should trigger exactly once per DamageEvent");
+    }
+
+    @DisplayName("""
+            Given
+            B 為曹操（WEI001）
+            stack 頂為 NormalActiveKillBehavior（模擬出殺中）
+            graveyard 含一張 Kill 作為 sourceCard
+
+            When
+            直接呼叫 JianXiongSkill.onDamaged with points=2（模擬未來雷殺等多點傷害源）
+
+            Then
+            事件中只有 1 個 AskJianXiongEffectEvent（鎖定 v1 spec：多點傷害整次只觸發 1 次）
+            stack 頂被換成 WaitingJianXiongResponseBehavior
+            """)
+    @Test
+    public void givenMultiPointDamage_OnlyOneAskJianXiongEffectEventEmitted() {
+        Game game = setupGameCaoCaoB(General.曹操);
+        Player caoCao = game.getPlayer("player-b");
+        Player attacker = game.getPlayer("player-a");
+
+        Kill kill = new Kill(BS8008);
+        game.getGraveyard().add(kill);
+
+        NormalActiveKillBehavior normalKill = new NormalActiveKillBehavior(
+                game, attacker, List.of(caoCao.getId()), caoCao,
+                kill.getId(), "active", kill);
+        game.updateTopBehavior(normalKill);
+
+        DamageContext ctx = new DamageContext(caoCao, attacker, kill, 2);
+        List<DomainEvent> events = new JianXiongSkill().onDamaged(game, ctx);
+
+        long count = events.stream().filter(e -> e instanceof AskJianXiongEffectEvent).count();
+        assertEquals(1, count,
+                "JianXiong should trigger exactly once regardless of damage points (v1 spec)");
+        assertTrue(game.getTopBehavior().peek() instanceof WaitingJianXiongResponseBehavior);
     }
 
     @DisplayName("""

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/GameController.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/GameController.java
@@ -37,6 +37,7 @@ public class GameController {
     private final UseYinYangSwordsEffectUseCase useYinYangSwordsEffectUseCase;
     private final UseGreenDragonCrescentBladeEffectUseCase useGreenDragonCrescentBladeEffectUseCase;
     private final UseStonePiercingAxeEffectUseCase useStonePiercingAxeEffectUseCase;
+    private final UseJianXiongEffectUseCase useJianXiongEffectUseCase;
     private final UseViperSpearKillUseCase useViperSpearKillUseCase;
     private final UseHeavenlyDoubleHalberdKillUseCase useHeavenlyDoubleHalberdKillUseCase;
 
@@ -176,6 +177,14 @@ public class GameController {
         UseStonePiercingAxeEffectPresenter presenter = new UseStonePiercingAxeEffectPresenter();
         useStonePiercingAxeEffectUseCase.execute(gameId, request.toUseStonePiercingAxeEffectRequest(), presenter);
         webSocketBroadCast.pushUseStonePiercingAxeEffectEvent(presenter);
+        return ResponseEntity.ok(HttpStatus.OK);
+    }
+
+    @PostMapping("/api/games/{gameId}/player:useJianXiongEffect")
+    public ResponseEntity<?> playerUseJianXiongEffect(@PathVariable String gameId, @RequestBody UseJianXiongEffectRequest request) {
+        UseJianXiongEffectPresenter presenter = new UseJianXiongEffectPresenter();
+        useJianXiongEffectUseCase.execute(gameId, request.toUseJianXiongEffectRequest(), presenter);
+        webSocketBroadCast.pushUseJianXiongEffectEvent(presenter);
         return ResponseEntity.ok(HttpStatus.OK);
     }
 

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/WebSocketBroadCast.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/WebSocketBroadCast.java
@@ -218,6 +218,19 @@ public class WebSocketBroadCast {
         }
     }
 
+    public void pushUseJianXiongEffectEvent(UseJianXiongEffectPresenter presenter) {
+        List<UseJianXiongEffectPresenter.GameViewModel> viewModels = presenter.present();
+        try {
+            for (UseJianXiongEffectPresenter.GameViewModel viewModel : viewModels) {
+                String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(viewModel);
+                messagingTemplate.convertAndSend(String.format("/websocket/legendsOfTheThreeKingdoms/%s/%s", viewModel.getGameId(), viewModel.getPlayerId()), json);
+            }
+        } catch (Exception e) {
+            System.err.println("****************** pushUseJianXiongEffectEvent ");
+            e.printStackTrace();
+        }
+    }
+
     public void pushUseStonePiercingAxeEffectEvent(UseStonePiercingAxeEffectPresenter presenter) {
         List<UseStonePiercingAxeEffectPresenter.GameViewModel> viewModels = presenter.present();
         try {

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/UseJianXiongEffectRequest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/UseJianXiongEffectRequest.java
@@ -1,0 +1,16 @@
+package com.gaas.threeKingdoms.controller.dto;
+
+import com.gaas.threeKingdoms.usecase.UseJianXiongEffectUseCase;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UseJianXiongEffectRequest {
+    private String playerId;
+    private String choice; // "ACCEPT" or "SKIP"
+
+    public UseJianXiongEffectUseCase.UseJianXiongEffectRequest toUseJianXiongEffectRequest() {
+        return new UseJianXiongEffectUseCase.UseJianXiongEffectRequest(playerId, choice);
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseEquipmentEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseEquipmentEffectPresenter.java
@@ -132,18 +132,6 @@ public class UseEquipmentEffectPresenter implements UseEquipmentUseCase.UseEquip
         }
     }
 
-    public static class AskJianXiongEffectViewModel extends ViewModel<AskJianXiongEffectDataViewModel> {
-        public AskJianXiongEffectViewModel(AskJianXiongEffectDataViewModel data) {
-            super("AskJianXiongEffectEvent", data, "奸雄：是否獲得造成傷害的牌");
-        }
-    }
-
-    public static class JianXiongEffectViewModel extends ViewModel<JianXiongEffectDataViewModel> {
-        public JianXiongEffectViewModel(JianXiongEffectDataViewModel data) {
-            super("JianXiongEffectEvent", data, "奸雄發動");
-        }
-    }
-
     public static class SkipEquipmentEffectViewModel extends ViewModel<SkipEquipmentEffectDataViewModel> {
         public SkipEquipmentEffectViewModel(SkipEquipmentEffectDataViewModel data) {
             super("SkipEquipmentEffectEvent", data, "跳過裝備效果");
@@ -241,23 +229,6 @@ public class UseEquipmentEffectPresenter implements UseEquipmentUseCase.UseEquip
         private String attackerPlayerId;
         private String targetPlayerId;
         private List<String> discardedCardIds;
-    }
-
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class AskJianXiongEffectDataViewModel {
-        private String playerId;
-        private String sourceCardId;
-    }
-
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class JianXiongEffectDataViewModel {
-        private String playerId;
-        private String sourceCardId;
-        private boolean taken;
     }
 
     @Data

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseEquipmentEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseEquipmentEffectPresenter.java
@@ -132,6 +132,18 @@ public class UseEquipmentEffectPresenter implements UseEquipmentUseCase.UseEquip
         }
     }
 
+    public static class AskJianXiongEffectViewModel extends ViewModel<AskJianXiongEffectDataViewModel> {
+        public AskJianXiongEffectViewModel(AskJianXiongEffectDataViewModel data) {
+            super("AskJianXiongEffectEvent", data, "奸雄：是否獲得造成傷害的牌");
+        }
+    }
+
+    public static class JianXiongEffectViewModel extends ViewModel<JianXiongEffectDataViewModel> {
+        public JianXiongEffectViewModel(JianXiongEffectDataViewModel data) {
+            super("JianXiongEffectEvent", data, "奸雄發動");
+        }
+    }
+
     public static class SkipEquipmentEffectViewModel extends ViewModel<SkipEquipmentEffectDataViewModel> {
         public SkipEquipmentEffectViewModel(SkipEquipmentEffectDataViewModel data) {
             super("SkipEquipmentEffectEvent", data, "跳過裝備效果");
@@ -229,6 +241,23 @@ public class UseEquipmentEffectPresenter implements UseEquipmentUseCase.UseEquip
         private String attackerPlayerId;
         private String targetPlayerId;
         private List<String> discardedCardIds;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AskJianXiongEffectDataViewModel {
+        private String playerId;
+        private String sourceCardId;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class JianXiongEffectDataViewModel {
+        private String playerId;
+        private String sourceCardId;
+        private boolean taken;
     }
 
     @Data

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseJianXiongEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseJianXiongEffectPresenter.java
@@ -1,0 +1,66 @@
+package com.gaas.threeKingdoms.presenter;
+
+import com.gaas.threeKingdoms.events.*;
+import com.gaas.threeKingdoms.presenter.common.GameDataViewModel;
+import com.gaas.threeKingdoms.presenter.common.PlayerDataViewModel;
+import com.gaas.threeKingdoms.presenter.common.RoundDataViewModel;
+import com.gaas.threeKingdoms.presenter.mapper.DomainEventToViewModelMapper;
+import com.gaas.threeKingdoms.usecase.UseJianXiongEffectUseCase;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.gaas.threeKingdoms.presenter.ViewModel.getEvent;
+
+public class UseJianXiongEffectPresenter implements UseJianXiongEffectUseCase.UseJianXiongEffectPresenter<List<UseJianXiongEffectPresenter.GameViewModel>> {
+
+    private List<GameViewModel> viewModels = new ArrayList<>();
+    private final DomainEventToViewModelMapper domainEventToViewModelMapper = new DomainEventToViewModelMapper();
+
+    @Override
+    public void renderEvents(List<DomainEvent> events) {
+        List<ViewModel<?>> effectViewModels = domainEventToViewModelMapper.mapEventsToViewModels(events);
+
+        GameStatusEvent gameStatusEvent = getEvent(events, GameStatusEvent.class).orElseThrow();
+        List<PlayerEvent> playerEvents = gameStatusEvent.getSeats();
+        RoundEvent roundEvent = gameStatusEvent.getRound();
+        List<PlayerDataViewModel> playerDataViewModels = playerEvents.stream().map(PlayerDataViewModel::new).toList();
+
+        RoundDataViewModel roundDataViewModel = new RoundDataViewModel(roundEvent);
+
+        for (PlayerDataViewModel viewModel : playerDataViewModels) {
+            GameDataViewModel gameDataViewModel = new GameDataViewModel(
+                    PlayerDataViewModel.hiddenOtherPlayerRoleInformation(
+                            playerDataViewModels, viewModel.getId()), roundDataViewModel, gameStatusEvent.getGamePhase());
+
+            viewModels.add(new GameViewModel(
+                    new ArrayList<>(effectViewModels),
+                    gameDataViewModel,
+                    gameStatusEvent.getMessage(),
+                    gameStatusEvent.getGameId(),
+                    viewModel.getId()));
+        }
+    }
+
+    @Override
+    public List<GameViewModel> present() {
+        return viewModels;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class GameViewModel extends GameProcessViewModel<GameDataViewModel> {
+        private String gameId;
+        private String playerId;
+
+        public GameViewModel(List<ViewModel<?>> viewModels, GameDataViewModel data, String message, String gameId, String playerId) {
+            super(viewModels, data, message);
+            this.gameId = gameId;
+            this.playerId = playerId;
+        }
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseJianXiongEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseJianXiongEffectPresenter.java
@@ -81,7 +81,7 @@ public class UseJianXiongEffectPresenter implements UseJianXiongEffectUseCase.Us
     @NoArgsConstructor
     public static class AskJianXiongEffectDataViewModel {
         private String playerId;
-        private String sourceCardId;
+        private java.util.List<String> sourceCardIds;
     }
 
     @Data
@@ -89,7 +89,7 @@ public class UseJianXiongEffectPresenter implements UseJianXiongEffectUseCase.Us
     @NoArgsConstructor
     public static class JianXiongEffectDataViewModel {
         private String playerId;
-        private String sourceCardId;
+        private java.util.List<String> sourceCardIds;
         private boolean taken;
     }
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseJianXiongEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseJianXiongEffectPresenter.java
@@ -63,4 +63,33 @@ public class UseJianXiongEffectPresenter implements UseJianXiongEffectUseCase.Us
             this.playerId = playerId;
         }
     }
+
+    public static class AskJianXiongEffectViewModel extends ViewModel<AskJianXiongEffectDataViewModel> {
+        public AskJianXiongEffectViewModel(AskJianXiongEffectDataViewModel data) {
+            super("AskJianXiongEffectEvent", data, "奸雄：是否獲得造成傷害的牌");
+        }
+    }
+
+    public static class JianXiongEffectViewModel extends ViewModel<JianXiongEffectDataViewModel> {
+        public JianXiongEffectViewModel(JianXiongEffectDataViewModel data) {
+            super("JianXiongEffectEvent", data, "奸雄發動");
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AskJianXiongEffectDataViewModel {
+        private String playerId;
+        private String sourceCardId;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class JianXiongEffectDataViewModel {
+        private String playerId;
+        private String sourceCardId;
+        private boolean taken;
+    }
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/mapper/DomainEventToViewModelMapper.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/mapper/DomainEventToViewModelMapper.java
@@ -281,6 +281,25 @@ public class DomainEventToViewModelMapper {
             return new UseEquipmentEffectPresenter.HeavenlyDoubleHalberdKillTriggerViewModel(dataViewModel);
         });
 
+        eventToViewModelMappers.put(AskJianXiongEffectEvent.class, event -> {
+            AskJianXiongEffectEvent askEvent = (AskJianXiongEffectEvent) event;
+            UseEquipmentEffectPresenter.AskJianXiongEffectDataViewModel dataViewModel = new UseEquipmentEffectPresenter.AskJianXiongEffectDataViewModel(
+                    askEvent.getPlayerId(),
+                    askEvent.getSourceCardId()
+            );
+            return new UseEquipmentEffectPresenter.AskJianXiongEffectViewModel(dataViewModel);
+        });
+
+        eventToViewModelMappers.put(JianXiongEffectEvent.class, event -> {
+            JianXiongEffectEvent jxEvent = (JianXiongEffectEvent) event;
+            UseEquipmentEffectPresenter.JianXiongEffectDataViewModel dataViewModel = new UseEquipmentEffectPresenter.JianXiongEffectDataViewModel(
+                    jxEvent.getPlayerId(),
+                    jxEvent.getSourceCardId(),
+                    jxEvent.isTaken()
+            );
+            return new UseEquipmentEffectPresenter.JianXiongEffectViewModel(dataViewModel);
+        });
+
         eventToViewModelMappers.put(AskChooseMountCardEvent.class, event -> {
             AskChooseMountCardEvent askChooseMountEvent = (AskChooseMountCardEvent) event;
             UseEquipmentEffectPresenter.AskChooseMountCardDataViewModel dataViewModel = new UseEquipmentEffectPresenter.AskChooseMountCardDataViewModel(

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/mapper/DomainEventToViewModelMapper.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/mapper/DomainEventToViewModelMapper.java
@@ -285,7 +285,7 @@ public class DomainEventToViewModelMapper {
             AskJianXiongEffectEvent askEvent = (AskJianXiongEffectEvent) event;
             UseJianXiongEffectPresenter.AskJianXiongEffectDataViewModel dataViewModel = new UseJianXiongEffectPresenter.AskJianXiongEffectDataViewModel(
                     askEvent.getPlayerId(),
-                    askEvent.getSourceCardId()
+                    askEvent.getSourceCardIds()
             );
             return new UseJianXiongEffectPresenter.AskJianXiongEffectViewModel(dataViewModel);
         });
@@ -294,7 +294,7 @@ public class DomainEventToViewModelMapper {
             JianXiongEffectEvent jxEvent = (JianXiongEffectEvent) event;
             UseJianXiongEffectPresenter.JianXiongEffectDataViewModel dataViewModel = new UseJianXiongEffectPresenter.JianXiongEffectDataViewModel(
                     jxEvent.getPlayerId(),
-                    jxEvent.getSourceCardId(),
+                    jxEvent.getSourceCardIds(),
                     jxEvent.isTaken()
             );
             return new UseJianXiongEffectPresenter.JianXiongEffectViewModel(dataViewModel);

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/mapper/DomainEventToViewModelMapper.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/mapper/DomainEventToViewModelMapper.java
@@ -283,21 +283,21 @@ public class DomainEventToViewModelMapper {
 
         eventToViewModelMappers.put(AskJianXiongEffectEvent.class, event -> {
             AskJianXiongEffectEvent askEvent = (AskJianXiongEffectEvent) event;
-            UseEquipmentEffectPresenter.AskJianXiongEffectDataViewModel dataViewModel = new UseEquipmentEffectPresenter.AskJianXiongEffectDataViewModel(
+            UseJianXiongEffectPresenter.AskJianXiongEffectDataViewModel dataViewModel = new UseJianXiongEffectPresenter.AskJianXiongEffectDataViewModel(
                     askEvent.getPlayerId(),
                     askEvent.getSourceCardId()
             );
-            return new UseEquipmentEffectPresenter.AskJianXiongEffectViewModel(dataViewModel);
+            return new UseJianXiongEffectPresenter.AskJianXiongEffectViewModel(dataViewModel);
         });
 
         eventToViewModelMappers.put(JianXiongEffectEvent.class, event -> {
             JianXiongEffectEvent jxEvent = (JianXiongEffectEvent) event;
-            UseEquipmentEffectPresenter.JianXiongEffectDataViewModel dataViewModel = new UseEquipmentEffectPresenter.JianXiongEffectDataViewModel(
+            UseJianXiongEffectPresenter.JianXiongEffectDataViewModel dataViewModel = new UseJianXiongEffectPresenter.JianXiongEffectDataViewModel(
                     jxEvent.getPlayerId(),
                     jxEvent.getSourceCardId(),
                     jxEvent.isTaken()
             );
-            return new UseEquipmentEffectPresenter.JianXiongEffectViewModel(dataViewModel);
+            return new UseJianXiongEffectPresenter.JianXiongEffectViewModel(dataViewModel);
         });
 
         eventToViewModelMappers.put(AskChooseMountCardEvent.class, event -> {

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
@@ -25,6 +25,8 @@ public class BehaviorData {
     private static final String POLLING_STARTED = "POLLING_STARTED";
     private static final String VIPER_SPEAR_DISCARDED_CARD_IDS = "VIPER_SPEAR_DISCARDED_CARD_IDS";
     private static final String JIANXIONG_SOURCE_CARD_IDS = "JIANXIONG_SOURCE_CARD_IDS";
+    private static final String DYING_PENDING_SOURCE_CARD_ID = "DYING_PENDING_SOURCE_CARD_ID";
+    private static final String DYING_PENDING_ATTACKER_PLAYER_ID = "DYING_PENDING_ATTACKER_PLAYER_ID";
 
     private String behaviorName;
     private String behaviorPlayerId;
@@ -92,15 +94,21 @@ public class BehaviorData {
                 }
                 yield borrowedSwordBehavior;
             }
-            case "DyingAskPeachBehavior" -> new DyingAskPeachBehavior(
-                    game,
-                    game.getPlayer(behaviorPlayerId),
-                    reactionPlayers,
-                    game.getPlayer(currentReactionPlayerId),
-                    cardId,
-                    playType,
-                    PlayCard.findById(cardId)
-            );
+            case "DyingAskPeachBehavior" -> {
+                String pendingSrcCardId = params != null ? (String) params.get(DYING_PENDING_SOURCE_CARD_ID) : null;
+                String pendingAttackerId = params != null ? (String) params.get(DYING_PENDING_ATTACKER_PLAYER_ID) : null;
+                yield new DyingAskPeachBehavior(
+                        game,
+                        game.getPlayer(behaviorPlayerId),
+                        reactionPlayers,
+                        game.getPlayer(currentReactionPlayerId),
+                        cardId,
+                        playType,
+                        cardId != null ? PlayCard.findById(cardId) : null,
+                        pendingSrcCardId,
+                        pendingAttackerId
+                );
+            }
             case "EquipArmorBehavior" -> new EquipArmorBehavior(
                     game,
                     game.getPlayer(behaviorPlayerId),
@@ -389,6 +397,13 @@ public class BehaviorData {
             params.put(VIPER_SPEAR_DISCARDED_CARD_IDS, vs.getDiscardedCardIds());
         } else if (behavior instanceof WaitingJianXiongResponseBehavior jx) {
             params.put(JIANXIONG_SOURCE_CARD_IDS, jx.getSourceCardIds());
+        } else if (behavior instanceof DyingAskPeachBehavior dying) {
+            if (dying.getPendingSourceCardId() != null) {
+                params.put(DYING_PENDING_SOURCE_CARD_ID, dying.getPendingSourceCardId());
+            }
+            if (dying.getPendingAttackerPlayerId() != null) {
+                params.put(DYING_PENDING_ATTACKER_PLAYER_ID, dying.getPendingAttackerPlayerId());
+            }
         }
         return BehaviorData.builder()
                 .behaviorName(behavior.getClass().getSimpleName())

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
@@ -27,6 +27,7 @@ public class BehaviorData {
     private static final String JIANXIONG_SOURCE_CARD_IDS = "JIANXIONG_SOURCE_CARD_IDS";
     private static final String DYING_PENDING_SOURCE_CARD_ID = "DYING_PENDING_SOURCE_CARD_ID";
     private static final String DYING_PENDING_ATTACKER_PLAYER_ID = "DYING_PENDING_ATTACKER_PLAYER_ID";
+    private static final String DYING_PENDING_VIPER_SPEAR_DISCARD_CARD_IDS = "DYING_PENDING_VIPER_SPEAR_DISCARD_CARD_IDS";
 
     private String behaviorName;
     private String behaviorPlayerId;
@@ -97,6 +98,10 @@ public class BehaviorData {
             case "DyingAskPeachBehavior" -> {
                 String pendingSrcCardId = params != null ? (String) params.get(DYING_PENDING_SOURCE_CARD_ID) : null;
                 String pendingAttackerId = params != null ? (String) params.get(DYING_PENDING_ATTACKER_PLAYER_ID) : null;
+                @SuppressWarnings("unchecked")
+                List<String> pendingViperSpearIds = params != null
+                        ? (List<String>) params.get(DYING_PENDING_VIPER_SPEAR_DISCARD_CARD_IDS)
+                        : null;
                 yield new DyingAskPeachBehavior(
                         game,
                         game.getPlayer(behaviorPlayerId),
@@ -106,7 +111,8 @@ public class BehaviorData {
                         playType,
                         cardId != null ? PlayCard.findById(cardId) : null,
                         pendingSrcCardId,
-                        pendingAttackerId
+                        pendingAttackerId,
+                        pendingViperSpearIds
                 );
             }
             case "EquipArmorBehavior" -> new EquipArmorBehavior(
@@ -403,6 +409,9 @@ public class BehaviorData {
             }
             if (dying.getPendingAttackerPlayerId() != null) {
                 params.put(DYING_PENDING_ATTACKER_PLAYER_ID, dying.getPendingAttackerPlayerId());
+            }
+            if (dying.getPendingViperSpearDiscardCardIds() != null) {
+                params.put(DYING_PENDING_VIPER_SPEAR_DISCARD_CARD_IDS, dying.getPendingViperSpearDiscardCardIds());
             }
         }
         return BehaviorData.builder()

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
@@ -357,6 +357,11 @@ public class BehaviorData {
                     playType,
                     PlayCard.findById(cardId)
             );
+            case "WaitingJianXiongResponseBehavior" -> new WaitingJianXiongResponseBehavior(
+                    game,
+                    game.getPlayer(behaviorPlayerId),
+                    PlayCard.findById(cardId)
+            );
             default -> throw new RuntimeException("Unknown behavior name: " + behaviorName);
         };
         behavior.setIsOneRound(isOneRound);

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
@@ -360,7 +360,7 @@ public class BehaviorData {
             case "WaitingJianXiongResponseBehavior" -> new WaitingJianXiongResponseBehavior(
                     game,
                     game.getPlayer(behaviorPlayerId),
-                    PlayCard.findById(cardId)
+                    cardId
             );
             default -> throw new RuntimeException("Unknown behavior name: " + behaviorName);
         };

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 public class BehaviorData {
     private static final String POLLING_STARTED = "POLLING_STARTED";
     private static final String VIPER_SPEAR_DISCARDED_CARD_IDS = "VIPER_SPEAR_DISCARDED_CARD_IDS";
+    private static final String JIANXIONG_SOURCE_CARD_IDS = "JIANXIONG_SOURCE_CARD_IDS";
 
     private String behaviorName;
     private String behaviorPlayerId;
@@ -357,11 +358,17 @@ public class BehaviorData {
                     playType,
                     PlayCard.findById(cardId)
             );
-            case "WaitingJianXiongResponseBehavior" -> new WaitingJianXiongResponseBehavior(
-                    game,
-                    game.getPlayer(behaviorPlayerId),
-                    cardId
-            );
+            case "WaitingJianXiongResponseBehavior" -> {
+                @SuppressWarnings("unchecked")
+                List<String> sourceCardIds = params != null && params.get(JIANXIONG_SOURCE_CARD_IDS) != null
+                        ? (List<String>) params.get(JIANXIONG_SOURCE_CARD_IDS)
+                        : (cardId != null ? List.of(cardId) : List.of());
+                yield new WaitingJianXiongResponseBehavior(
+                        game,
+                        game.getPlayer(behaviorPlayerId),
+                        sourceCardIds
+                );
+            }
             default -> throw new RuntimeException("Unknown behavior name: " + behaviorName);
         };
         behavior.setIsOneRound(isOneRound);
@@ -380,6 +387,8 @@ public class BehaviorData {
             params.put(POLLING_STARTED, bh.isPollingStarted());
         } else if (behavior instanceof ViperSpearKillBehavior vs) {
             params.put(VIPER_SPEAR_DISCARDED_CARD_IDS, vs.getDiscardedCardIds());
+        } else if (behavior instanceof WaitingJianXiongResponseBehavior jx) {
+            params.put(JIANXIONG_SOURCE_CARD_IDS, jx.getSourceCardIds());
         }
         return BehaviorData.builder()
                 .behaviorName(behavior.getClass().getSimpleName())

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/MockMvcUtil.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/MockMvcUtil.java
@@ -83,6 +83,15 @@ public class MockMvcUtil {
                         }""", playerId, choice, cardId)));
     }
 
+    public ResultActions useJianXiongEffect(String gameId, String playerId, String choice) throws Exception {
+        return this.mockMvc.perform(post("/api/games/" + gameId + "/player:useJianXiongEffect")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(String.format("""
+                        { "playerId": "%s",
+                          "choice": "%s"
+                        }""", playerId, choice)));
+    }
+
     public ResultActions useGreenDragonCrescentBladeEffect(String gameId, String playerId, String choice, String killCardId) throws Exception {
         return this.mockMvc.perform(post("/api/games/" + gameId + "/player:useGreenDragonCrescentBladeEffect")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
@@ -64,6 +64,47 @@ public class JianXiongTest extends AbstractBaseIntegrationTest {
     }
 
     @Test
+    public void testCaoCaoLethalDamageThenRevived_AskJianXiongEffectEmitted_AndAccept() throws Exception {
+        // Given B 為曹操，HP=1；A 有殺；C 有桃
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008));
+        Player playerB = createPlayer("player-b", 1, General.曹操, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL,
+                new Peach(BH3029));
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Peach(BH4030)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // When A 出殺打 B → B 不出閃 → HP=0 進瀕死
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B 自己沒桃，跳過
+        mockMvcUtil.playCard(gameId, "player-b", "player-b", "", "skip")
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // C 出桃救 B → 觸發 AskJianXiong
+        mockMvcUtil.playCard(gameId, "player-c", "player-b", "BH3029", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B 選 ACCEPT → 殺進手牌
+        mockMvcUtil.useJianXiongEffect(gameId, "player-b", "ACCEPT")
+                .andExpect(status().isOk()).andReturn();
+
+        assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_revived_accept_for_%s.json");
+    }
+
+    @Test
     public void testCaoCaoLosesBarbarianInvasion_AskJianXiongEffectEmitted_AndAccept() throws Exception {
         // Given B 為曹操，無殺；A 有南蠻入侵
         Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
@@ -8,6 +8,7 @@ import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.Peach;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.EighteenSpanViperSpearCard;
+import com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion;
 import com.gaas.threeKingdoms.handcard.scrollcard.Duel;
 import com.gaas.threeKingdoms.player.HealthStatus;
 import com.gaas.threeKingdoms.player.Player;
@@ -60,6 +61,38 @@ public class JianXiongTest extends AbstractBaseIntegrationTest {
 
         // Then 驗證 4 個玩家收到的 JSON
         assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_%s.json");
+    }
+
+    @Test
+    public void testCaoCaoLosesBarbarianInvasion_AskJianXiongEffectEmitted_AndAccept() throws Exception {
+        // Given B 為曹操，無殺；A 有南蠻入侵
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new BarbarianInvasion(SS7007));
+        Player playerB = createPlayer("player-b", 4, General.曹操, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL,
+                new Kill(BS9009));
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER,
+                new Kill(BHJ037));
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Peach(BH3029)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // When A 出南蠻 → B (曹操) 不出殺受傷 → 觸發奸雄
+        mockMvcUtil.playCard(gameId, "player-a", "", "SS7007", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // When B 選 ACCEPT → 南蠻進手牌、polling resume 到 C 收 AskKillEvent
+        mockMvcUtil.useJianXiongEffect(gameId, "player-b", "ACCEPT")
+                .andExpect(status().isOk()).andReturn();
+
+        assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_%s.json");
     }
 
     @Test

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
@@ -1,0 +1,84 @@
+package com.gaas.threeKingdoms.e2e.skill;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.Deck;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.player.HealthStatus;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.rolecard.Role;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.gaas.threeKingdoms.e2e.MockUtil.createPlayer;
+import static com.gaas.threeKingdoms.e2e.MockUtil.initGame;
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class JianXiongTest extends AbstractBaseIntegrationTest {
+
+    // @Override protected boolean shouldRegenerateFixtures() { return true; }
+
+    private void givenPlayerBIsCaoCao() {
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008));
+        Player playerB = createPlayer("player-b", 4, General.曹操, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+        List<Player> players = Arrays.asList(playerA, playerB, playerC, playerD);
+        Game game = initGame(gameId, players, playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Peach(BH3029)));
+        game.setDeck(deck);
+        repository.save(game);
+    }
+
+    @Test
+    public void testCaoCaoTakesKillDamage_AskJianXiongEffectEmitted_AndAccept() throws Exception {
+        // Given B 為曹操
+        givenPlayerBIsCaoCao();
+
+        // When A 出殺打 B → B 不出閃 → 受到傷害
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // When B 選 ACCEPT 發動奸雄
+        mockMvcUtil.useJianXiongEffect(gameId, "player-b", "ACCEPT")
+                .andExpect(status().isOk()).andReturn();
+
+        // Then 驗證 4 個玩家收到的 JSON
+        assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_%s.json");
+    }
+
+    @Test
+    public void testCaoCaoTakesKillDamage_AskJianXiongEffectEmitted_AndSkip() throws Exception {
+        // Given B 為曹操
+        givenPlayerBIsCaoCao();
+
+        // When A 出殺打 B → B 不出閃 → 受到傷害
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // When B 選 SKIP 不發動
+        mockMvcUtil.useJianXiongEffect(gameId, "player-b", "SKIP")
+                .andExpect(status().isOk()).andReturn();
+
+        // Then 驗證 4 個玩家收到的 JSON
+        assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_%s.json");
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
@@ -7,6 +7,7 @@ import com.gaas.threeKingdoms.handcard.Deck;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.EighteenSpanViperSpearCard;
 import com.gaas.threeKingdoms.player.HealthStatus;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.rolecard.Role;
@@ -58,6 +59,39 @@ public class JianXiongTest extends AbstractBaseIntegrationTest {
 
         // Then 驗證 4 個玩家收到的 JSON
         assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_%s.json");
+    }
+
+    @Test
+    public void testCaoCaoTakesViperSpearDamage_JianXiongTakesTwoDiscards() throws Exception {
+        // Given B 為曹操；A 裝丈八蛇矛 + 兩張手牌
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Peach(BH3029), new Peach(BH4030));
+        playerA.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+        Player playerB = createPlayer("player-b", 4, General.曹操, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Peach(BH6032)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // When A 用丈八蛇矛攻擊 B（棄兩張桃當虛擬殺）
+        mockMvcUtil.useViperSpearKill(gameId, "player-a", "player-b",
+                        List.of(BH3029.getCardId(), BH4030.getCardId()))
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B 不出閃
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B 選 ACCEPT 發動奸雄 → 應收兩張棄牌
+        mockMvcUtil.useJianXiongEffect(gameId, "player-b", "ACCEPT")
+                .andExpect(status().isOk()).andReturn();
+
+        assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_accept_for_%s.json");
     }
 
     @Test

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
@@ -107,6 +107,53 @@ public class JianXiongTest extends AbstractBaseIntegrationTest {
     }
 
     @Test
+    public void testCaoCaoLethalInBarbarianInvasion_RevivedAndAccept_PollingResumesToNextReactor() throws Exception {
+        // Given B 為曹操 HP=1，AOE polling 中的第一個 reactor
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new BarbarianInvasion(SS7007));
+        Player playerB = createPlayer("player-b", 1, General.曹操, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL,
+                new Kill(BS9009));
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER,
+                new Peach(BH4030));
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Peach(BH7033)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // When A 出南蠻 → B (曹操) 不出殺 → HP=0 進瀕死
+        mockMvcUtil.playCard(gameId, "player-a", "", "SS7007", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B 自己沒桃
+        mockMvcUtil.playCard(gameId, "player-b", "player-b", "", "skip")
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // C 沒桃
+        mockMvcUtil.playCard(gameId, "player-c", "player-b", "", "skip")
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // D 出桃救 B → 觸發 AskJianXiongEffectEvent
+        mockMvcUtil.playCard(gameId, "player-d", "player-b", "BH4030", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B 選 ACCEPT → 南蠻進手牌、polling resume 到 C 收 AskKillEvent
+        mockMvcUtil.useJianXiongEffect(gameId, "player-b", "ACCEPT")
+                .andExpect(status().isOk()).andReturn();
+
+        assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_%s.json");
+    }
+
+    @Test
     public void testCaoCaoLethalDamageThenRevived_AskJianXiongEffectEmitted_AndAccept() throws Exception {
         // Given B 為曹操，HP=1；A 有殺；C 有桃
         Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
@@ -64,6 +64,49 @@ public class JianXiongTest extends AbstractBaseIntegrationTest {
     }
 
     @Test
+    public void testCaoCaoLethalDamageFromViperSpearThenRevived_AcceptTakesTwoDiscards() throws Exception {
+        // Given B 為曹操 HP=1；A 裝丈八蛇矛 + 兩張手牌；C 有桃
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Peach(BH3029), new Peach(BH4030));
+        playerA.getEquipment().setWeapon(new EighteenSpanViperSpearCard(ESQ025));
+        Player playerB = createPlayer("player-b", 1, General.曹操, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL,
+                new Peach(BH6032));
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Peach(BH7033)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // When A 用丈八蛇矛攻擊 B（棄兩張桃當虛擬殺）→ B HP=0 進瀕死
+        mockMvcUtil.useViperSpearKill(gameId, "player-a", "player-b",
+                        List.of(BH3029.getCardId(), BH4030.getCardId()))
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B 自己沒桃 → 跳過
+        mockMvcUtil.playCard(gameId, "player-b", "player-b", "", "skip")
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // C 出桃救 B → 觸發 AskJianXiong（兩張棄牌 = ViperSpear 兩張棄牌）
+        mockMvcUtil.playCard(gameId, "player-c", "player-b", "BH6032", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B 選 ACCEPT → 兩張棄牌進手牌
+        mockMvcUtil.useJianXiongEffect(gameId, "player-b", "ACCEPT")
+                .andExpect(status().isOk()).andReturn();
+
+        assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_revived_accept_for_%s.json");
+    }
+
+    @Test
     public void testCaoCaoLethalDamageThenRevived_AskJianXiongEffectEmitted_AndAccept() throws Exception {
         // Given B 為曹操，HP=1；A 有殺；C 有桃
         Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/JianXiongTest.java
@@ -8,6 +8,7 @@ import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.Peach;
 import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.EighteenSpanViperSpearCard;
+import com.gaas.threeKingdoms.handcard.scrollcard.Duel;
 import com.gaas.threeKingdoms.player.HealthStatus;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.rolecard.Role;
@@ -59,6 +60,32 @@ public class JianXiongTest extends AbstractBaseIntegrationTest {
 
         // Then 驗證 4 個玩家收到的 JSON
         assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_%s.json");
+    }
+
+    @Test
+    public void testCaoCaoLosesDuel_AskJianXiongEffectEmitted_AndAccept() throws Exception {
+        // Given B 為曹操，無殺；A 有決鬥
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Duel(SSA001));
+        Player playerB = createPlayer("player-b", 4, General.曹操, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Peach(BH3029)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // When A 對 B 決鬥（B 沒殺 → 立刻扣血 → 觸發奸雄）
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "SSA001", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // When B 選 ACCEPT 發動奸雄
+        mockMvcUtil.useJianXiongEffect(gameId, "player-b", "ACCEPT")
+                .andExpect(status().isOk()).andReturn();
+
+        assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_duel_accept_for_%s.json");
     }
 
     @Test

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_a.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardId" : "BS8008",
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_a.json
@@ -3,7 +3,7 @@
     "event" : "JianXiongEffectEvent",
     "data" : {
       "playerId" : "player-b",
-      "sourceCardId" : "BS8008",
+      "sourceCardIds" : [ "BS8008" ],
       "taken" : true
     },
     "message" : "奸雄發動"

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_b.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardId" : "BS8008",
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Minister",
+      "hp" : 3,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ "BS8008" ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_b.json
@@ -3,7 +3,7 @@
     "event" : "JianXiongEffectEvent",
     "data" : {
       "playerId" : "player-b",
-      "sourceCardId" : "BS8008",
+      "sourceCardIds" : [ "BS8008" ],
       "taken" : true
     },
     "message" : "奸雄發動"

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_c.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardId" : "BS8008",
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_c.json
@@ -3,7 +3,7 @@
     "event" : "JianXiongEffectEvent",
     "data" : {
       "playerId" : "player-b",
-      "sourceCardId" : "BS8008",
+      "sourceCardIds" : [ "BS8008" ],
       "taken" : true
     },
     "message" : "奸雄發動"

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_d.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardId" : "BS8008",
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_accept_for_player_d.json
@@ -3,7 +3,7 @@
     "event" : "JianXiongEffectEvent",
     "data" : {
       "playerId" : "player-b",
-      "sourceCardId" : "BS8008",
+      "sourceCardIds" : [ "BS8008" ],
       "taken" : true
     },
     "message" : "奸雄發動"

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_a.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "SS7007" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 1,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_b.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "SS7007" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Minister",
+      "hp" : 1,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ "SS7007" ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_c.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "SS7007" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 1,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ "BS9009" ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_d.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "SS7007" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 1,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_a.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "SS7007" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_b.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "SS7007" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Minister",
+      "hp" : 3,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ "SS7007" ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_c.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "SS7007" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ "BS9009" ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_d.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "SS7007" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ "BHJ037" ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_duel_accept_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_duel_accept_for_player_a.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "SSA001" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_duel_accept_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_duel_accept_for_player_b.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "SSA001" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Minister",
+      "hp" : 3,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ "SSA001" ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_duel_accept_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_duel_accept_for_player_c.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "SSA001" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_duel_accept_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_duel_accept_for_player_d.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "SSA001" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : false
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_revived_accept_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_revived_accept_for_player_a.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "BS8008" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 1,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_revived_accept_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_revived_accept_for_player_b.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "BS8008" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Minister",
+      "hp" : 1,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ "BS8008" ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_revived_accept_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_revived_accept_for_player_c.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "BS8008" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 1,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_revived_accept_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_revived_accept_for_player_d.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "BS8008" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 1,
+      "hand" : {
+        "size" : 1,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_a.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardId" : "BS8008",
+      "taken" : false
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "放棄奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_a.json
@@ -3,7 +3,7 @@
     "event" : "JianXiongEffectEvent",
     "data" : {
       "playerId" : "player-b",
-      "sourceCardId" : "BS8008",
+      "sourceCardIds" : [ "BS8008" ],
       "taken" : false
     },
     "message" : "奸雄發動"

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_b.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardId" : "BS8008",
+      "taken" : false
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Minister",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "放棄奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_c.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardId" : "BS8008",
+      "taken" : false
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "放棄奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_c.json
@@ -3,7 +3,7 @@
     "event" : "JianXiongEffectEvent",
     "data" : {
       "playerId" : "player-b",
-      "sourceCardId" : "BS8008",
+      "sourceCardIds" : [ "BS8008" ],
       "taken" : false
     },
     "message" : "奸雄發動"

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_d.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardId" : "BS8008",
+      "taken" : false
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "放棄奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_skip_for_player_d.json
@@ -3,7 +3,7 @@
     "event" : "JianXiongEffectEvent",
     "data" : {
       "playerId" : "player-b",
-      "sourceCardId" : "BS8008",
+      "sourceCardIds" : [ "BS8008" ],
       "taken" : false
     },
     "message" : "奸雄發動"

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_accept_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_accept_for_player_a.json
@@ -3,8 +3,8 @@
     "event" : "JianXiongEffectEvent",
     "data" : {
       "playerId" : "player-b",
-      "sourceCardIds" : [ "BS8008" ],
-      "taken" : false
+      "sourceCardIds" : [ "BH3029", "BH4030" ],
+      "taken" : true
     },
     "message" : "奸雄發動"
   } ],
@@ -18,15 +18,15 @@
         "size" : 0,
         "cardIds" : [ ]
       },
-      "equipments" : [ "", "", "", "" ],
+      "equipments" : [ "ESQ025", "", "", "" ],
       "delayScrolls" : [ ]
     }, {
       "id" : "player-b",
       "generalId" : "WEI001",
-      "roleId" : "Minister",
+      "roleId" : "",
       "hp" : 3,
       "hand" : {
-        "size" : 0,
+        "size" : 2,
         "cardIds" : [ ]
       },
       "equipments" : [ "", "", "", "" ],
@@ -63,7 +63,7 @@
     },
     "gamePhase" : "Normal"
   },
-  "message" : "放棄奸雄",
+  "message" : "player-b 發動奸雄",
   "gameId" : "my-id",
-  "playerId" : "player-b"
+  "playerId" : "player-a"
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_accept_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_accept_for_player_b.json
@@ -3,8 +3,8 @@
     "event" : "JianXiongEffectEvent",
     "data" : {
       "playerId" : "player-b",
-      "sourceCardIds" : [ "BS8008" ],
-      "taken" : false
+      "sourceCardIds" : [ "BH3029", "BH4030" ],
+      "taken" : true
     },
     "message" : "奸雄發動"
   } ],
@@ -18,7 +18,7 @@
         "size" : 0,
         "cardIds" : [ ]
       },
-      "equipments" : [ "", "", "", "" ],
+      "equipments" : [ "ESQ025", "", "", "" ],
       "delayScrolls" : [ ]
     }, {
       "id" : "player-b",
@@ -26,8 +26,8 @@
       "roleId" : "Minister",
       "hp" : 3,
       "hand" : {
-        "size" : 0,
-        "cardIds" : [ ]
+        "size" : 2,
+        "cardIds" : [ "BH3029", "BH4030" ]
       },
       "equipments" : [ "", "", "", "" ],
       "delayScrolls" : [ ]
@@ -63,7 +63,7 @@
     },
     "gamePhase" : "Normal"
   },
-  "message" : "放棄奸雄",
+  "message" : "player-b 發動奸雄",
   "gameId" : "my-id",
   "playerId" : "player-b"
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_accept_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_accept_for_player_c.json
@@ -3,8 +3,8 @@
     "event" : "JianXiongEffectEvent",
     "data" : {
       "playerId" : "player-b",
-      "sourceCardIds" : [ "BS8008" ],
-      "taken" : false
+      "sourceCardIds" : [ "BH3029", "BH4030" ],
+      "taken" : true
     },
     "message" : "奸雄發動"
   } ],
@@ -18,15 +18,15 @@
         "size" : 0,
         "cardIds" : [ ]
       },
-      "equipments" : [ "", "", "", "" ],
+      "equipments" : [ "ESQ025", "", "", "" ],
       "delayScrolls" : [ ]
     }, {
       "id" : "player-b",
       "generalId" : "WEI001",
-      "roleId" : "Minister",
+      "roleId" : "",
       "hp" : 3,
       "hand" : {
-        "size" : 0,
+        "size" : 2,
         "cardIds" : [ ]
       },
       "equipments" : [ "", "", "", "" ],
@@ -34,7 +34,7 @@
     }, {
       "id" : "player-c",
       "generalId" : "SHU001",
-      "roleId" : "",
+      "roleId" : "Rebel",
       "hp" : 4,
       "hand" : {
         "size" : 0,
@@ -63,7 +63,7 @@
     },
     "gamePhase" : "Normal"
   },
-  "message" : "放棄奸雄",
+  "message" : "player-b 發動奸雄",
   "gameId" : "my-id",
-  "playerId" : "player-b"
+  "playerId" : "player-c"
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_accept_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_accept_for_player_d.json
@@ -3,8 +3,8 @@
     "event" : "JianXiongEffectEvent",
     "data" : {
       "playerId" : "player-b",
-      "sourceCardIds" : [ "BS8008" ],
-      "taken" : false
+      "sourceCardIds" : [ "BH3029", "BH4030" ],
+      "taken" : true
     },
     "message" : "奸雄發動"
   } ],
@@ -18,15 +18,15 @@
         "size" : 0,
         "cardIds" : [ ]
       },
-      "equipments" : [ "", "", "", "" ],
+      "equipments" : [ "ESQ025", "", "", "" ],
       "delayScrolls" : [ ]
     }, {
       "id" : "player-b",
       "generalId" : "WEI001",
-      "roleId" : "Minister",
+      "roleId" : "",
       "hp" : 3,
       "hand" : {
-        "size" : 0,
+        "size" : 2,
         "cardIds" : [ ]
       },
       "equipments" : [ "", "", "", "" ],
@@ -45,7 +45,7 @@
     }, {
       "id" : "player-d",
       "generalId" : "SHU001",
-      "roleId" : "",
+      "roleId" : "Minister",
       "hp" : 4,
       "hand" : {
         "size" : 0,
@@ -63,7 +63,7 @@
     },
     "gamePhase" : "Normal"
   },
-  "message" : "放棄奸雄",
+  "message" : "player-b 發動奸雄",
   "gameId" : "my-id",
-  "playerId" : "player-b"
+  "playerId" : "player-d"
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_revived_accept_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_revived_accept_for_player_a.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "BH3029", "BH4030" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 1,
+      "hand" : {
+        "size" : 2,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_revived_accept_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_revived_accept_for_player_b.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "BH3029", "BH4030" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Minister",
+      "hp" : 1,
+      "hand" : {
+        "size" : 2,
+        "cardIds" : [ "BH3029", "BH4030" ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_revived_accept_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_revived_accept_for_player_c.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "BH3029", "BH4030" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 1,
+      "hand" : {
+        "size" : 2,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_revived_accept_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_viper_spear_revived_accept_for_player_d.json
@@ -1,0 +1,69 @@
+{
+  "events" : [ {
+    "event" : "JianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "BH3029", "BH4030" ],
+      "taken" : true
+    },
+    "message" : "奸雄發動"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "ESQ025", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "",
+      "hp" : 1,
+      "hand" : {
+        "size" : 2,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU001",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "SHU001",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "player-b 發動奸雄",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}


### PR DESCRIPTION
## Summary
- 建立 **Skill 抽象骨架** (`skill/Skill`, `skill/trigger/OnDamagedSkill`, `skill/context/DamageContext`, `skill/registry/SkillRegistry|SkillEngine`)，讓後續 34 個武將技可以加新檔即用，無需在 `Game` / `Behavior` / `Card` 散布 `if (general == X)` 判斷
- 第一個 concrete skill：**奸雄**（曹操 WEI001，受傷觸發類）
  - 受到殺造成的傷害後，可選 `ACCEPT`（收到那張殺）或 `SKIP`
  - 整合點：`Game.getDamagedEvent` → `SkillEngine.onDamaged`
  - 新增 API：`POST /api/games/{gameId}/player:useJianXiongEffect`

## v1 範圍 / TODO
**接受的觸發**：
- `sourceCard instanceof Kill`（普通殺、虛擬殺等）
- 受傷者仍存活
- sourceCard 仍在棄牌堆

**留 TODO（後續對應類技能再做）**：
- AOE 觸發（南蠻入侵 / 萬箭齊發 — sourceCard 是 scroll）
- 決鬥 / 火攻 等非 Kill 來源
- 多點傷害多次觸發
- dying 觸發

## 檔案異動
**新增**：
- `domain/.../skill/{Skill,OnDamagedSkill,DamageContext,SkillRegistry,SkillEngine,wei/JianXiongSkill}` (6 檔)
- `domain/.../behavior/behavior/WaitingJianXiongResponseBehavior`
- `domain/.../events/{AskJianXiongEffectEvent, JianXiongEffectEvent}`
- `app/.../usecase/UseJianXiongEffectUseCase`
- `spring/.../{controller/dto, presenter}/UseJianXiongEffect*` + GameController endpoint + WebSocketBroadCast push method
- `domain/.../JianXiongSkillTest`（4 case）
- `spring/.../e2e/skill/JianXiongTest`（2 case，accept / skip）+ 8 JSON fixtures

**修改**：
- `domain/.../Game.java`：getDamagedEvent 加 `SkillEngine.onDamaged` hook + 新增 `playerUseJianXiongEffect` method
- `domain/.../handcard/Graveyard.java`：加 `contains(cardId)` / `removeCard(cardId)` helper
- `spring/.../presenter/{UseEquipmentEffectPresenter, mapper/DomainEventToViewModelMapper}`：註冊新 ViewModel
- `spring/.../repository/data/BehaviorData.java`：MongoDB 還原 `WaitingJianXiongResponseBehavior`

## Test plan
- [x] Domain test：`JianXiongSkillTest` 4/4 過（accept / skip / 非曹操不觸發 / 非 Kill 不觸發）
- [x] Domain 全套測試 370/370 過
- [x] E2E：`JianXiongTest` 2/2 過（accept / skip + JSON fixture）
- [x] Spring 全套 e2e 228/228 過（含 ArrowBarrage / BarbarianInvasion 等 AOE，因 fix `attackerPlayerId` 空字串問題後通過）

Refs #160（武將技實作 Epic）

🤖 Generated with [Claude Code](https://claude.com/claude-code)