### PR TITLE
refactor: 方天畫戟 DTO 合併 targets 為單一 list

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -483,8 +483,7 @@ POST /api/games/{gameId}/player:useHeavenlyDoubleHalberdKill
 |------|------|------|
 | playerId | String | 攻擊者玩家 ID（裝備方天畫戟） |
 | cardId | String | 要打出的殺 cardId（必須為攻擊者**最後一張手牌**） |
-| primaryTargetPlayerId | String | 主要目標玩家 ID |
-| additionalTargetPlayerIds | List\<String\> | 額外目標玩家 ID（0~2 名；須在攻擊範圍內） |
+| targetPlayerIds | List\<String\> | 全部目標玩家 ID（size 1~3；index 0 為主要目標；不重複、不含自己、皆需在攻擊範圍內） |
 
 **觸發時機**：攻擊者裝備方天畫戟、手上**只剩一張殺**時主動呼叫（不透過 `playCard` API）
 
@@ -502,8 +501,8 @@ A (裝備方天畫戟) 呼叫本 API → 棄最後一張殺到墓地
 **特殊情況**：
 - 攻擊者必須裝備方天畫戟
 - 該殺必須是攻擊者最後一張手牌（出牌後手牌為空才會觸發武器效果）
-- 額外目標必須在攻擊者攻擊範圍內、且不能與主要目標重複
-- 額外目標數為 0 時行為等同普通殺
+- 所有目標皆需在攻擊者攻擊範圍內、不重複、不可含攻擊者自己
+- 單目標時（`targetPlayerIds.size() == 1`）短路為一般殺
 - 中間目標進入瀕死：暫停 polling，dying flow 結束後恢復下一目標詢問
 - 可與八卦陣 / 青釭劍 / 各防具並存：目標各自獨立判定
 

--- a/LegendsOfTheThreeKingdoms/app/src/main/java/com/gaas/threeKingdoms/usecase/UseHeavenlyDoubleHalberdKillUseCase.java
+++ b/LegendsOfTheThreeKingdoms/app/src/main/java/com/gaas/threeKingdoms/usecase/UseHeavenlyDoubleHalberdKillUseCase.java
@@ -23,8 +23,7 @@ public class UseHeavenlyDoubleHalberdKillUseCase {
         List<DomainEvent> events = game.playerUseHeavenlyDoubleHalberdKill(
                 request.playerId,
                 request.cardId,
-                request.primaryTargetPlayerId,
-                request.additionalTargetPlayerIds);
+                request.targetPlayerIds);
         gameRepository.save(game);
         presenter.renderEvents(events);
     }
@@ -35,8 +34,8 @@ public class UseHeavenlyDoubleHalberdKillUseCase {
     public static class UseHeavenlyDoubleHalberdKillRequest {
         private String playerId;
         private String cardId;
-        private String primaryTargetPlayerId;
-        private List<String> additionalTargetPlayerIds; // size 0..2
+        /** 全部目標 id；size 1~3，index 0 為主要目標 */
+        private List<String> targetPlayerIds;
     }
 
     public interface UseHeavenlyDoubleHalberdKillPresenter<T> {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -981,9 +981,12 @@ public class Game {
             throw new IllegalStateException("Halberd effect only usable when the Kill is the last hand card");
         }
 
-        // 6. 目標列表驗證：size 1~3、不重複、不含自己
-        if (targetPlayerIds == null || targetPlayerIds.isEmpty() || targetPlayerIds.size() > 3) {
-            throw new IllegalArgumentException("targetPlayerIds size must be 1~3");
+        // 6. 目標列表驗證：null / size 1~3 / 不重複 / 不含自己
+        if (targetPlayerIds == null) {
+            throw new IllegalArgumentException("targetPlayerIds is required");
+        }
+        if (targetPlayerIds.isEmpty() || targetPlayerIds.size() > 3) {
+            throw new IllegalArgumentException("targetPlayerIds size must be 1~3, got " + targetPlayerIds.size());
         }
         if (new HashSet<>(targetPlayerIds).size() != targetPlayerIds.size()) {
             throw new IllegalArgumentException("Duplicate targets");
@@ -992,31 +995,32 @@ public class Game {
             throw new IllegalArgumentException("Cannot target self");
         }
 
-        // 7. 短路：只有 1 個目標 → 行為等同普通殺，走正常 playCard 路徑
-        if (targetPlayerIds.size() == 1) {
-            return playerPlayCard(playerId, cardId, targetPlayerIds.get(0), PlayType.ACTIVE.getPlayType());
-        }
-
-        // 8. 多目標 — 驗證攻擊範圍 + 取得 primary
-        Player primaryTarget = getPlayer(targetPlayerIds.get(0));
+        // 7. 攻擊範圍驗證（兩條路徑都套用，避免 short-circuit 隱式依賴下游 handler）
         for (String targetId : targetPlayerIds) {
-            Player target = getPlayer(targetId);
-            if (!isInAttackRange(attacker, target)) {
+            if (!isInAttackRange(attacker, getPlayer(targetId))) {
                 throw new IllegalStateException(String.format("%s is not in attack range", targetId));
             }
         }
 
-        // 9. 回合出殺次數限制（考慮諸葛連弩——實際上不會同時裝兩把武器，但保留邏輯對稱性）
+        // 8. 短路：只有 1 個目標 → 行為等同普通殺，走正常 playCard 路徑
+        if (targetPlayerIds.size() == 1) {
+            return playerPlayCard(playerId, cardId, targetPlayerIds.get(0), PlayType.ACTIVE.getPlayType());
+        }
+
+        // 9. 多目標 — 取得 primary
+        Player primaryTarget = getPlayer(targetPlayerIds.get(0));
+
+        // 10. 回合出殺次數限制（考慮諸葛連弩——實際上不會同時裝兩把武器，但保留邏輯對稱性）
         if (currentRound.isShowKill() && !(attacker.getEquipmentWeaponCard() instanceof RepeatingCrossbowCard)) {
             throw new IllegalStateException("Player already played Kill Card");
         }
 
-        // 10. 棄殺到墓地，標記本回合已出殺
+        // 11. 棄殺到墓地，標記本回合已出殺
         HandCard killCard = attacker.playCard(cardId);
         graveyard.add(killCard);
         currentRound.setShowKill(true);
 
-        // 11. push HeavenlyDoubleHalberdKillBehavior
+        // 12. push HeavenlyDoubleHalberdKillBehavior
         HeavenlyDoubleHalberdKillBehavior behavior = new HeavenlyDoubleHalberdKillBehavior(
                 this, attacker, targetPlayerIds, primaryTarget, cardId, killCard);
         updateTopBehavior(behavior);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -953,8 +953,7 @@ public class Game {
 
     public List<DomainEvent> playerUseHeavenlyDoubleHalberdKill(String playerId,
                                                                  String cardId,
-                                                                 String primaryTargetPlayerId,
-                                                                 List<String> additionalTargetPlayerIds) {
+                                                                 List<String> targetPlayerIds) {
         Player attacker = getPlayer(playerId);
 
         // 1. activePlayer 驗證
@@ -982,54 +981,44 @@ public class Game {
             throw new IllegalStateException("Halberd effect only usable when the Kill is the last hand card");
         }
 
-        // 6. primary target
-        Player primaryTarget = getPlayer(primaryTargetPlayerId);
-        if (playerId.equals(primaryTargetPlayerId)) {
-            throw new IllegalArgumentException("Cannot target self");
+        // 6. 目標列表驗證：size 1~3、不重複、不含自己
+        if (targetPlayerIds == null || targetPlayerIds.isEmpty() || targetPlayerIds.size() > 3) {
+            throw new IllegalArgumentException("targetPlayerIds size must be 1~3");
         }
-
-        // 7. additional targets 驗證
-        List<String> additionalIds = additionalTargetPlayerIds == null ? new ArrayList<>() : additionalTargetPlayerIds;
-        if (additionalIds.size() > 2) {
-            throw new IllegalArgumentException("At most 2 additional targets");
-        }
-
-        // 8. 短路：沒有 additional target → 走正常 playCard 路徑
-        if (additionalIds.isEmpty()) {
-            return playerPlayCard(playerId, cardId, primaryTargetPlayerId, PlayType.ACTIVE.getPlayType());
-        }
-
-        // 9. 組成完整目標列表並檢查重複 / 自己 / 存活 / 攻擊範圍
-        List<String> fullTargets = new ArrayList<>();
-        fullTargets.add(primaryTargetPlayerId);
-        fullTargets.addAll(additionalIds);
-
-        if (new HashSet<>(fullTargets).size() != fullTargets.size()) {
+        if (new HashSet<>(targetPlayerIds).size() != targetPlayerIds.size()) {
             throw new IllegalArgumentException("Duplicate targets");
         }
-        if (fullTargets.contains(playerId)) {
+        if (targetPlayerIds.contains(playerId)) {
             throw new IllegalArgumentException("Cannot target self");
         }
-        for (String targetId : fullTargets) {
+
+        // 7. 短路：只有 1 個目標 → 行為等同普通殺，走正常 playCard 路徑
+        if (targetPlayerIds.size() == 1) {
+            return playerPlayCard(playerId, cardId, targetPlayerIds.get(0), PlayType.ACTIVE.getPlayType());
+        }
+
+        // 8. 多目標 — 驗證攻擊範圍 + 取得 primary
+        Player primaryTarget = getPlayer(targetPlayerIds.get(0));
+        for (String targetId : targetPlayerIds) {
             Player target = getPlayer(targetId);
             if (!isInAttackRange(attacker, target)) {
                 throw new IllegalStateException(String.format("%s is not in attack range", targetId));
             }
         }
 
-        // 10. 回合出殺次數限制（考慮諸葛連弩——實際上不會同時裝兩把武器，但保留邏輯對稱性）
+        // 9. 回合出殺次數限制（考慮諸葛連弩——實際上不會同時裝兩把武器，但保留邏輯對稱性）
         if (currentRound.isShowKill() && !(attacker.getEquipmentWeaponCard() instanceof RepeatingCrossbowCard)) {
             throw new IllegalStateException("Player already played Kill Card");
         }
 
-        // 11. 棄殺到墓地，標記本回合已出殺
+        // 10. 棄殺到墓地，標記本回合已出殺
         HandCard killCard = attacker.playCard(cardId);
         graveyard.add(killCard);
         currentRound.setShowKill(true);
 
-        // 12. push HeavenlyDoubleHalberdKillBehavior
+        // 11. push HeavenlyDoubleHalberdKillBehavior
         HeavenlyDoubleHalberdKillBehavior behavior = new HeavenlyDoubleHalberdKillBehavior(
-                this, attacker, fullTargets, primaryTarget, cardId, killCard);
+                this, attacker, targetPlayerIds, primaryTarget, cardId, killCard);
         updateTopBehavior(behavior);
 
         List<DomainEvent> events = behavior.playerAction();

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HeavenlyDoubleHalberdTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HeavenlyDoubleHalberdTest.java
@@ -82,9 +82,9 @@ public class HeavenlyDoubleHalberdTest {
         assertEquals(List.of("player-b", "player-c"), trigger.getTargetPlayerIds());
     }
 
-    @DisplayName("A 用方天畫戟出殺但 0 個額外目標 → 短路走一般 playCard 流程，不產生 halberd 事件")
+    @DisplayName("A 用方天畫戟出殺但 targetPlayerIds 只有 1 個目標 → 短路走一般 playCard 流程，不產生 halberd 事件")
     @Test
-    public void testUseHalberdKill_ZeroAdditionalTargets_ShortCircuits() {
+    public void testUseHalberdKill_SingleTarget_ShortCircuits() {
         Game game = createGame();
         Player playerA = game.getPlayer("player-a");
         equipHalberdWithSingleKill(playerA);
@@ -286,9 +286,9 @@ public class HeavenlyDoubleHalberdTest {
                         "player-a", BS8008.getCardId(), List.of("player-b", "player-c")));
     }
 
-    @DisplayName("additionalTargets 超過 2 → 拋例外")
+    @DisplayName("targetPlayerIds 超過 3 → 拋例外")
     @Test
-    public void testMoreThanTwoAdditionalTargets_ThrowsException() {
+    public void testMoreThanThreeTargets_ThrowsException() {
         Game game = createGame();
         Player playerA = game.getPlayer("player-a");
         equipHalberdWithSingleKill(playerA);
@@ -299,9 +299,9 @@ public class HeavenlyDoubleHalberdTest {
                         List.of("player-b", "player-c", "player-d", "player-e")));
     }
 
-    @DisplayName("additionalTargets 包含重複玩家 → 拋例外")
+    @DisplayName("targetPlayerIds 包含重複玩家 → 拋例外")
     @Test
-    public void testDuplicateAdditionalTarget_ThrowsException() {
+    public void testDuplicateTarget_ThrowsException() {
         Game game = createGame();
         Player playerA = game.getPlayer("player-a");
         equipHalberdWithSingleKill(playerA);
@@ -312,9 +312,9 @@ public class HeavenlyDoubleHalberdTest {
                         List.of("player-b", "player-b", "player-c")));
     }
 
-    @DisplayName("additionalTargets 包含自己 → 拋例外")
+    @DisplayName("targetPlayerIds 包含自己（非 index 0） → 拋例外")
     @Test
-    public void testSelfAsAdditionalTarget_ThrowsException() {
+    public void testSelfAsNonPrimaryTarget_ThrowsException() {
         Game game = createGame();
         Player playerA = game.getPlayer("player-a");
         equipHalberdWithSingleKill(playerA);
@@ -325,7 +325,7 @@ public class HeavenlyDoubleHalberdTest {
                         List.of("player-b", "player-c", "player-a")));
     }
 
-    @DisplayName("primaryTarget 是自己 → 拋例外")
+    @DisplayName("targetPlayerIds index 0（primary）是自己 → 拋例外")
     @Test
     public void testSelfAsPrimaryTarget_ThrowsException() {
         Game game = createGame();
@@ -381,6 +381,32 @@ public class HeavenlyDoubleHalberdTest {
         assertThrows(IllegalStateException.class, () ->
                 game.playerUseHeavenlyDoubleHalberdKill(
                         "player-a", BS9009.getCardId(), List.of("player-c", "player-d")));
+    }
+
+    @DisplayName("targetPlayerIds 為 null → 拋例外")
+    @Test
+    public void testNullTargetPlayerIds_ThrowsException() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        equipHalberdWithSingleKill(playerA);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseHeavenlyDoubleHalberdKill(
+                        "player-a", BS8008.getCardId(), null));
+        assertTrue(ex.getMessage().contains("required"),
+                "null 應觸發 'required' message，而非 'size must be 1~3'");
+    }
+
+    @DisplayName("targetPlayerIds 為空 list → 拋例外（不可短路為一般殺）")
+    @Test
+    public void testEmptyTargetPlayerIds_ThrowsException() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        equipHalberdWithSingleKill(playerA);
+
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseHeavenlyDoubleHalberdKill(
+                        "player-a", BS8008.getCardId(), List.of()));
     }
 
     // -------- Helpers --------

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HeavenlyDoubleHalberdTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HeavenlyDoubleHalberdTest.java
@@ -50,7 +50,7 @@ public class HeavenlyDoubleHalberdTest {
         equipHalberdWithSingleKill(playerA);
 
         List<DomainEvent> events = game.playerUseHeavenlyDoubleHalberdKill(
-                "player-a", BS8008.getCardId(), "player-b", List.of("player-c", "player-d"));
+                "player-a", BS8008.getCardId(), List.of("player-b", "player-c", "player-d"));
 
         HeavenlyDoubleHalberdKillTriggerEvent trigger = events.stream()
                 .filter(e -> e instanceof HeavenlyDoubleHalberdKillTriggerEvent)
@@ -73,7 +73,7 @@ public class HeavenlyDoubleHalberdTest {
         equipHalberdWithSingleKill(playerA);
 
         List<DomainEvent> events = game.playerUseHeavenlyDoubleHalberdKill(
-                "player-a", BS8008.getCardId(), "player-b", List.of("player-c"));
+                "player-a", BS8008.getCardId(), List.of("player-b", "player-c"));
 
         HeavenlyDoubleHalberdKillTriggerEvent trigger = events.stream()
                 .filter(e -> e instanceof HeavenlyDoubleHalberdKillTriggerEvent)
@@ -90,7 +90,7 @@ public class HeavenlyDoubleHalberdTest {
         equipHalberdWithSingleKill(playerA);
 
         List<DomainEvent> events = game.playerUseHeavenlyDoubleHalberdKill(
-                "player-a", BS8008.getCardId(), "player-b", List.of());
+                "player-a", BS8008.getCardId(), List.of("player-b"));
 
         // 走 NormalActiveKillBehavior 路徑
         assertFalse(game.getTopBehavior().isEmpty());
@@ -113,7 +113,7 @@ public class HeavenlyDoubleHalberdTest {
         equipHalberdWithSingleKill(playerA);
 
         game.playerUseHeavenlyDoubleHalberdKill(
-                "player-a", BS8008.getCardId(), "player-b", List.of("player-c", "player-d"));
+                "player-a", BS8008.getCardId(), List.of("player-b", "player-c", "player-d"));
 
         game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
         game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
@@ -139,7 +139,7 @@ public class HeavenlyDoubleHalberdTest {
         playerD.getHand().addCardToHand(new Dodge(BD2080));
 
         game.playerUseHeavenlyDoubleHalberdKill(
-                "player-a", BS8008.getCardId(), "player-b", List.of("player-c", "player-d"));
+                "player-a", BS8008.getCardId(), List.of("player-b", "player-c", "player-d"));
 
         game.playerPlayCard("player-b", BH2028.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
         game.playerPlayCard("player-c", BH2041.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
@@ -164,7 +164,7 @@ public class HeavenlyDoubleHalberdTest {
         playerD.getHand().addCardToHand(new Dodge(BD2080));
 
         game.playerUseHeavenlyDoubleHalberdKill(
-                "player-a", BS8008.getCardId(), "player-b", List.of("player-c", "player-d"));
+                "player-a", BS8008.getCardId(), List.of("player-b", "player-c", "player-d"));
 
         game.playerPlayCard("player-b", BH2028.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
         game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
@@ -186,7 +186,7 @@ public class HeavenlyDoubleHalberdTest {
         playerB.getEquipment().setArmor(new EightDiagramTactic(ES2015));
 
         List<DomainEvent> events = game.playerUseHeavenlyDoubleHalberdKill(
-                "player-a", BS8008.getCardId(), "player-b", List.of("player-c"));
+                "player-a", BS8008.getCardId(), List.of("player-b", "player-c"));
 
         assertTrue(events.stream().anyMatch(e -> e instanceof AskPlayEquipmentEffectEvent));
         assertFalse(events.stream().anyMatch(e -> e instanceof AskDodgeEvent));
@@ -204,7 +204,7 @@ public class HeavenlyDoubleHalberdTest {
         playerB.getHand().addCardToHand(new Dodge(BH2028));
 
         game.playerUseHeavenlyDoubleHalberdKill(
-                "player-a", BS8008.getCardId(), "player-b", List.of("player-c", "player-d"));
+                "player-a", BS8008.getCardId(), List.of("player-b", "player-c", "player-d"));
 
         // B 出閃
         game.playerPlayCard("player-b", BH2028.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
@@ -237,7 +237,7 @@ public class HeavenlyDoubleHalberdTest {
         equipHalberdWithSingleKill(playerA);
 
         game.playerUseHeavenlyDoubleHalberdKill(
-                "player-a", BS8008.getCardId(), "player-b", List.of("player-d"));
+                "player-a", BS8008.getCardId(), List.of("player-b", "player-d"));
 
         // B 不出閃
         game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
@@ -270,7 +270,7 @@ public class HeavenlyDoubleHalberdTest {
 
         assertThrows(IllegalStateException.class, () ->
                 game.playerUseHeavenlyDoubleHalberdKill(
-                        "player-a", BS8008.getCardId(), "player-b", List.of("player-c")));
+                        "player-a", BS8008.getCardId(), List.of("player-b", "player-c")));
     }
 
     @DisplayName("A 的殺不是最後一張手牌 → 拋例外")
@@ -283,7 +283,7 @@ public class HeavenlyDoubleHalberdTest {
 
         assertThrows(IllegalStateException.class, () ->
                 game.playerUseHeavenlyDoubleHalberdKill(
-                        "player-a", BS8008.getCardId(), "player-b", List.of("player-c")));
+                        "player-a", BS8008.getCardId(), List.of("player-b", "player-c")));
     }
 
     @DisplayName("additionalTargets 超過 2 → 拋例外")
@@ -295,8 +295,8 @@ public class HeavenlyDoubleHalberdTest {
 
         assertThrows(IllegalArgumentException.class, () ->
                 game.playerUseHeavenlyDoubleHalberdKill(
-                        "player-a", BS8008.getCardId(), "player-b",
-                        List.of("player-c", "player-d", "player-e")));
+                        "player-a", BS8008.getCardId(),
+                        List.of("player-b", "player-c", "player-d", "player-e")));
     }
 
     @DisplayName("additionalTargets 包含重複玩家 → 拋例外")
@@ -308,8 +308,8 @@ public class HeavenlyDoubleHalberdTest {
 
         assertThrows(IllegalArgumentException.class, () ->
                 game.playerUseHeavenlyDoubleHalberdKill(
-                        "player-a", BS8008.getCardId(), "player-b",
-                        List.of("player-b", "player-c")));
+                        "player-a", BS8008.getCardId(),
+                        List.of("player-b", "player-b", "player-c")));
     }
 
     @DisplayName("additionalTargets 包含自己 → 拋例外")
@@ -321,8 +321,8 @@ public class HeavenlyDoubleHalberdTest {
 
         assertThrows(IllegalArgumentException.class, () ->
                 game.playerUseHeavenlyDoubleHalberdKill(
-                        "player-a", BS8008.getCardId(), "player-b",
-                        List.of("player-c", "player-a")));
+                        "player-a", BS8008.getCardId(),
+                        List.of("player-b", "player-c", "player-a")));
     }
 
     @DisplayName("primaryTarget 是自己 → 拋例外")
@@ -334,8 +334,8 @@ public class HeavenlyDoubleHalberdTest {
 
         assertThrows(IllegalArgumentException.class, () ->
                 game.playerUseHeavenlyDoubleHalberdKill(
-                        "player-a", BS8008.getCardId(), "player-a",
-                        List.of("player-b", "player-c")));
+                        "player-a", BS8008.getCardId(),
+                        List.of("player-a", "player-b", "player-c")));
     }
 
     @DisplayName("cardId 不在手牌 → 拋例外")
@@ -348,7 +348,7 @@ public class HeavenlyDoubleHalberdTest {
 
         assertThrows(IllegalArgumentException.class, () ->
                 game.playerUseHeavenlyDoubleHalberdKill(
-                        "player-a", BS9009.getCardId(), "player-b", List.of("player-c")));
+                        "player-a", BS9009.getCardId(), List.of("player-b", "player-c")));
     }
 
     @DisplayName("cardId 指向非殺 → 拋例外")
@@ -361,7 +361,7 @@ public class HeavenlyDoubleHalberdTest {
 
         assertThrows(IllegalArgumentException.class, () ->
                 game.playerUseHeavenlyDoubleHalberdKill(
-                        "player-a", BH3029.getCardId(), "player-b", List.of("player-c")));
+                        "player-a", BH3029.getCardId(), List.of("player-b", "player-c")));
     }
 
     @DisplayName("本回合已出過殺 → 拋例外")
@@ -380,7 +380,7 @@ public class HeavenlyDoubleHalberdTest {
         // 再嘗試用方天畫戟出殺 → 應拋例外（此時只剩 BS9009 一張，滿足 last hand card）
         assertThrows(IllegalStateException.class, () ->
                 game.playerUseHeavenlyDoubleHalberdKill(
-                        "player-a", BS9009.getCardId(), "player-c", List.of("player-d")));
+                        "player-a", BS9009.getCardId(), List.of("player-c", "player-d")));
     }
 
     // -------- Helpers --------

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/UseHeavenlyDoubleHalberdKillRequest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/UseHeavenlyDoubleHalberdKillRequest.java
@@ -11,11 +11,14 @@ import java.util.List;
 public class UseHeavenlyDoubleHalberdKillRequest {
     private String playerId;
     private String cardId;
-    private String primaryTargetPlayerId;
-    private List<String> additionalTargetPlayerIds;
+    /**
+     * 全部目標玩家 id（含主要與額外目標）；size 1~3、不重複、不能含自己、皆需在攻擊範圍。
+     * Index 0 為主要目標。
+     */
+    private List<String> targetPlayerIds;
 
     public UseHeavenlyDoubleHalberdKillUseCase.UseHeavenlyDoubleHalberdKillRequest toUseHeavenlyDoubleHalberdKillRequest() {
         return new UseHeavenlyDoubleHalberdKillUseCase.UseHeavenlyDoubleHalberdKillRequest(
-                playerId, cardId, primaryTargetPlayerId, additionalTargetPlayerIds);
+                playerId, cardId, targetPlayerIds);
     }
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/MockMvcUtil.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/MockMvcUtil.java
@@ -121,9 +121,8 @@ public class MockMvcUtil {
     }
 
     public ResultActions useHeavenlyDoubleHalberdKill(String gameId, String playerId, String cardId,
-                                                      String primaryTargetPlayerId,
-                                                      java.util.List<String> additionalTargetPlayerIds) throws Exception {
-        String additionalJson = additionalTargetPlayerIds.stream()
+                                                      java.util.List<String> targetPlayerIds) throws Exception {
+        String targetsJson = targetPlayerIds.stream()
                 .map(id -> "\"" + id + "\"")
                 .collect(java.util.stream.Collectors.joining(","));
         return this.mockMvc.perform(post("/api/games/" + gameId + "/player:useHeavenlyDoubleHalberdKill")
@@ -131,9 +130,8 @@ public class MockMvcUtil {
                 .content(String.format("""
                         { "playerId": "%s",
                           "cardId": "%s",
-                          "primaryTargetPlayerId": "%s",
-                          "additionalTargetPlayerIds": [%s]
-                        }""", playerId, cardId, primaryTargetPlayerId, additionalJson)));
+                          "targetPlayerIds": [%s]
+                        }""", playerId, cardId, targetsJson)));
     }
 
     public ResultActions playCard(String gameId, String currentPlayerId, String targetPlayerId, String cardId, String playType) throws Exception {

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/equipment/HeavenlyDoubleHalberdTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/equipment/HeavenlyDoubleHalberdTest.java
@@ -52,7 +52,7 @@ public class HeavenlyDoubleHalberdTest extends AbstractBaseIntegrationTest {
         givenPlayerAEquippedHalberdWithSingleKill();
 
         mockMvcUtil.useHeavenlyDoubleHalberdKill(gameId, "player-a", "BS8008",
-                        "player-b", List.of("player-c"))
+                        List.of("player-b", "player-c"))
                 .andExpect(status().isOk()).andReturn();
 
         // 驗證 HeavenlyDoubleHalberdKillTriggerEvent + AskDodgeEvent(B) 有廣播到 4 位玩家
@@ -64,7 +64,7 @@ public class HeavenlyDoubleHalberdTest extends AbstractBaseIntegrationTest {
         givenPlayerAEquippedHalberdWithSingleKill();
 
         mockMvcUtil.useHeavenlyDoubleHalberdKill(gameId, "player-a", "BS8008",
-                        "player-b", List.of("player-c"))
+                        List.of("player-b", "player-c"))
                 .andExpect(status().isOk()).andReturn();
         websocketUtil.popAllPlayerMessage();
 
@@ -96,7 +96,7 @@ public class HeavenlyDoubleHalberdTest extends AbstractBaseIntegrationTest {
         repository.save(game);
 
         mockMvcUtil.useHeavenlyDoubleHalberdKill(gameId, "player-a", "BS8008",
-                        "player-b", List.of("player-c"))
+                        List.of("player-b", "player-c"))
                 .andExpect(status().isOk()).andReturn();
         websocketUtil.popAllPlayerMessage();
 
@@ -116,9 +116,9 @@ public class HeavenlyDoubleHalberdTest extends AbstractBaseIntegrationTest {
     public void testUseHalberdKill_ZeroAdditional_ShortCircuitsToNormalKill() throws Exception {
         givenPlayerAEquippedHalberdWithSingleKill();
 
-        // additional 空陣列 → 短路為一般殺
+        // 單目標 → 短路為一般殺
         mockMvcUtil.useHeavenlyDoubleHalberdKill(gameId, "player-a", "BS8008",
-                        "player-b", List.of())
+                        List.of("player-b"))
                 .andExpect(status().isOk()).andReturn();
 
         // 驗證沒有 HeavenlyDoubleHalberdKillTriggerEvent，只有一般 PlayCardEvent + AskDodgeEvent
@@ -138,7 +138,7 @@ public class HeavenlyDoubleHalberdTest extends AbstractBaseIntegrationTest {
         repository.save(game);
 
         mockMvcUtil.useHeavenlyDoubleHalberdKill(gameId, "player-a", "BS8008",
-                        "player-b", List.of("player-c"))
+                        List.of("player-b", "player-c"))
                 .andExpect(status().is4xxClientError());
     }
 
@@ -158,7 +158,7 @@ public class HeavenlyDoubleHalberdTest extends AbstractBaseIntegrationTest {
 
         // A 有兩張手牌 → halberd 不可觸發
         mockMvcUtil.useHeavenlyDoubleHalberdKill(gameId, "player-a", "BS8008",
-                        "player-b", List.of("player-c"))
+                        List.of("player-b", "player-c"))
                 .andExpect(status().is4xxClientError());
     }
 


### PR DESCRIPTION
## Summary
- `useHeavenlyDoubleHalberdKill` Request DTO 把 `primaryTargetPlayerId: String` + `additionalTargetPlayerIds: List<String>` 合併為單一 `targetPlayerIds: List<String>`（size 1~3、index 0 為主要目標）
- broadcast event / Behavior 內部 / e2e fixture 早已使用合併形式，Request 是唯一拆開的位置；此 PR 對齊整個 endpoint 的 schema
- 同步更新 `Game.playerUseHeavenlyDoubleHalberdKill` 簽名、validation（size / 不重複 / 不含自己 / 攻擊範圍集中），以及 API_DOC.md #19
- 由於前端尚未對接，breaking change 成本最低

## Why now
PR #198 補完 API_DOC #19 時暴露的不對稱。其他位置（event、Behavior、fixture）早已合併，只有 Request 落單。

## Behavior
- `size == 1` 短路為一般殺（保留原本「額外目標數為 0 等同普通殺」語意）
- `size 2~3`：與既有 polling 流程一致

## Test plan
- [x] `mvn -pl domain test`（全綠，370 tests）
- [x] `mvn -pl spring test`（全綠，229 tests）
- [x] `grep "primaryTargetPlayerId\|additionalTargetPlayerIds"` 全 repo 0 hit
- [ ] Reviewer 確認 API_DOC.md #19 文字描述符合新 shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)