### PR TITLE
feat: 武將技 — 護駕（曹操 WEI001 主公技）+ Faction 模型

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -560,6 +560,54 @@ B 對曹操出殺（或丈八蛇矛攻擊）→ 曹操不出閃、扣血未死
 
 ---
 
+## 21. 護駕（曹操主公技）效果選擇
+
+```
+POST /api/games/{gameId}/player:useHuJiaEffect
+```
+
+| 欄位 | 型別 | 說明 |
+|------|------|------|
+| playerId | String | 當前被詢問的魏勢力玩家 ID（不是曹操） |
+| choice | String | `ACCEPT`（代替主公出閃）或 `DECLINE`（拒絕） |
+| cardId | String? | `ACCEPT` 必填，為要打出的閃 cardId；`DECLINE` 時可為 null |
+
+**觸發時機**：曹操（`WEI001`）為主公（`MONARCH`）且 stack 頂為 emit `AskDodgeEvent` 的 behavior 時，系統不發 `AskDodgeEvent`，改為依座位順序（曹操下家起）對每位存活魏勢力武將 broadcast `AskHuJiaEffectEvent`。任一人 ACCEPT → 視為曹操打出此閃；全部 DECLINE → fallback emit 原本的 `AskDodgeEvent(曹操)`。
+
+**啟動條件**（同時成立）：
+1. 受詢問玩家武將為曹操（WEI001）
+2. 曹操為主公（`role == MONARCH`）
+3. 至少有一個其他存活魏勢力武將（`faction == WEI` && 非曹操本人）
+4. Top behavior 為以下 emitter 之一（實作 `HuJiaCompatibleAskDodgeBehavior`）：
+   - `NormalActiveKillBehavior`（普通殺）
+   - `ArrowBarrageBehavior`（萬箭齊發）
+   - `HeavenlyDoubleHalberdKillBehavior`（方天畫戟）
+
+**流程**：
+```
+A 對曹操 (B) 出殺（或萬箭齊發/方天畫戟瞄到曹操）
+  → 系統 push WaitingHuJiaResponseBehavior 並 broadcast AskHuJiaEffectEvent(座位次序下一位 Wei)
+  → activePlayer 切到該 Wei 武將
+  → Wei 武將呼叫本 API：
+    - ACCEPT: Wei 棄一張閃到墓地 → HuJiaEffectEvent(accepted=true)
+              → pop WaitingHuJia → parent behavior 接手「視為曹操打出此閃」的後續（青龍/貫石斧/AOE polling 推進）
+    - DECLINE: HuJiaEffectEvent(accepted=false)
+              → 若還有下一位 Wei：activePlayer 換人、AskHuJiaEffectEvent(next)
+              → 若已是最後一位：pop WaitingHuJia、AskDodgeEvent(曹操)、activePlayer 切回曹操
+```
+
+**特殊情況**：
+- Wei 武將沒有閃：`AskHuJiaEffectEvent.dodgeCardIdsInHand` 為空，只能 DECLINE
+- ACCEPT 但 cardId 不在 Wei 手中 → 400 `IllegalArgumentException`
+- ACCEPT 但 cardId 不是閃 → 400 `IllegalArgumentException`
+- 曹操自己無閃 + 所有 Wei 全 DECLINE → fallback AskDodge(曹操) 後 SKIP 受傷（不影響後續流程）
+- 視為曹操出閃，因此攻擊者的青龍偃月刀 / 貫石斧鏈仍正常觸發
+- v1 範圍：護駕僅在三處 AskDodge emitter（普通殺/萬箭齊發/方天畫戟）攔截；其他二次 AskDodge 場景（八卦陣失敗、青龍鏈、雌雄雙股劍、丈八蛇矛被動殺、瀕死 resume）為 follow-up
+
+**備註**：此 API 獨立於 `playCard`。前端在收到 `AskHuJiaEffectEvent` 時應只開啟被詢問玩家的選擇 UI。
+
+---
+
 ## WebSocket 事件類型
 
 前端透過 WebSocket 接收以下事件，根據事件類型決定 UI 行為：

--- a/LegendsOfTheThreeKingdoms/app/src/main/java/com/gaas/threeKingdoms/usecase/UseHuJiaEffectUseCase.java
+++ b/LegendsOfTheThreeKingdoms/app/src/main/java/com/gaas/threeKingdoms/usecase/UseHuJiaEffectUseCase.java
@@ -1,0 +1,47 @@
+package com.gaas.threeKingdoms.usecase;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.events.AskHuJiaEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.exception.NotFoundException;
+import com.gaas.threeKingdoms.outport.GameRepository;
+import jakarta.inject.Named;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Named
+public class UseHuJiaEffectUseCase {
+    private final GameRepository gameRepository;
+
+    public void execute(String gameId, UseHuJiaEffectRequest request, UseHuJiaEffectPresenter presenter) {
+        Game game = gameRepository.findById(gameId)
+                .orElseThrow(() -> new NotFoundException("Game not found"));
+        List<DomainEvent> events = game.playerUseHuJiaEffect(
+                request.playerId,
+                AskHuJiaEffectEvent.Choice.valueOf(request.choice),
+                request.cardId
+        );
+        gameRepository.save(game);
+        presenter.renderEvents(events);
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UseHuJiaEffectRequest {
+        private String playerId;
+        private String choice;   // "ACCEPT" or "DECLINE"
+        private String cardId;   // 必填 when ACCEPT；DECLINE 時可為 null
+    }
+
+    public interface UseHuJiaEffectPresenter<T> {
+        void renderEvents(List<DomainEvent> events);
+
+        T present();
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -882,6 +882,21 @@ public class Game {
         return events;
     }
 
+    public List<DomainEvent> playerUseHuJiaEffect(String playerId,
+                                                  com.gaas.threeKingdoms.events.AskHuJiaEffectEvent.Choice choice,
+                                                  String cardId) {
+        if (topBehavior.isEmpty()) {
+            throw new IllegalStateException("No active behavior waiting for HuJia effect response");
+        }
+        Behavior behavior = topBehavior.peek();
+        if (!(behavior instanceof com.gaas.threeKingdoms.behavior.behavior.WaitingHuJiaResponseBehavior huJia)) {
+            throw new IllegalStateException("Current behavior is not WaitingHuJiaResponseBehavior");
+        }
+        List<DomainEvent> events = huJia.resolveChoice(playerId, choice, cardId);
+        removeCompletedBehaviors();
+        return events;
+    }
+
     public List<DomainEvent> playerUseStonePiercingAxeEffect(String playerId, AskStonePiercingAxeEffectEvent.Choice choice, List<String> discardCardIds) {
         if (topBehavior.isEmpty()) {
             throw new IllegalStateException("No active behavior waiting for StonePiercingAxe effect response");

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/HuJiaCompatibleAskDodgeBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/HuJiaCompatibleAskDodgeBehavior.java
@@ -1,0 +1,29 @@
+package com.gaas.threeKingdoms.behavior;
+
+import com.gaas.threeKingdoms.events.DomainEvent;
+
+import java.util.List;
+
+/**
+ * Marker + capability：能 host 護駕 substitute 的「會 emit AskDodgeEvent」behavior。
+ *
+ * 當 Wei 武將代替主公曹操出閃後，{@link com.gaas.threeKingdoms.behavior.behavior.WaitingHuJiaResponseBehavior}
+ * 會 pop 自己並 dispatch 到 parent (this) 的 {@code acceptDodgeFromHuJia}，由 parent 負責執行
+ * 後續流程（青龍偃月刀鏈 / 貫石斧鏈 / AOE polling 推進）。
+ *
+ * 實作類別：
+ *   - {@link com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior}
+ *   - {@link com.gaas.threeKingdoms.behavior.behavior.HeavenlyDoubleHalberdKillBehavior}（繼承上者）
+ *   - {@link com.gaas.threeKingdoms.behavior.behavior.ArrowBarrageBehavior}
+ */
+public interface HuJiaCompatibleAskDodgeBehavior {
+
+    /**
+     * Wei 武將已經把代閃 cardId 從手中棄到墓地後，parent 在此繼續未完的 dodge 流程。
+     *
+     * @param dodgedPlayerId 被代替的玩家（曹操）ID
+     * @param weiPlayerId    實際打出閃的 Wei 武將 ID
+     * @param dodgeCardId    被打出的閃 cardId（已在墓地）
+     */
+    List<DomainEvent> acceptDodgeFromHuJia(String dodgedPlayerId, String weiPlayerId, String dodgeCardId);
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
@@ -2,6 +2,7 @@ package com.gaas.threeKingdoms.behavior.behavior;
 
 import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.behavior.Behavior;
+import com.gaas.threeKingdoms.behavior.HuJiaCompatibleAskDodgeBehavior;
 import com.gaas.threeKingdoms.events.AskDodgeEvent;
 import com.gaas.threeKingdoms.events.AskPlayEquipmentEffectEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
@@ -10,6 +11,7 @@ import com.gaas.threeKingdoms.handcard.HandCard;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.round.Stage;
+import com.gaas.threeKingdoms.skill.registry.SkillEngine;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +23,9 @@ import static com.gaas.threeKingdoms.behavior.behavior.WardBehavior.WARD_TARGET_
 import static com.gaas.threeKingdoms.behavior.behavior.WardBehavior.WARD_TRIGGER_PLAYER_ID;
 import static com.gaas.threeKingdoms.handcard.PlayCard.*;
 
-public class ArrowBarrageBehavior extends Behavior implements com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior {
+public class ArrowBarrageBehavior extends Behavior
+        implements com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior,
+                   HuJiaCompatibleAskDodgeBehavior {
 
     @Override
     public boolean isPollingCaller() {
@@ -89,7 +93,7 @@ public class ArrowBarrageBehavior extends Behavior implements com.gaas.threeKing
                 game.getCurrentRound().setStage(Stage.Wait_Equipment_Effect);
                 events.add(new AskPlayEquipmentEffectEvent(targetPlayer.getId(), targetPlayer.getEquipment().getArmor(), List.of(targetPlayer.getId())));
             } else {
-                events.add(new AskDodgeEvent(currentReactionPlayer.getId()));
+                emitAskDodgeOrHuJia(events, targetPlayer);
             }
             game.getCurrentRound().setActivePlayer(currentReactionPlayer);
         }
@@ -142,7 +146,7 @@ public class ArrowBarrageBehavior extends Behavior implements com.gaas.threeKing
                 game.getCurrentRound().setStage(Stage.Wait_Equipment_Effect);
                 events.add(new AskPlayEquipmentEffectEvent(targetPlayer.getId(), targetPlayer.getEquipment().getArmor(), List.of(targetPlayer.getId())));
             } else {
-                events.add(new AskDodgeEvent(currentReactionPlayer.getId()));
+                emitAskDodgeOrHuJia(events, targetPlayer);
             }
             game.getCurrentRound().setActivePlayer(currentReactionPlayer);
         }
@@ -197,6 +201,38 @@ public class ArrowBarrageBehavior extends Behavior implements com.gaas.threeKing
 
     public boolean isInReactionPlayers(String playerId) {
         return reactionPlayers.contains(playerId);
+    }
+
+    /**
+     * AskDodge 前先讓 SkillEngine 介入（護駕等）。
+     */
+    private void emitAskDodgeOrHuJia(List<DomainEvent> events, Player targetPlayer) {
+        Optional<List<DomainEvent>> intercepted = SkillEngine.beforeAskDodge(game, targetPlayer, this);
+        if (intercepted.isPresent()) {
+            events.addAll(intercepted.get());
+        } else {
+            events.add(new AskDodgeEvent(targetPlayer.getId()));
+        }
+    }
+
+    @Override
+    public List<DomainEvent> acceptDodgeFromHuJia(String dodgedPlayerId, String weiPlayerId, String dodgeCardId) {
+        // dodge 已在 WaitingHuJia 中由 Wei 棄入墓地；這裡推進 polling
+        List<DomainEvent> events = new ArrayList<>();
+        currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
+        boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(dodgedPlayerId);
+        if (isLastPlayer) {
+            isOneRound = true;
+            game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
+        } else {
+            game.getCurrentRound().setActivePlayer(currentReactionPlayer);
+        }
+        events.add(game.getGameStatusEvent(dodgedPlayerId + "出閃"));
+        events.add(new PlayCardEvent("出牌", weiPlayerId, "", dodgeCardId, PlayType.ACTIVE.getPlayType()));
+        if (!isLastPlayer) {
+            events.addAll(askNextPlayerOrWard());
+        }
+        return events;
     }
 
     /**

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/HeavenlyDoubleHalberdKillBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/HeavenlyDoubleHalberdKillBehavior.java
@@ -11,6 +11,7 @@ import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.round.Round;
 import com.gaas.threeKingdoms.round.Stage;
+import com.gaas.threeKingdoms.skill.registry.SkillEngine;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -169,7 +170,34 @@ public class HeavenlyDoubleHalberdKillBehavior extends NormalActiveKillBehavior 
                     List.of(targetPlayer.getId())));
         } else {
             currentRound.setStage(Stage.Normal);
-            events.add(new AskDodgeEvent(targetPlayer.getId()));
+            // 護駕 hook：若目標為主公曹操且有其他存活 Wei，攔截 AskDodge
+            Optional<List<DomainEvent>> intercepted = SkillEngine.beforeAskDodge(game, targetPlayer, this);
+            if (intercepted.isPresent()) {
+                events.addAll(intercepted.get());
+            } else {
+                events.add(new AskDodgeEvent(targetPlayer.getId()));
+            }
         }
+    }
+
+    @Override
+    public List<DomainEvent> acceptDodgeFromHuJia(String dodgedPlayerId, String weiPlayerId, String dodgeCardId) {
+        // 方天畫戟不會觸發 GDCB / SPA（武器槽已被佔用）— 直接走 polling 推進
+        Round currentRound = game.getCurrentRound();
+        List<DomainEvent> events = new ArrayList<>();
+        events.add(new PlayCardEvent("出牌", weiPlayerId, behaviorPlayer.getId(),
+                dodgeCardId, PlayType.ACTIVE.getPlayType()));
+
+        boolean isLast = isLastReactionPlayer(dodgedPlayerId);
+        if (isLast) {
+            isOneRound = true;
+            currentRound.setActivePlayer(currentRound.getCurrentRoundPlayer());
+        } else {
+            isOneRound = false;
+            advanceToNextTarget();
+            askCurrentTargetDodgeOrEquipmentEffect(events);
+        }
+        events.add(game.getGameStatusEvent(dodgedPlayerId + " 出閃"));
+        return events;
     }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
@@ -126,7 +126,9 @@ public class NormalActiveKillBehavior extends Behavior
             isOneRound = true;
             return events;
         } else if (isDodgeCard(cardId)) {
-            damagedPlayer.playCard(cardId);
+            // 用 helper 確保閃進墓地（與 ArrowBarrage / HDH / Duel 等行為一致；
+            // 既有 bare playCard(cardId) 寫法只移出手牌、不進墓地，導致取墓地牌的技能行為分歧）
+            playerPlayCardNotUpdateActivePlayer(damagedPlayer, cardId);
             return handleDodgeChain(playerId, playerId, cardId, playType);
         } else if (isQilinBowSuccess(playType)) {
             Round currentRound = game.getCurrentRound();

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
@@ -126,40 +126,8 @@ public class NormalActiveKillBehavior extends Behavior
             isOneRound = true;
             return events;
         } else if (isDodgeCard(cardId)) {
-            Round currentRound = game.getCurrentRound();
             damagedPlayer.playCard(cardId);
-            PlayCardEvent playCardEvent = new PlayCardEvent("出牌", playerId, targetPlayerId, cardId, playType);
-
-            // 青龍偃月刀效果：攻擊者裝備青龍偃月刀時，可再出一張殺
-            if (behaviorPlayer.getEquipmentWeaponCard() instanceof GreenDragonCrescentBladeCard) {
-                isOneRound = false;
-                currentRound.setActivePlayer(behaviorPlayer);
-                // 使用 this.cardId/this.card（殺的），不是 parameter cardId（閃的）
-                game.updateTopBehavior(new WaitingGreenDragonCrescentBladeResponseBehavior(
-                        game, behaviorPlayer, List.of(playerId),
-                        behaviorPlayer, this.cardId, PlayType.ACTIVE.getPlayType(), this.card));
-                AskGreenDragonCrescentBladeEffectEvent askEvent = new AskGreenDragonCrescentBladeEffectEvent(
-                        behaviorPlayer.getId(), playerId);
-                return List.of(playCardEvent, askEvent, game.getGameStatusEvent("出牌"));
-            }
-
-            // 貫石斧效果：攻擊者裝備貫石斧且可棄牌 ≥2 張時，可棄兩牌強制命中
-            if (behaviorPlayer.getEquipmentWeaponCard() instanceof StonePiercingAxeCard
-                    && getDiscardableCardCount(behaviorPlayer) >= 2) {
-                isOneRound = false;
-                currentRound.setActivePlayer(behaviorPlayer);
-                // 使用 this.cardId/this.card（殺的），不是 parameter cardId（閃的）
-                game.updateTopBehavior(new WaitingStonePiercingAxeResponseBehavior(
-                        game, behaviorPlayer, List.of(playerId),
-                        behaviorPlayer, this.cardId, PlayType.ACTIVE.getPlayType(), this.card));
-                AskStonePiercingAxeEffectEvent askEvent = new AskStonePiercingAxeEffectEvent(
-                        behaviorPlayer.getId(), playerId);
-                return List.of(playCardEvent, askEvent, game.getGameStatusEvent("出牌"));
-            }
-
-            currentRound.setActivePlayer(currentRound.getCurrentRoundPlayer());
-            isOneRound = true;
-            return List.of(playCardEvent, game.getGameStatusEvent("出牌"));
+            return handleDodgeChain(playerId, playerId, cardId, playType);
         } else if (isQilinBowSuccess(playType)) {
             Round currentRound = game.getCurrentRound();
             List<DomainEvent> events = game.getDamagedEvent(playerId, targetPlayerId, cardId, card, playType, originalHp, damagedPlayer, currentRound, Optional.of(this));
@@ -176,15 +144,36 @@ public class NormalActiveKillBehavior extends Behavior
 
     @Override
     public List<DomainEvent> acceptDodgeFromHuJia(String dodgedPlayerId, String weiPlayerId, String dodgeCardId) {
-        Round currentRound = game.getCurrentRound();
         // 注意：dodge cardId 已在 WaitingHuJiaResponseBehavior 中由 Wei 棄入墓地
-        PlayCardEvent playCardEvent = new PlayCardEvent(
-                "出牌", weiPlayerId, behaviorPlayer.getId(), dodgeCardId, PlayType.ACTIVE.getPlayType());
+        return handleDodgeChain(dodgedPlayerId, weiPlayerId, dodgeCardId, PlayType.ACTIVE.getPlayType());
+    }
 
-        // 青龍偃月刀效果：與標準 dodge 路徑一致 — 攻擊者裝備青龍時，可再出一張殺
+    /**
+     * 共用的 dodge 後處理鏈：emit PlayCardEvent + 處理 GDCB / SPA 鏈、否則結束 behavior。
+     * <p>
+     * 由兩條路徑共享：
+     * <ul>
+     *   <li>正常 dodge response（{@code doResponseToPlayerAction} 內，dodgedPlayerId == cardSourcePlayerId）— 出閃者即被詢問者</li>
+     *   <li>護駕代閃（{@code acceptDodgeFromHuJia}，cardSourcePlayerId 為 Wei 武將）— 出閃者非被詢問者</li>
+     * </ul>
+     * 抽出此共用 helper 是為了避免兩條路徑在 GDCB/SPA 鏈邏輯上分歧。
+     *
+     * @param dodgedPlayerId 被詢問出閃的玩家 ID（曹操在 HuJia 路徑下）
+     * @param cardSourcePlayerId 實際打出閃的玩家 ID（HuJia 路徑下為 Wei 武將；正常路徑下與 dodgedPlayerId 相同）
+     * @param dodgeCardId 打出的閃 cardId
+     * @param playType {@link PlayType#ACTIVE} 字串值
+     */
+    private List<DomainEvent> handleDodgeChain(String dodgedPlayerId, String cardSourcePlayerId,
+                                                String dodgeCardId, String playType) {
+        Round currentRound = game.getCurrentRound();
+        PlayCardEvent playCardEvent = new PlayCardEvent(
+                "出牌", cardSourcePlayerId, behaviorPlayer.getId(), dodgeCardId, playType);
+
+        // 青龍偃月刀效果：攻擊者裝備青龍偃月刀時，可再出一張殺
         if (behaviorPlayer.getEquipmentWeaponCard() instanceof GreenDragonCrescentBladeCard) {
             isOneRound = false;
             currentRound.setActivePlayer(behaviorPlayer);
+            // 使用 this.cardId/this.card（殺的），不是 parameter dodgeCardId（閃的）
             game.updateTopBehavior(new WaitingGreenDragonCrescentBladeResponseBehavior(
                     game, behaviorPlayer, List.of(dodgedPlayerId),
                     behaviorPlayer, this.cardId, PlayType.ACTIVE.getPlayType(), this.card));
@@ -193,11 +182,12 @@ public class NormalActiveKillBehavior extends Behavior
                     game.getGameStatusEvent("出牌"));
         }
 
-        // 貫石斧效果
+        // 貫石斧效果：攻擊者裝備貫石斧且可棄牌 ≥2 張時，可棄兩牌強制命中
         if (behaviorPlayer.getEquipmentWeaponCard() instanceof StonePiercingAxeCard
                 && getDiscardableCardCount(behaviorPlayer) >= 2) {
             isOneRound = false;
             currentRound.setActivePlayer(behaviorPlayer);
+            // 使用 this.cardId/this.card（殺的），不是 parameter dodgeCardId（閃的）
             game.updateTopBehavior(new WaitingStonePiercingAxeResponseBehavior(
                     game, behaviorPlayer, List.of(dodgedPlayerId),
                     behaviorPlayer, this.cardId, PlayType.ACTIVE.getPlayType(), this.card));

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
@@ -2,6 +2,7 @@ package com.gaas.threeKingdoms.behavior.behavior;
 
 import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.behavior.Behavior;
+import com.gaas.threeKingdoms.behavior.HuJiaCompatibleAskDodgeBehavior;
 import com.gaas.threeKingdoms.events.AskActivateYinYangSwordsEvent;
 import com.gaas.threeKingdoms.events.AskDodgeEvent;
 import com.gaas.threeKingdoms.events.AskGreenDragonCrescentBladeEffectEvent;
@@ -10,6 +11,7 @@ import com.gaas.threeKingdoms.events.AskStonePiercingAxeEffectEvent;
 import com.gaas.threeKingdoms.events.BlackPommelEffectEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
 import com.gaas.threeKingdoms.events.PlayCardEvent;
+import com.gaas.threeKingdoms.skill.registry.SkillEngine;
 import com.gaas.threeKingdoms.handcard.HandCard;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.equipmentcard.EquipmentCard;
@@ -31,7 +33,9 @@ import static com.gaas.threeKingdoms.handcard.PlayCard.isDodgeCard;
 import static com.gaas.threeKingdoms.handcard.PlayCard.isSkip;
 
 
-public class NormalActiveKillBehavior extends Behavior implements com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior {
+public class NormalActiveKillBehavior extends Behavior
+        implements com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior,
+                   HuJiaCompatibleAskDodgeBehavior {
 
     public NormalActiveKillBehavior(Game game, Player behaviorPlayer, List<String> reactionPlayers, Player currentReactionPlayer, String cardId, String playType, HandCard card) {
         super(game, behaviorPlayer, reactionPlayers, currentReactionPlayer, cardId, playType, card, true, false, false);
@@ -66,10 +70,22 @@ public class NormalActiveKillBehavior extends Behavior implements com.gaas.three
             if (isAttackerHasBlackPommel(behaviorPlayer) && isEquipmentHasSpecialEffect(targetPlayer)) {
                 events.add(new BlackPommelEffectEvent(behaviorPlayer.getId(), targetPlayerId));
             }
-            events.add(new AskDodgeEvent(targetPlayerId));
+            emitAskDodgeOrHuJia(events, targetPlayer);
         }
         events.add(game.getGameStatusEvent("出牌"));
         return events;
+    }
+
+    /**
+     * AskDodge 前先讓 SkillEngine 介入（護駕等）。若介入，跳過原本 AskDodgeEvent。
+     */
+    private void emitAskDodgeOrHuJia(List<DomainEvent> events, Player targetPlayer) {
+        Optional<List<DomainEvent>> intercepted = SkillEngine.beforeAskDodge(game, targetPlayer, this);
+        if (intercepted.isPresent()) {
+            events.addAll(intercepted.get());
+        } else {
+            events.add(new AskDodgeEvent(targetPlayer.getId()));
+        }
     }
 
     private boolean shouldTriggerYinYangSwords(Player attacker, Player target) {
@@ -82,7 +98,7 @@ public class NormalActiveKillBehavior extends Behavior implements com.gaas.three
             currentRound.setStage(Stage.Wait_Equipment_Effect);
             events.add(new AskPlayEquipmentEffectEvent(targetPlayer.getId(), targetPlayer.getEquipment().getArmor(), List.of(targetPlayer.getId())));
         } else {
-            events.add(new AskDodgeEvent(targetPlayer.getId()));
+            emitAskDodgeOrHuJia(events, targetPlayer);
         }
     }
 
@@ -156,6 +172,43 @@ public class NormalActiveKillBehavior extends Behavior implements com.gaas.three
             //TODO:怕有其他效果或殺的其他case
             return new ArrayList<>();
         }
+    }
+
+    @Override
+    public List<DomainEvent> acceptDodgeFromHuJia(String dodgedPlayerId, String weiPlayerId, String dodgeCardId) {
+        Round currentRound = game.getCurrentRound();
+        // 注意：dodge cardId 已在 WaitingHuJiaResponseBehavior 中由 Wei 棄入墓地
+        PlayCardEvent playCardEvent = new PlayCardEvent(
+                "出牌", weiPlayerId, behaviorPlayer.getId(), dodgeCardId, PlayType.ACTIVE.getPlayType());
+
+        // 青龍偃月刀效果：與標準 dodge 路徑一致 — 攻擊者裝備青龍時，可再出一張殺
+        if (behaviorPlayer.getEquipmentWeaponCard() instanceof GreenDragonCrescentBladeCard) {
+            isOneRound = false;
+            currentRound.setActivePlayer(behaviorPlayer);
+            game.updateTopBehavior(new WaitingGreenDragonCrescentBladeResponseBehavior(
+                    game, behaviorPlayer, List.of(dodgedPlayerId),
+                    behaviorPlayer, this.cardId, PlayType.ACTIVE.getPlayType(), this.card));
+            return List.of(playCardEvent,
+                    new AskGreenDragonCrescentBladeEffectEvent(behaviorPlayer.getId(), dodgedPlayerId),
+                    game.getGameStatusEvent("出牌"));
+        }
+
+        // 貫石斧效果
+        if (behaviorPlayer.getEquipmentWeaponCard() instanceof StonePiercingAxeCard
+                && getDiscardableCardCount(behaviorPlayer) >= 2) {
+            isOneRound = false;
+            currentRound.setActivePlayer(behaviorPlayer);
+            game.updateTopBehavior(new WaitingStonePiercingAxeResponseBehavior(
+                    game, behaviorPlayer, List.of(dodgedPlayerId),
+                    behaviorPlayer, this.cardId, PlayType.ACTIVE.getPlayType(), this.card));
+            return List.of(playCardEvent,
+                    new AskStonePiercingAxeEffectEvent(behaviorPlayer.getId(), dodgedPlayerId),
+                    game.getGameStatusEvent("出牌"));
+        }
+
+        currentRound.setActivePlayer(currentRound.getCurrentRoundPlayer());
+        isOneRound = true;
+        return List.of(playCardEvent, game.getGameStatusEvent("出牌"));
     }
 
     private boolean isQilinBowSuccess(String playType) {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingHuJiaResponseBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingHuJiaResponseBehavior.java
@@ -1,0 +1,143 @@
+package com.gaas.threeKingdoms.behavior.behavior;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.behavior.Behavior;
+import com.gaas.threeKingdoms.behavior.HuJiaCompatibleAskDodgeBehavior;
+import com.gaas.threeKingdoms.events.AskDodgeEvent;
+import com.gaas.threeKingdoms.events.AskHuJiaEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.HuJiaEffectEvent;
+import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.player.Player;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.gaas.threeKingdoms.handcard.PlayCard.isDodgeCard;
+
+/**
+ * 護駕（主公技）等待 Wei 武將回應 — 依序詢問每個存活 Wei 武將是否代替主公曹操出閃。
+ *
+ * behaviorPlayer = 曹操（被代替者，AskDodge 原本要問的人）
+ * weiOrder       = 完整 Wei polling 順序（以曹操為起點，下家開始）
+ * currentIndex   = 目前正在詢問的 Wei index
+ *
+ * ACCEPT：currentWei 打出指定 dodge cardId → 該閃進墓地、pop self、由 parent
+ * {@link HuJiaCompatibleAskDodgeBehavior#acceptDodgeFromHuJia} 接手後續（GDCB / SPA / AOE polling）
+ *
+ * DECLINE：
+ *   - 若還有下一個 Wei → 切 currentWei、emit 下一個 AskHuJiaEffectEvent、activePlayer 換人
+ *   - 若已是最後一個 → pop self、emit 原本的 AskDodgeEvent(曹操)、activePlayer 切回曹操
+ */
+@Getter
+public class WaitingHuJiaResponseBehavior extends Behavior {
+
+    private final String caoCaoPlayerId;
+    private final List<String> weiOrder;
+    private int currentIndex;
+
+    public WaitingHuJiaResponseBehavior(Game game, Player caoCao, List<String> weiOrder, int currentIndex) {
+        super(game,
+                caoCao,
+                List.of(caoCao.getId()),
+                caoCao,
+                null,
+                PlayType.SYSTEM_INTERNAL.getPlayType(),
+                null,
+                false,
+                false,
+                true);
+        this.caoCaoPlayerId = caoCao.getId();
+        this.weiOrder = List.copyOf(weiOrder);
+        this.currentIndex = currentIndex;
+    }
+
+    public WaitingHuJiaResponseBehavior(Game game, Player caoCao, List<String> weiOrder) {
+        this(game, caoCao, weiOrder, 0);
+    }
+
+    public String getCurrentWei() {
+        return weiOrder.get(currentIndex);
+    }
+
+    public List<DomainEvent> resolveChoice(String respondingPlayerId, AskHuJiaEffectEvent.Choice choice, String dodgeCardId) {
+        String expected = getCurrentWei();
+        if (!expected.equals(respondingPlayerId)) {
+            throw new IllegalStateException(
+                    String.format("player %s is not the current Wei reactor (%s)", respondingPlayerId, expected));
+        }
+
+        if (choice == AskHuJiaEffectEvent.Choice.ACCEPT) {
+            return resolveAccept(respondingPlayerId, dodgeCardId);
+        } else if (choice == AskHuJiaEffectEvent.Choice.DECLINE) {
+            return resolveDecline(respondingPlayerId);
+        } else {
+            throw new IllegalArgumentException("Invalid HuJia choice: " + choice);
+        }
+    }
+
+    private List<DomainEvent> resolveAccept(String weiPlayerId, String dodgeCardId) {
+        if (dodgeCardId == null || dodgeCardId.isEmpty()) {
+            throw new IllegalArgumentException("ACCEPT requires a dodge cardId");
+        }
+        Player wei = game.getPlayer(weiPlayerId);
+        HandCard handCard = wei.getHand().getCard(dodgeCardId)
+                .orElseThrow(() -> new IllegalArgumentException("Card not in Wei's hand: " + dodgeCardId));
+        if (!isDodgeCard(handCard.getId())) {
+            throw new IllegalArgumentException("Card is not a Dodge: " + dodgeCardId);
+        }
+
+        // Wei 失去這張閃，移到墓地
+        wei.playCard(dodgeCardId);
+        game.getGraveyard().add(handCard);
+
+        // Pop self（必須先 pop，下面 dispatch 才會把 parent 接到 stack 頂）
+        isOneRound = true;
+        game.removeCompletedBehaviors();
+
+        Behavior parent = game.peekTopBehavior();
+        if (!(parent instanceof HuJiaCompatibleAskDodgeBehavior compatibleParent)) {
+            throw new IllegalStateException(
+                    "HuJia parent behavior does not implement HuJiaCompatibleAskDodgeBehavior: "
+                            + parent.getClass().getSimpleName());
+        }
+
+        List<DomainEvent> events = new ArrayList<>();
+        events.add(new HuJiaEffectEvent(weiPlayerId, caoCaoPlayerId, true, dodgeCardId));
+        events.addAll(compatibleParent.acceptDodgeFromHuJia(caoCaoPlayerId, weiPlayerId, dodgeCardId));
+        return events;
+    }
+
+    private List<DomainEvent> resolveDecline(String weiPlayerId) {
+        List<DomainEvent> events = new ArrayList<>();
+        events.add(new HuJiaEffectEvent(weiPlayerId, caoCaoPlayerId, false, null));
+
+        if (currentIndex + 1 < weiOrder.size()) {
+            currentIndex++;
+            String nextWei = getCurrentWei();
+            Player nextWeiPlayer = game.getPlayer(nextWei);
+            game.getCurrentRound().setActivePlayer(nextWeiPlayer);
+            events.add(new AskHuJiaEffectEvent(nextWei, caoCaoPlayerId, dodgeCardIdsInHand(nextWeiPlayer)));
+            events.add(game.getGameStatusEvent(weiPlayerId + " 拒絕護駕，詢問下一位魏勢力"));
+            return events;
+        }
+
+        // 所有 Wei 都拒絕 → pop self、fallback 到原本的 AskDodge(曹操)
+        isOneRound = true;
+        Player caoCao = game.getPlayer(caoCaoPlayerId);
+        game.getCurrentRound().setActivePlayer(caoCao);
+        events.add(new AskDodgeEvent(caoCaoPlayerId));
+        events.add(game.getGameStatusEvent("護駕全部拒絕，回到主公出閃"));
+        return events;
+    }
+
+    public static List<String> dodgeCardIdsInHand(Player player) {
+        return player.getHand().getCards().stream()
+                .filter(c -> isDodgeCard(c.getId()))
+                .map(HandCard::getId)
+                .collect(Collectors.toList());
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingHuJiaResponseBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingHuJiaResponseBehavior.java
@@ -31,6 +31,12 @@ import static com.gaas.threeKingdoms.handcard.PlayCard.isDodgeCard;
  * DECLINE：
  *   - 若還有下一個 Wei → 切 currentWei、emit 下一個 AskHuJiaEffectEvent、activePlayer 換人
  *   - 若已是最後一個 → pop self、emit 原本的 AskDodgeEvent(曹操)、activePlayer 切回曹操
+ *
+ * Stack 隱性假設（ACCEPT 路徑）：本 behavior 是由 {@link com.gaas.threeKingdoms.skill.wei.HuJiaSkill}
+ * 在 {@link com.gaas.threeKingdoms.skill.registry.SkillEngine#beforeAskDodge} 內 push 在原 emit AskDodge 的
+ * host 之上，因此 pop self 後 stack 第二格必定是該 {@link HuJiaCompatibleAskDodgeBehavior}。若未來有
+ * 其他 behavior 在 HuJia push 之後又插入額外行為（堆出 [host, X, WaitingHuJia]），ACCEPT 路徑 peek
+ * 到的 parent 會是 X 而非 host → instanceof 檢查會丟例外（已加守門）。新增此類介入時須一併處理。
  */
 @Getter
 public class WaitingHuJiaResponseBehavior extends Behavior {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/AskHuJiaEffectEvent.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/AskHuJiaEffectEvent.java
@@ -1,0 +1,33 @@
+package com.gaas.threeKingdoms.events;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 護駕：詢問 Wei 武將是否代替主公曹操出閃。
+ *
+ * playerId            — 被詢問的 Wei 武將 ID（當前 reactor）
+ * caoCaoPlayerId      — 被代替的主公（曹操）ID
+ * dodgeCardIdsInHand  — 該 Wei 手中所有「閃」cardId，可用於 ACCEPT
+ */
+@Getter
+public class AskHuJiaEffectEvent extends DomainEvent {
+
+    private final String playerId;
+    private final String caoCaoPlayerId;
+    private final List<String> dodgeCardIdsInHand;
+
+    public AskHuJiaEffectEvent(String playerId, String caoCaoPlayerId, List<String> dodgeCardIdsInHand) {
+        super("AskHuJiaEffectEvent",
+                String.format("護駕：詢問 %s 是否代替主公 %s 打出閃", playerId, caoCaoPlayerId));
+        this.playerId = playerId;
+        this.caoCaoPlayerId = caoCaoPlayerId;
+        this.dodgeCardIdsInHand = dodgeCardIdsInHand;
+    }
+
+    public enum Choice {
+        ACCEPT,
+        DECLINE
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/HuJiaEffectEvent.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/HuJiaEffectEvent.java
@@ -1,0 +1,29 @@
+package com.gaas.threeKingdoms.events;
+
+import lombok.Getter;
+
+/**
+ * 護駕：Wei 武將回應結果廣播。
+ *
+ * playerId        — 回應的 Wei 武將 ID
+ * caoCaoPlayerId  — 被代替的曹操 ID
+ * accepted        — true 為代閃成功（含 dodgeCardId）；false 為拒絕
+ * dodgeCardId     — accepted=true 時 Wei 打出的閃；accepted=false 時為 null
+ */
+@Getter
+public class HuJiaEffectEvent extends DomainEvent {
+
+    private final String playerId;
+    private final String caoCaoPlayerId;
+    private final boolean accepted;
+    private final String dodgeCardId;
+
+    public HuJiaEffectEvent(String playerId, String caoCaoPlayerId, boolean accepted, String dodgeCardId) {
+        super("HuJiaEffectEvent",
+                String.format("護駕：%s %s 代替 %s 出閃", playerId, accepted ? "成功" : "拒絕", caoCaoPlayerId));
+        this.playerId = playerId;
+        this.caoCaoPlayerId = caoCaoPlayerId;
+        this.accepted = accepted;
+        this.dodgeCardId = dodgeCardId;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/generalcard/Faction.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/generalcard/Faction.java
@@ -1,0 +1,18 @@
+package com.gaas.threeKingdoms.generalcard;
+
+public enum Faction {
+    SHU("蜀"),
+    WEI("魏"),
+    WU("吳"),
+    QUN("群");
+
+    private final String displayName;
+
+    Faction(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/generalcard/General.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/generalcard/General.java
@@ -4,33 +4,34 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum General {
-    劉備("劉備",4, "SHU001", Gender.MALE),
-    曹操("曹操",4,"WEI001", Gender.MALE),
-    孫權("孫權",4,"WU001", Gender.MALE),
-    關羽("關羽",4, "SHU002", Gender.MALE),
-    張飛("張飛",4, "SHU003", Gender.MALE),
-    馬超("馬超",4,"SHU006", Gender.MALE),
-    趙雲("趙雲",4,"SHU005", Gender.MALE),
-    黃月英("黃月英",3,"SHU007", Gender.FEMALE),
-    諸葛亮("諸葛亮",3,"SHU004", Gender.MALE),
-    司馬懿("司馬懿",3, "WEI002", Gender.MALE),
-    夏侯惇("夏侯惇",4, "WEI003", Gender.MALE),
-    許褚("許褚",4, "WEI005", Gender.MALE),
-    郭嘉("郭嘉",3, "WEI006", Gender.MALE),
-    甄姬("甄姬",3, "WEI007", Gender.FEMALE),
-    張遼("張遼",4, "WEI004", Gender.MALE),
-    甘寧("甘寧",4, "WU002", Gender.MALE),
-    呂蒙("呂蒙",4, "WU003", Gender.MALE),
-    黃蓋("黃蓋",4, "WU004", Gender.MALE),
-    周瑜("周瑜",3, "WU005", Gender.MALE),
-    大喬("大喬",3, "WU006", Gender.FEMALE),
-    陸遜("陸遜",3, "WU007", Gender.MALE),
-    孫尚香("孫尚香",3, "WU008", Gender.FEMALE);
+    劉備("劉備", 4, "SHU001", Gender.MALE, Faction.SHU),
+    曹操("曹操", 4, "WEI001", Gender.MALE, Faction.WEI),
+    孫權("孫權", 4, "WU001", Gender.MALE, Faction.WU),
+    關羽("關羽", 4, "SHU002", Gender.MALE, Faction.SHU),
+    張飛("張飛", 4, "SHU003", Gender.MALE, Faction.SHU),
+    馬超("馬超", 4, "SHU006", Gender.MALE, Faction.SHU),
+    趙雲("趙雲", 4, "SHU005", Gender.MALE, Faction.SHU),
+    黃月英("黃月英", 3, "SHU007", Gender.FEMALE, Faction.SHU),
+    諸葛亮("諸葛亮", 3, "SHU004", Gender.MALE, Faction.SHU),
+    司馬懿("司馬懿", 3, "WEI002", Gender.MALE, Faction.WEI),
+    夏侯惇("夏侯惇", 4, "WEI003", Gender.MALE, Faction.WEI),
+    許褚("許褚", 4, "WEI005", Gender.MALE, Faction.WEI),
+    郭嘉("郭嘉", 3, "WEI006", Gender.MALE, Faction.WEI),
+    甄姬("甄姬", 3, "WEI007", Gender.FEMALE, Faction.WEI),
+    張遼("張遼", 4, "WEI004", Gender.MALE, Faction.WEI),
+    甘寧("甘寧", 4, "WU002", Gender.MALE, Faction.WU),
+    呂蒙("呂蒙", 4, "WU003", Gender.MALE, Faction.WU),
+    黃蓋("黃蓋", 4, "WU004", Gender.MALE, Faction.WU),
+    周瑜("周瑜", 3, "WU005", Gender.MALE, Faction.WU),
+    大喬("大喬", 3, "WU006", Gender.FEMALE, Faction.WU),
+    陸遜("陸遜", 3, "WU007", Gender.MALE, Faction.WU),
+    孫尚香("孫尚香", 3, "WU008", Gender.FEMALE, Faction.WU);
 
     public final String generalName;
     public final int healthPoint;
     public final String generalId;
     public final Gender gender;
+    public final Faction faction;
 
     private static final Map<String, General> GENERAL_MAP = new HashMap<>();
 
@@ -40,11 +41,12 @@ public enum General {
         }
     }
 
-    General(String generalName, int healthPoint, String generalId, Gender gender) {
+    General(String generalName, int healthPoint, String generalId, Gender gender, Faction faction) {
         this.generalName = generalName;
         this.healthPoint = healthPoint;
         this.generalId = generalId;
         this.gender = gender;
+        this.faction = faction;
     }
 
     public static General findById(String generalId) {
@@ -69,5 +71,9 @@ public enum General {
 
     public Gender getGender() {
         return gender;
+    }
+
+    public Faction getFaction() {
+        return faction;
     }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/generalcard/GeneralCard.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/generalcard/GeneralCard.java
@@ -14,12 +14,14 @@ public class GeneralCard {
     private String generalName;
     private int healthPoint;
     private Gender gender;
+    private Faction faction;
 
     public GeneralCard(General general) {
         this.generalId = general.getGeneralId();
         this.generalName = general.getGeneralName();
         this.healthPoint = general.getHealthPoint();
         this.gender = general.getGender();
+        this.faction = general.getFaction();
     }
 
     public static final Map<String, GeneralCard> generals = new HashMap<>();

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/player/Player.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/player/Player.java
@@ -283,6 +283,10 @@ public class Player {
         return generalCard.getGender();
     }
 
+    public com.gaas.threeKingdoms.generalcard.Faction getFaction() {
+        return generalCard.getFaction();
+    }
+
 
     // 覆寫 equals 方法
     @Override

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillEngine.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillEngine.java
@@ -1,15 +1,18 @@
 package com.gaas.threeKingdoms.skill.registry;
 
 import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.behavior.Behavior;
 import com.gaas.threeKingdoms.events.DomainEvent;
 import com.gaas.threeKingdoms.generalcard.GeneralCard;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.skill.Skill;
 import com.gaas.threeKingdoms.skill.context.DamageContext;
+import com.gaas.threeKingdoms.skill.trigger.BeforeAskDodgeSkill;
 import com.gaas.threeKingdoms.skill.trigger.OnDamagedSkill;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public final class SkillEngine {
 
@@ -32,5 +35,28 @@ public final class SkillEngine {
             }
         }
         return events;
+    }
+
+    /**
+     * AskDodge 前介入鉤點：iterate damaged 武將綁定的技能，第一個回傳非 empty 的 win。
+     * caller 用 {@code intercepted.ifPresentOrElse(events::addAll, () -> events.add(new AskDodgeEvent(...)))}。
+     */
+    public static Optional<List<DomainEvent>> beforeAskDodge(Game game, Player damaged, Behavior parentBehavior) {
+        if (damaged == null) {
+            return Optional.empty();
+        }
+        GeneralCard general = damaged.getGeneralCard();
+        if (general == null) {
+            return Optional.empty();
+        }
+        for (Skill skill : SkillRegistry.of(general.getGeneralId())) {
+            if (skill instanceof BeforeAskDodgeSkill beforeAsk) {
+                Optional<List<DomainEvent>> result = beforeAsk.beforeAskDodge(game, damaged, parentBehavior);
+                if (result.isPresent()) {
+                    return result;
+                }
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillRegistry.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillRegistry.java
@@ -1,6 +1,7 @@
 package com.gaas.threeKingdoms.skill.registry;
 
 import com.gaas.threeKingdoms.skill.Skill;
+import com.gaas.threeKingdoms.skill.wei.HuJiaSkill;
 import com.gaas.threeKingdoms.skill.wei.JianXiongSkill;
 
 import java.util.ArrayList;
@@ -13,6 +14,7 @@ public final class SkillRegistry {
 
     static {
         register(new JianXiongSkill());
+        register(new HuJiaSkill());
     }
 
     private SkillRegistry() {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/trigger/BeforeAskDodgeSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/trigger/BeforeAskDodgeSkill.java
@@ -1,0 +1,22 @@
+package com.gaas.threeKingdoms.skill.trigger;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.behavior.Behavior;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.skill.Skill;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 在 AskDodgeEvent 即將被 emit 時介入的技能 trigger（例：護駕）。
+ *
+ * 回傳語意：
+ *   - Optional.empty()：不介入，caller 自行 emit 原本的 AskDodgeEvent
+ *   - Optional.of(events)：已 push 替代 behavior 至 stack 並組好替代 ask 事件，caller 直接把
+ *     events addAll 進回傳事件列表，跳過原本的 AskDodgeEvent
+ */
+public interface BeforeAskDodgeSkill extends Skill {
+    Optional<List<DomainEvent>> beforeAskDodge(Game game, Player damaged, Behavior parentBehavior);
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/HuJiaSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/HuJiaSkill.java
@@ -7,7 +7,6 @@ import com.gaas.threeKingdoms.events.AskHuJiaEffectEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
 import com.gaas.threeKingdoms.generalcard.Faction;
 import com.gaas.threeKingdoms.generalcard.General;
-import com.gaas.threeKingdoms.player.HealthStatus;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.rolecard.Role;
 import com.gaas.threeKingdoms.skill.trigger.BeforeAskDodgeSkill;
@@ -69,13 +68,15 @@ public class HuJiaSkill implements BeforeAskDodgeSkill {
     }
 
     private List<Player> otherAliveWeiInSeatingOrder(Game game, Player caoCao) {
+        // 用 isAlreadyDeath() 作為「未結算死亡」判準（與 Player API 一致）。
+        // 注意：DYING 狀態仍視為存活，可以代替主公出閃（標準三國殺 dying 期間仍能打閃 / 桃 / 無懈）。
         List<Player> helpers = new ArrayList<>();
         int total = game.getPlayers().size();
         Player cursor = caoCao;
         for (int i = 0; i < total; i++) {
             cursor = game.getNextPlayer(cursor);
             if (cursor.equals(caoCao)) break;
-            if (cursor.getHealthStatus() == HealthStatus.DEATH) continue;
+            if (cursor.isAlreadyDeath()) continue;
             if (cursor.getFaction() == Faction.WEI) {
                 helpers.add(cursor);
             }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/HuJiaSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/HuJiaSkill.java
@@ -1,0 +1,85 @@
+package com.gaas.threeKingdoms.skill.wei;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.behavior.Behavior;
+import com.gaas.threeKingdoms.behavior.behavior.WaitingHuJiaResponseBehavior;
+import com.gaas.threeKingdoms.events.AskHuJiaEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.generalcard.Faction;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.player.HealthStatus;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.rolecard.Role;
+import com.gaas.threeKingdoms.skill.trigger.BeforeAskDodgeSkill;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 曹操 (WEI001) 護駕 — 主公技。
+ *
+ * 標準版規則：當主公（曹操）需要使用或打出一張閃時，其他存活的魏勢力角色按行動順序，依次選擇是否為其打出一張閃。
+ * 任一人打出則視為曹操打出此閃。
+ *
+ * 守門：
+ *   - 曹操必須是 MONARCH（非主公的曹操不觸發）
+ *   - 必須有其他存活的 Wei 武將
+ *
+ * 觸發後：push {@link WaitingHuJiaResponseBehavior} 並 emit {@link AskHuJiaEffectEvent} 給第一位 Wei；
+ * caller 跳過原本的 AskDodgeEvent。所有 Wei 拒絕 → WaitingHuJia 在收最後一個 DECLINE 時自動 fallback
+ * emit AskDodgeEvent(曹操)。
+ */
+public class HuJiaSkill implements BeforeAskDodgeSkill {
+
+    public static final String GENERAL_ID = General.曹操.getGeneralId();
+    public static final String SKILL_NAME = "護駕";
+
+    @Override
+    public String getGeneralId() {
+        return GENERAL_ID;
+    }
+
+    @Override
+    public String getSkillName() {
+        return SKILL_NAME;
+    }
+
+    @Override
+    public Optional<List<DomainEvent>> beforeAskDodge(Game game, Player damaged, Behavior parentBehavior) {
+        if (damaged.getRoleCard().getRole() != Role.MONARCH) {
+            return Optional.empty();
+        }
+
+        List<Player> weiHelpers = otherAliveWeiInSeatingOrder(game, damaged);
+        if (weiHelpers.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<String> weiOrder = weiHelpers.stream().map(Player::getId).toList();
+        WaitingHuJiaResponseBehavior waiting = new WaitingHuJiaResponseBehavior(game, damaged, weiOrder);
+        game.updateTopBehavior(waiting);
+
+        Player firstWei = weiHelpers.get(0);
+        game.getCurrentRound().setActivePlayer(firstWei);
+
+        return Optional.of(List.of(new AskHuJiaEffectEvent(
+                firstWei.getId(), damaged.getId(),
+                WaitingHuJiaResponseBehavior.dodgeCardIdsInHand(firstWei))));
+    }
+
+    private List<Player> otherAliveWeiInSeatingOrder(Game game, Player caoCao) {
+        List<Player> helpers = new ArrayList<>();
+        int total = game.getPlayers().size();
+        Player cursor = caoCao;
+        for (int i = 0; i < total; i++) {
+            cursor = game.getNextPlayer(cursor);
+            if (cursor.equals(caoCao)) break;
+            if (cursor.getHealthStatus() == HealthStatus.DEATH) continue;
+            if (cursor.getFaction() == Faction.WEI) {
+                helpers.add(cursor);
+            }
+        }
+        return helpers;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HuJiaSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HuJiaSkillTest.java
@@ -321,4 +321,73 @@ public class HuJiaSkillTest {
                 .map(b -> b instanceof HeavenlyDoubleHalberdKillBehavior).orElse(false),
                 "HeavenlyDoubleHalberd should be parent");
     }
+
+    @DisplayName("""
+            Given 萬箭齊發 reactionPlayers=[B(曹操), C(Wei), D(Wei)]，C 手中有閃
+            When  B 被詢問 → HuJia 觸發 → C ACCEPT 代閃
+            Then  WaitingHuJia pop、stack 頂回到 ArrowBarrage
+                  currentReactionPlayer 推進到 C
+                  emit AskDodgeEvent(C)（C 非主公，不再觸發 HuJia）
+                  C 失去那張閃
+            """)
+    @Test
+    public void givenArrowBarrageOnMonarchCaoCao_WeiAccept_PollingResumesToNextReactor() {
+        Game game = setupMonarchCaoCaoWithTwoWei();
+        Player playerA = game.getPlayer("player-a");
+        Player playerC = game.getPlayer("player-c");
+        playerA.getHand().addCardToHand(new ArrowBarrage(SS7007));
+        giveDodge(playerC, BH2028);
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-b", "active");
+        // ACCEPT 代替曹操出閃
+        List<DomainEvent> events = game.playerUseHuJiaEffect(
+                "player-c", AskHuJiaEffectEvent.Choice.ACCEPT, BH2028.getCardId());
+
+        // 推進到 polling 下一位 C，由 C 自己被問 dodge（C 非主公不觸發 HuJia 再次）
+        assertTrue(game.peekTopBehavior() instanceof ArrowBarrageBehavior,
+                "WaitingHuJia should be popped; ArrowBarrage back to top");
+        assertEquals("player-c", ((ArrowBarrageBehavior) game.peekTopBehavior())
+                .getCurrentReactionPlayer().getId());
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent
+                        && ((AskDodgeEvent) e).getPlayerId().equals("player-c")),
+                "should ask dodge to next reactor C");
+        assertTrue(playerC.getHand().getCards().stream().noneMatch(c -> c.getId().equals(BH2028.getCardId())),
+                "C should have lost the dodge used for HuJia");
+        // 曹操 HP 未受影響
+        assertEquals(4, game.getPlayer("player-b").getHP());
+    }
+
+    @DisplayName("""
+            Given 方天畫戟多目標 [B(曹操), C(Wei)]，C 與 D 皆 Wei，D 手中有閃
+            When  B 被詢問 → HuJia 觸發 → 因 B 下家 C 也是 target reactor，
+                  但 HuJia 順序按座位（C 為 caoCao 下家），C ACCEPT 出閃代替
+            Then  WaitingHuJia pop、stack 頂回到 HDH
+                  currentReactionPlayer 推進到下一 target（reactionPlayers 順序）= C
+                  emit AskDodgeEvent(C)
+            """)
+    @Test
+    public void givenHDHOnMonarchCaoCao_WeiAccept_PollingAdvancesToNextHDHTarget() {
+        Game game = setupMonarchCaoCaoWithTwoWei();
+        Player playerA = game.getPlayer("player-a");
+        Player playerC = game.getPlayer("player-c");
+        playerA.getEquipment().setWeapon(new HeavenlyDoubleHalberdCard(EDQ103));
+        // C 額外多兩張閃（一張用於 HuJia 代閃曹操，一張為 C 自己 dodge）
+        giveDodge(playerC, BH2028);
+        giveDodge(playerC, BHK039);
+
+        game.playerUseHeavenlyDoubleHalberdKill(
+                "player-a", BS8008.getCardId(), List.of("player-b", "player-c"));
+
+        List<DomainEvent> events = game.playerUseHuJiaEffect(
+                "player-c", AskHuJiaEffectEvent.Choice.ACCEPT, BH2028.getCardId());
+
+        assertTrue(game.peekTopBehavior() instanceof HeavenlyDoubleHalberdKillBehavior,
+                "WaitingHuJia should be popped; HDH back to top");
+        HeavenlyDoubleHalberdKillBehavior hdh = (HeavenlyDoubleHalberdKillBehavior) game.peekTopBehavior();
+        assertEquals("player-c", hdh.getCurrentReactionPlayer().getId(),
+                "HDH polling should advance from B to next target C");
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent
+                        && ((AskDodgeEvent) e).getPlayerId().equals("player-c")));
+        assertEquals(4, game.getPlayer("player-b").getHP(), "曹操 not damaged");
+    }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HuJiaSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HuJiaSkillTest.java
@@ -1,0 +1,324 @@
+package com.gaas.threeKingdoms;
+
+import com.gaas.threeKingdoms.behavior.behavior.ArrowBarrageBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.HeavenlyDoubleHalberdKillBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.WaitingHuJiaResponseBehavior;
+import com.gaas.threeKingdoms.builders.PlayerBuilder;
+import com.gaas.threeKingdoms.events.AskDodgeEvent;
+import com.gaas.threeKingdoms.events.AskHuJiaEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.HuJiaEffectEvent;
+import com.gaas.threeKingdoms.gamephase.Normal;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.generalcard.GeneralCard;
+import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.HeavenlyDoubleHalberdCard;
+import com.gaas.threeKingdoms.handcard.scrollcard.ArrowBarrage;
+import com.gaas.threeKingdoms.player.*;
+import com.gaas.threeKingdoms.rolecard.Role;
+import com.gaas.threeKingdoms.rolecard.RoleCard;
+import com.gaas.threeKingdoms.round.Round;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HuJiaSkillTest {
+
+    /**
+     * 4 人場：
+     *   player-a = 馬超（蜀）反賊，攻擊者
+     *   player-b = 曹操 主公（MONARCH），HP 4，無閃
+     *   player-c = caoCaoFollower1General（決定 c 是否為 Wei）忠臣
+     *   player-d = caoCaoFollower2General（決定 d 是否為 Wei）忠臣
+     * 座位順序：a → b → c → d → a
+     * 護駕 polling 順序：以 b 為起點 next 開始 → c → d → a（過濾 alive Wei + 排除曹操）
+     */
+    private Game setupGame(General caoCaoRole, General caoCaoFollower1General, General caoCaoFollower2General) {
+        Game game = new Game();
+        game.initDeck();
+
+        Player playerA = PlayerBuilder.construct()
+                .withId("player-a")
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(General.馬超))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(Role.REBEL))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .build();
+        playerA.getHand().addCardToHand(Arrays.asList(new Kill(BS8008)));
+
+        Player playerB = PlayerBuilder.construct()
+                .withId("player-b")
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(General.曹操))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(caoCaoRole == General.曹操 ? Role.MONARCH : Role.MINISTER))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .build();
+
+        Player playerC = PlayerBuilder.construct()
+                .withId("player-c")
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(caoCaoFollower1General))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(Role.MINISTER))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .build();
+
+        Player playerD = PlayerBuilder.construct()
+                .withId("player-d")
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(caoCaoFollower2General))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(Role.MINISTER))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .build();
+
+        game.setPlayers(Arrays.asList(playerA, playerB, playerC, playerD));
+        game.setCurrentRound(new Round(playerA));
+        game.enterPhase(new Normal(game));
+        return game;
+    }
+
+    /** 曹操主公 + C 是 Wei，D 是非 Wei → Wei polling 只有 [C] */
+    private Game setupMonarchCaoCaoWithOneWei() {
+        return setupGame(General.曹操, General.夏侯惇, General.諸葛亮);
+    }
+
+    /** 曹操主公 + C/D 都是 Wei → Wei polling = [C, D] */
+    private Game setupMonarchCaoCaoWithTwoWei() {
+        return setupGame(General.曹操, General.夏侯惇, General.張遼);
+    }
+
+    private void giveDodge(Player p, com.gaas.threeKingdoms.handcard.PlayCard card) {
+        p.getHand().addCardToHand(new Dodge(card));
+    }
+
+    @DisplayName("""
+            Given 曹操為主公，C 為 Wei（夏侯惇）、D 為非 Wei
+            When  A 對曹操 (B) 出殺
+            Then  emit AskHuJiaEffectEvent 給 C；不 emit AskDodgeEvent；stack 頂為 WaitingHuJiaResponseBehavior；activePlayer = C
+            """)
+    @Test
+    public void givenMonarchCaoCaoAndOneWei_WhenKilled_ThenAskHuJiaToWei() {
+        Game game = setupMonarchCaoCaoWithOneWei();
+        Player playerC = game.getPlayer("player-c");
+        giveDodge(playerC, BH2028);
+
+        List<DomainEvent> events = game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        AskHuJiaEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskHuJiaEffectEvent)
+                .map(e -> (AskHuJiaEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskHuJiaEffectEvent"));
+        assertEquals("player-c", ask.getPlayerId());
+        assertEquals("player-b", ask.getCaoCaoPlayerId());
+        assertEquals(List.of(BH2028.getCardId()), ask.getDodgeCardIdsInHand());
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskDodgeEvent),
+                "AskDodgeEvent should be replaced by HuJia ask");
+        assertTrue(game.peekTopBehavior() instanceof WaitingHuJiaResponseBehavior);
+        assertEquals("player-c", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("""
+            Given 曹操為主公、C/D 皆 Wei，C 有閃 D 無
+            When  A 對曹操出殺、C ACCEPT 出閃
+            Then  C 失去該閃、曹操 HP 不變、stack 回到 Normal、HuJiaEffectEvent(accepted=true) 出現
+            """)
+    @Test
+    public void givenMonarchCaoCao_WhenWeiAcceptDodge_ThenCaoCaoNotDamaged() {
+        Game game = setupMonarchCaoCaoWithTwoWei();
+        Player playerB = game.getPlayer("player-b");
+        Player playerC = game.getPlayer("player-c");
+        giveDodge(playerC, BH2028);
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        List<DomainEvent> events = game.playerUseHuJiaEffect(
+                "player-c", AskHuJiaEffectEvent.Choice.ACCEPT, BH2028.getCardId());
+
+        assertEquals(4, playerB.getHP());
+        assertTrue(playerC.getHand().getCards().stream().noneMatch(c -> c.getId().equals(BH2028.getCardId())),
+                "Wei should lose the dodge");
+        HuJiaEffectEvent huJia = events.stream()
+                .filter(e -> e instanceof HuJiaEffectEvent)
+                .map(e -> (HuJiaEffectEvent) e)
+                .findFirst().orElseThrow();
+        assertTrue(huJia.isAccepted());
+        assertEquals(BH2028.getCardId(), huJia.getDodgeCardId());
+        assertTrue(game.isTopBehaviorEmpty(), "behavior stack should be empty after dodge resolves");
+    }
+
+    @DisplayName("""
+            Given 曹操主公、C/D 皆 Wei
+            When  C DECLINE
+            Then  emit 下一個 AskHuJiaEffectEvent(D)、activePlayer = D、stack 仍是 WaitingHuJiaResponseBehavior
+            """)
+    @Test
+    public void givenFirstWeiDecline_ThenAskNextWei() {
+        Game game = setupMonarchCaoCaoWithTwoWei();
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        List<DomainEvent> events = game.playerUseHuJiaEffect(
+                "player-c", AskHuJiaEffectEvent.Choice.DECLINE, null);
+
+        AskHuJiaEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskHuJiaEffectEvent)
+                .map(e -> (AskHuJiaEffectEvent) e)
+                .findFirst().orElseThrow();
+        assertEquals("player-d", ask.getPlayerId());
+        assertTrue(game.peekTopBehavior() instanceof WaitingHuJiaResponseBehavior);
+        assertEquals("player-d", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("""
+            Given 曹操主公、僅 C 為 Wei，C 無閃
+            When  C DECLINE（最後一個 Wei）
+            Then  pop WaitingHuJia、emit AskDodgeEvent(曹操)、activePlayer = 曹操
+            """)
+    @Test
+    public void givenAllWeiDecline_ThenFallbackToAskCaoCaoDodge() {
+        Game game = setupMonarchCaoCaoWithOneWei();
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        List<DomainEvent> events = game.playerUseHuJiaEffect(
+                "player-c", AskHuJiaEffectEvent.Choice.DECLINE, null);
+
+        AskDodgeEvent ask = events.stream()
+                .filter(e -> e instanceof AskDodgeEvent)
+                .map(e -> (AskDodgeEvent) e)
+                .findFirst().orElseThrow();
+        assertEquals("player-b", ask.getPlayerId());
+        assertFalse(game.peekTopBehavior() instanceof WaitingHuJiaResponseBehavior);
+        assertTrue(game.peekTopBehavior() instanceof NormalActiveKillBehavior);
+        assertEquals("player-b", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("""
+            Given 曹操非主公（MINISTER）、其他 Wei 存活
+            When  曹操被殺
+            Then  不觸發護駕，emit AskDodgeEvent(曹操)
+            """)
+    @Test
+    public void givenCaoCaoIsNotMonarch_NoHuJiaTrigger() {
+        Game game = setupGame(General.劉備 /* not 曹操 → makes B = MINISTER */, General.夏侯惇, General.張遼);
+        // override: B 仍是曹操 but as MINISTER（setupGame 已根據 caoCaoRole != 曹操 設成 MINISTER）
+
+        List<DomainEvent> events = game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskHuJiaEffectEvent));
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent));
+    }
+
+    @DisplayName("""
+            Given 曹操主公、無其他存活 Wei（C / D 皆非 Wei）
+            When  曹操被殺
+            Then  不觸發護駕，emit AskDodgeEvent(曹操)
+            """)
+    @Test
+    public void givenMonarchCaoCao_NoOtherAliveWei_NoHuJiaTrigger() {
+        Game game = setupGame(General.曹操, General.諸葛亮, General.孫權);
+
+        List<DomainEvent> events = game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskHuJiaEffectEvent));
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent));
+    }
+
+    @DisplayName("""
+            Given 曹操主公、唯一 Wei 武將為死亡狀態
+            Then  不觸發護駕
+            """)
+    @Test
+    public void givenOnlyWeiHelperIsDead_NoHuJiaTrigger() {
+        Game game = setupMonarchCaoCaoWithOneWei();
+        game.getPlayer("player-c").setHealthStatus(HealthStatus.DEATH);
+
+        List<DomainEvent> events = game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskHuJiaEffectEvent));
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent));
+    }
+
+    @DisplayName("""
+            Given 曹操主公、僅 C 為 Wei；C 嘗試 ACCEPT 但傳的 cardId 不在手中
+            Then  throws IllegalArgumentException
+            """)
+    @Test
+    public void givenAcceptWithCardNotInHand_Throws() {
+        Game game = setupMonarchCaoCaoWithOneWei();
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseHuJiaEffect("player-c", AskHuJiaEffectEvent.Choice.ACCEPT, BH2028.getCardId()));
+    }
+
+    @DisplayName("""
+            Given 曹操主公、C 為 Wei、C 嘗試 ACCEPT 非閃 cardId（殺）
+            Then  throws IllegalArgumentException
+            """)
+    @Test
+    public void givenAcceptWithNonDodgeCard_Throws() {
+        Game game = setupMonarchCaoCaoWithOneWei();
+        game.getPlayer("player-c").getHand().addCardToHand(new Kill(BS9009));
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseHuJiaEffect("player-c", AskHuJiaEffectEvent.Choice.ACCEPT, BS9009.getCardId()));
+    }
+
+    @DisplayName("""
+            Given 萬箭齊發瞄到曹操主公 + 其他 Wei 存活
+            When  輪詢到曹操這 reactor
+            Then  emit AskHuJiaEffectEvent（不 emit AskDodge），stack 頂為 WaitingHuJia 在 ArrowBarrage 上
+            """)
+    @Test
+    public void givenArrowBarrageWithMonarchCaoCao_HuJiaFiresOnCaoCaoTurn() {
+        Game game = setupMonarchCaoCaoWithTwoWei();
+        Player playerA = game.getPlayer("player-a");
+        playerA.getHand().addCardToHand(new ArrowBarrage(SS7007));
+
+        // A 出萬箭，假設 B 第一個被詢問（座位順序）
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-b", "active");
+
+        // ArrowBarrage 應已 push；驗證 stack 頂是 WaitingHuJia，next-second 是 ArrowBarrage
+        assertTrue(game.peekTopBehavior() instanceof WaitingHuJiaResponseBehavior,
+                "WaitingHuJia should be top while polling Cao Cao");
+        assertTrue(game.peekTopBehaviorSecondElement()
+                .map(b -> b instanceof ArrowBarrageBehavior).orElse(false),
+                "ArrowBarrage should be the parent behavior");
+    }
+
+    @DisplayName("""
+            Given 方天畫戟瞄到曹操主公（多目標）+ 其他 Wei 存活
+            When  曹操是當前 reactor
+            Then  emit AskHuJiaEffectEvent；stack：HeavenlyDoubleHalberd / WaitingHuJia
+            """)
+    @Test
+    public void givenHeavenlyDoubleHalberdWithMonarchCaoCao_HuJiaFiresOnCaoCaoTurn() {
+        Game game = setupMonarchCaoCaoWithTwoWei();
+        Player playerA = game.getPlayer("player-a");
+        playerA.getEquipment().setWeapon(new HeavenlyDoubleHalberdCard(EDQ103));
+        // 把 A 手牌弄成「只剩這張殺」(setupGame 已加了 BS8008)
+        // 方天畫戟需要 A 手中只剩一張 Kill
+
+        game.playerUseHeavenlyDoubleHalberdKill(
+                "player-a", BS8008.getCardId(), List.of("player-b", "player-c"));
+
+        assertTrue(game.peekTopBehavior() instanceof WaitingHuJiaResponseBehavior);
+        assertTrue(game.peekTopBehaviorSecondElement()
+                .map(b -> b instanceof HeavenlyDoubleHalberdKillBehavior).orElse(false),
+                "HeavenlyDoubleHalberd should be parent");
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/PlayerDeathTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/PlayerDeathTest.java
@@ -908,11 +908,11 @@ public class PlayerDeathTest {
         Game game = new Game();
         game.initDeck();
 
-        // A: 反賊
+        // A: 反賊（用非魏武將避免觸發護駕主公技干擾本死亡流程測試）
         Player playerA = PlayerBuilder.construct()
                 .withId("player-a")
                 .withBloodCard(new BloodCard(4))
-                .withGeneralCard(new GeneralCard(General.張遼))
+                .withGeneralCard(new GeneralCard(General.馬超))
                 .withHealthStatus(HealthStatus.ALIVE)
                 .withRoleCard(new RoleCard(Role.REBEL))
                 .withHand(new Hand())
@@ -942,11 +942,11 @@ public class PlayerDeathTest {
                 .withEquipment(new Equipment())
                 .build();
 
-        // D: 內奸
+        // D: 內奸（用非魏武將避免觸發護駕主公技干擾本死亡流程測試）
         Player playerD = PlayerBuilder.construct()
                 .withId("player-d")
                 .withBloodCard(new BloodCard(4))
-                .withGeneralCard(new GeneralCard(General.司馬懿))
+                .withGeneralCard(new GeneralCard(General.諸葛亮))
                 .withHealthStatus(HealthStatus.ALIVE)
                 .withRoleCard(new RoleCard(Role.TRAITOR))
                 .withHand(new Hand())

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/GameController.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/GameController.java
@@ -38,6 +38,7 @@ public class GameController {
     private final UseGreenDragonCrescentBladeEffectUseCase useGreenDragonCrescentBladeEffectUseCase;
     private final UseStonePiercingAxeEffectUseCase useStonePiercingAxeEffectUseCase;
     private final UseJianXiongEffectUseCase useJianXiongEffectUseCase;
+    private final UseHuJiaEffectUseCase useHuJiaEffectUseCase;
     private final UseViperSpearKillUseCase useViperSpearKillUseCase;
     private final UseHeavenlyDoubleHalberdKillUseCase useHeavenlyDoubleHalberdKillUseCase;
 
@@ -185,6 +186,14 @@ public class GameController {
         UseJianXiongEffectPresenter presenter = new UseJianXiongEffectPresenter();
         useJianXiongEffectUseCase.execute(gameId, request.toUseJianXiongEffectRequest(), presenter);
         webSocketBroadCast.pushUseJianXiongEffectEvent(presenter);
+        return ResponseEntity.ok(HttpStatus.OK);
+    }
+
+    @PostMapping("/api/games/{gameId}/player:useHuJiaEffect")
+    public ResponseEntity<?> playerUseHuJiaEffect(@PathVariable String gameId, @RequestBody UseHuJiaEffectRequest request) {
+        UseHuJiaEffectPresenter presenter = new UseHuJiaEffectPresenter();
+        useHuJiaEffectUseCase.execute(gameId, request.toUseHuJiaEffectRequest(), presenter);
+        webSocketBroadCast.pushUseHuJiaEffectEvent(presenter);
         return ResponseEntity.ok(HttpStatus.OK);
     }
 

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/WebSocketBroadCast.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/WebSocketBroadCast.java
@@ -231,6 +231,19 @@ public class WebSocketBroadCast {
         }
     }
 
+    public void pushUseHuJiaEffectEvent(UseHuJiaEffectPresenter presenter) {
+        List<UseHuJiaEffectPresenter.GameViewModel> viewModels = presenter.present();
+        try {
+            for (UseHuJiaEffectPresenter.GameViewModel viewModel : viewModels) {
+                String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(viewModel);
+                messagingTemplate.convertAndSend(String.format("/websocket/legendsOfTheThreeKingdoms/%s/%s", viewModel.getGameId(), viewModel.getPlayerId()), json);
+            }
+        } catch (Exception e) {
+            System.err.println("****************** pushUseHuJiaEffectEvent ");
+            e.printStackTrace();
+        }
+    }
+
     public void pushUseStonePiercingAxeEffectEvent(UseStonePiercingAxeEffectPresenter presenter) {
         List<UseStonePiercingAxeEffectPresenter.GameViewModel> viewModels = presenter.present();
         try {

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/UseHuJiaEffectRequest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/UseHuJiaEffectRequest.java
@@ -1,0 +1,17 @@
+package com.gaas.threeKingdoms.controller.dto;
+
+import com.gaas.threeKingdoms.usecase.UseHuJiaEffectUseCase;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UseHuJiaEffectRequest {
+    private String playerId;
+    private String choice;   // "ACCEPT" or "DECLINE"
+    private String cardId;   // 必填 when ACCEPT
+
+    public UseHuJiaEffectUseCase.UseHuJiaEffectRequest toUseHuJiaEffectRequest() {
+        return new UseHuJiaEffectUseCase.UseHuJiaEffectRequest(playerId, choice, cardId);
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseHuJiaEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseHuJiaEffectPresenter.java
@@ -1,0 +1,97 @@
+package com.gaas.threeKingdoms.presenter;
+
+import com.gaas.threeKingdoms.events.*;
+import com.gaas.threeKingdoms.presenter.common.GameDataViewModel;
+import com.gaas.threeKingdoms.presenter.common.PlayerDataViewModel;
+import com.gaas.threeKingdoms.presenter.common.RoundDataViewModel;
+import com.gaas.threeKingdoms.presenter.mapper.DomainEventToViewModelMapper;
+import com.gaas.threeKingdoms.usecase.UseHuJiaEffectUseCase;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.gaas.threeKingdoms.presenter.ViewModel.getEvent;
+
+public class UseHuJiaEffectPresenter implements UseHuJiaEffectUseCase.UseHuJiaEffectPresenter<List<UseHuJiaEffectPresenter.GameViewModel>> {
+
+    private List<GameViewModel> viewModels = new ArrayList<>();
+    private final DomainEventToViewModelMapper domainEventToViewModelMapper = new DomainEventToViewModelMapper();
+
+    @Override
+    public void renderEvents(List<DomainEvent> events) {
+        List<ViewModel<?>> effectViewModels = domainEventToViewModelMapper.mapEventsToViewModels(events);
+
+        GameStatusEvent gameStatusEvent = getEvent(events, GameStatusEvent.class).orElseThrow();
+        List<PlayerEvent> playerEvents = gameStatusEvent.getSeats();
+        RoundEvent roundEvent = gameStatusEvent.getRound();
+        List<PlayerDataViewModel> playerDataViewModels = playerEvents.stream().map(PlayerDataViewModel::new).toList();
+
+        RoundDataViewModel roundDataViewModel = new RoundDataViewModel(roundEvent);
+
+        for (PlayerDataViewModel viewModel : playerDataViewModels) {
+            GameDataViewModel gameDataViewModel = new GameDataViewModel(
+                    PlayerDataViewModel.hiddenOtherPlayerRoleInformation(
+                            playerDataViewModels, viewModel.getId()), roundDataViewModel, gameStatusEvent.getGamePhase());
+
+            viewModels.add(new GameViewModel(
+                    new ArrayList<>(effectViewModels),
+                    gameDataViewModel,
+                    gameStatusEvent.getMessage(),
+                    gameStatusEvent.getGameId(),
+                    viewModel.getId()));
+        }
+    }
+
+    @Override
+    public List<GameViewModel> present() {
+        return viewModels;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class GameViewModel extends GameProcessViewModel<GameDataViewModel> {
+        private String gameId;
+        private String playerId;
+
+        public GameViewModel(List<ViewModel<?>> viewModels, GameDataViewModel data, String message, String gameId, String playerId) {
+            super(viewModels, data, message);
+            this.gameId = gameId;
+            this.playerId = playerId;
+        }
+    }
+
+    public static class AskHuJiaEffectViewModel extends ViewModel<AskHuJiaEffectDataViewModel> {
+        public AskHuJiaEffectViewModel(AskHuJiaEffectDataViewModel data) {
+            super("AskHuJiaEffectEvent", data, "護駕：是否代替主公出閃");
+        }
+    }
+
+    public static class HuJiaEffectViewModel extends ViewModel<HuJiaEffectDataViewModel> {
+        public HuJiaEffectViewModel(HuJiaEffectDataViewModel data) {
+            super("HuJiaEffectEvent", data, "護駕回應");
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AskHuJiaEffectDataViewModel {
+        private String playerId;
+        private String caoCaoPlayerId;
+        private List<String> dodgeCardIdsInHand;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class HuJiaEffectDataViewModel {
+        private String playerId;
+        private String caoCaoPlayerId;
+        private boolean accepted;
+        private String dodgeCardId;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/mapper/DomainEventToViewModelMapper.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/mapper/DomainEventToViewModelMapper.java
@@ -300,6 +300,27 @@ public class DomainEventToViewModelMapper {
             return new UseJianXiongEffectPresenter.JianXiongEffectViewModel(dataViewModel);
         });
 
+        eventToViewModelMappers.put(AskHuJiaEffectEvent.class, event -> {
+            AskHuJiaEffectEvent askEvent = (AskHuJiaEffectEvent) event;
+            UseHuJiaEffectPresenter.AskHuJiaEffectDataViewModel dataViewModel = new UseHuJiaEffectPresenter.AskHuJiaEffectDataViewModel(
+                    askEvent.getPlayerId(),
+                    askEvent.getCaoCaoPlayerId(),
+                    askEvent.getDodgeCardIdsInHand()
+            );
+            return new UseHuJiaEffectPresenter.AskHuJiaEffectViewModel(dataViewModel);
+        });
+
+        eventToViewModelMappers.put(HuJiaEffectEvent.class, event -> {
+            HuJiaEffectEvent huJiaEvent = (HuJiaEffectEvent) event;
+            UseHuJiaEffectPresenter.HuJiaEffectDataViewModel dataViewModel = new UseHuJiaEffectPresenter.HuJiaEffectDataViewModel(
+                    huJiaEvent.getPlayerId(),
+                    huJiaEvent.getCaoCaoPlayerId(),
+                    huJiaEvent.isAccepted(),
+                    huJiaEvent.getDodgeCardId()
+            );
+            return new UseHuJiaEffectPresenter.HuJiaEffectViewModel(dataViewModel);
+        });
+
         eventToViewModelMappers.put(AskChooseMountCardEvent.class, event -> {
             AskChooseMountCardEvent askChooseMountEvent = (AskChooseMountCardEvent) event;
             UseEquipmentEffectPresenter.AskChooseMountCardDataViewModel dataViewModel = new UseEquipmentEffectPresenter.AskChooseMountCardDataViewModel(

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
@@ -25,6 +25,9 @@ public class BehaviorData {
     private static final String POLLING_STARTED = "POLLING_STARTED";
     private static final String VIPER_SPEAR_DISCARDED_CARD_IDS = "VIPER_SPEAR_DISCARDED_CARD_IDS";
     private static final String JIANXIONG_SOURCE_CARD_IDS = "JIANXIONG_SOURCE_CARD_IDS";
+    private static final String HUJIA_CAOCAO_ID = "HUJIA_CAOCAO_ID";
+    private static final String HUJIA_WEI_ORDER = "HUJIA_WEI_ORDER";
+    private static final String HUJIA_CURRENT_INDEX = "HUJIA_CURRENT_INDEX";
     private static final String DYING_PENDING_SOURCE_CARD_ID = "DYING_PENDING_SOURCE_CARD_ID";
     private static final String DYING_PENDING_ATTACKER_PLAYER_ID = "DYING_PENDING_ATTACKER_PLAYER_ID";
     private static final String DYING_PENDING_VIPER_SPEAR_DISCARD_CARD_IDS = "DYING_PENDING_VIPER_SPEAR_DISCARD_CARD_IDS";
@@ -383,6 +386,24 @@ public class BehaviorData {
                         sourceCardIds
                 );
             }
+            case "WaitingHuJiaResponseBehavior" -> {
+                @SuppressWarnings("unchecked")
+                List<String> weiOrder = params != null && params.get(HUJIA_WEI_ORDER) != null
+                        ? (List<String>) params.get(HUJIA_WEI_ORDER)
+                        : List.of();
+                int currentIndex = params != null && params.get(HUJIA_CURRENT_INDEX) != null
+                        ? ((Number) params.get(HUJIA_CURRENT_INDEX)).intValue()
+                        : 0;
+                String caoCaoId = params != null && params.get(HUJIA_CAOCAO_ID) != null
+                        ? (String) params.get(HUJIA_CAOCAO_ID)
+                        : behaviorPlayerId;
+                yield new com.gaas.threeKingdoms.behavior.behavior.WaitingHuJiaResponseBehavior(
+                        game,
+                        game.getPlayer(caoCaoId),
+                        weiOrder,
+                        currentIndex
+                );
+            }
             default -> throw new RuntimeException("Unknown behavior name: " + behaviorName);
         };
         behavior.setIsOneRound(isOneRound);
@@ -403,6 +424,10 @@ public class BehaviorData {
             params.put(VIPER_SPEAR_DISCARDED_CARD_IDS, vs.getDiscardedCardIds());
         } else if (behavior instanceof WaitingJianXiongResponseBehavior jx) {
             params.put(JIANXIONG_SOURCE_CARD_IDS, jx.getSourceCardIds());
+        } else if (behavior instanceof com.gaas.threeKingdoms.behavior.behavior.WaitingHuJiaResponseBehavior huJia) {
+            params.put(HUJIA_CAOCAO_ID, huJia.getCaoCaoPlayerId());
+            params.put(HUJIA_WEI_ORDER, huJia.getWeiOrder());
+            params.put(HUJIA_CURRENT_INDEX, huJia.getCurrentIndex());
         } else if (behavior instanceof DyingAskPeachBehavior dying) {
             if (dying.getPendingSourceCardId() != null) {
                 params.put(DYING_PENDING_SOURCE_CARD_ID, dying.getPendingSourceCardId());

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/GeneralCardData.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/GeneralCardData.java
@@ -36,11 +36,19 @@ public class GeneralCardData {
         generalCard.setGeneralName(this.generalName);
         generalCard.setHealthPoint(this.healthPoint);
         generalCard.setGender(this.gender);
-        // 對舊資料（無 faction）做 fallback 推導
-        generalCard.setFaction(this.faction != null
-                ? this.faction
-                : (this.generalId != null ? General.findById(this.generalId).getFaction() : null));
+        generalCard.setFaction(this.faction != null ? this.faction : tryDeriveFaction(this.generalId));
         return generalCard;
+    }
+
+    // 舊存檔可能沒有 faction 欄位；嘗試從 generalId 反推。未知 generalId（例如被移除的
+    // non-standard 武將、測試虛擬值）回 null 而非 throw，避免反序列化整個遊戲 crash。
+    private static Faction tryDeriveFaction(String generalId) {
+        if (generalId == null) return null;
+        try {
+            return General.findById(generalId).getFaction();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     // Convert from domain object

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/GeneralCardData.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/GeneralCardData.java
@@ -1,6 +1,8 @@
 package com.gaas.threeKingdoms.repository.data;
 
+import com.gaas.threeKingdoms.generalcard.Faction;
 import com.gaas.threeKingdoms.generalcard.Gender;
+import com.gaas.threeKingdoms.generalcard.General;
 import com.gaas.threeKingdoms.generalcard.GeneralCard;
 import lombok.Builder;
 import lombok.Data;
@@ -16,6 +18,7 @@ public class GeneralCardData {
     private String generalName;
     private int healthPoint;
     private Gender gender;
+    private Faction faction;
 
     // Backward-compat constructor for tests created before gender field was added
     public GeneralCardData(String generalId, String generalName, int healthPoint) {
@@ -23,6 +26,7 @@ public class GeneralCardData {
         this.generalName = generalName;
         this.healthPoint = healthPoint;
         this.gender = null;
+        this.faction = null;
     }
 
     // Convert to domain object
@@ -32,6 +36,10 @@ public class GeneralCardData {
         generalCard.setGeneralName(this.generalName);
         generalCard.setHealthPoint(this.healthPoint);
         generalCard.setGender(this.gender);
+        // 對舊資料（無 faction）做 fallback 推導
+        generalCard.setFaction(this.faction != null
+                ? this.faction
+                : (this.generalId != null ? General.findById(this.generalId).getFaction() : null));
         return generalCard;
     }
 
@@ -46,6 +54,7 @@ public class GeneralCardData {
                 .generalName(generalCard.getGeneralName())
                 .healthPoint(generalCard.getHealthPoint())
                 .gender(generalCard.getGender())
+                .faction(generalCard.getFaction())
                 .build();
     }
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/MockMvcUtil.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/MockMvcUtil.java
@@ -92,6 +92,17 @@ public class MockMvcUtil {
                         }""", playerId, choice)));
     }
 
+    public ResultActions useHuJiaEffect(String gameId, String playerId, String choice, String cardId) throws Exception {
+        String cardIdJson = cardId == null ? "null" : "\"" + cardId + "\"";
+        return this.mockMvc.perform(post("/api/games/" + gameId + "/player:useHuJiaEffect")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(String.format("""
+                        { "playerId": "%s",
+                          "choice": "%s",
+                          "cardId": %s
+                        }""", playerId, choice, cardIdJson)));
+    }
+
     public ResultActions useGreenDragonCrescentBladeEffect(String gameId, String playerId, String choice, String killCardId) throws Exception {
         return this.mockMvc.perform(post("/api/games/" + gameId + "/player:useGreenDragonCrescentBladeEffect")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/HuJiaTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/HuJiaTest.java
@@ -1,0 +1,99 @@
+package com.gaas.threeKingdoms.e2e.skill;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.Deck;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.player.HealthStatus;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.rolecard.Role;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.gaas.threeKingdoms.e2e.MockUtil.createPlayer;
+import static com.gaas.threeKingdoms.e2e.MockUtil.initGame;
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class HuJiaTest extends AbstractBaseIntegrationTest {
+
+    // 若需要重產本 class 的 fixture，把下列 @Override 取消註解並改為 return true，
+    // 產完後務必改回 false 或刪除 override 再 commit。
+    // @Override protected boolean shouldRegenerateFixtures() { return true; }
+
+    /**
+     * 4 人場，B = 曹操 主公，D = 夏侯惇（魏忠臣，代閃者）
+     * A 出殺打 B → HuJia 觸發 → D ACCEPT → 代閃成功
+     */
+    @Test
+    public void testCaoCaoMonarchAskedDodge_WeiHelperAcceptsAndSubstitutes() throws Exception {
+        // Given
+        Player playerA = createPlayer("player-a", 4, General.馬超, HealthStatus.ALIVE, Role.REBEL,
+                new Kill(BS8008));
+        Player playerB = createPlayer("player-b", 4, General.曹操, HealthStatus.ALIVE, Role.MONARCH);
+        Player playerC = createPlayer("player-c", 4, General.趙雲, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerD = createPlayer("player-d", 4, General.夏侯惇, HealthStatus.ALIVE, Role.MINISTER,
+                new Dodge(BH2028));
+        List<Player> players = Arrays.asList(playerA, playerB, playerC, playerD);
+        Game game = initGame(gameId, players, playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Peach(BH3029)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // When A 出殺打 B → 觸發護駕，活躍轉到 D（唯一其他 Wei）
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // D ACCEPT 出閃代替曹操
+        mockMvcUtil.useHuJiaEffect(gameId, "player-d", "ACCEPT", BH2028.getCardId())
+                .andExpect(status().isOk()).andReturn();
+
+        // Then 驗證所有玩家收到的 JSON：曹操不扣血、D 失去閃
+        assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_accept_for_%s.json");
+    }
+
+    /**
+     * 4 人場，B = 曹操 主公，D = 夏侯惇（魏忠臣）
+     * A 出殺打 B → HuJia → D DECLINE → fallback emit AskDodge(B) → B SKIP → 扣血
+     */
+    @Test
+    public void testCaoCaoMonarchAskedDodge_AllWeiDeclined_FallbackToCaoCaoDodge() throws Exception {
+        // Given
+        Player playerA = createPlayer("player-a", 4, General.馬超, HealthStatus.ALIVE, Role.REBEL,
+                new Kill(BS8008));
+        Player playerB = createPlayer("player-b", 4, General.曹操, HealthStatus.ALIVE, Role.MONARCH);
+        Player playerC = createPlayer("player-c", 4, General.趙雲, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerD = createPlayer("player-d", 4, General.夏侯惇, HealthStatus.ALIVE, Role.MINISTER);
+        List<Player> players = Arrays.asList(playerA, playerB, playerC, playerD);
+        Game game = initGame(gameId, players, playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Peach(BH3029)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // When A 出殺打 B → 護駕 ask D
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // D DECLINE → 應 fallback emit AskDodge(B)
+        mockMvcUtil.useHuJiaEffect(gameId, "player-d", "DECLINE", null)
+                .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // B SKIP → 扣血
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk()).andReturn();
+
+        // Then 曹操 HP=3
+        assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_decline_then_skip_for_%s.json");
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_accept_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_accept_for_player_a.json
@@ -1,0 +1,79 @@
+{
+  "events" : [ {
+    "event" : "HuJiaEffectEvent",
+    "data" : {
+      "playerId" : "player-d",
+      "caoCaoPlayerId" : "player-b",
+      "accepted" : true,
+      "dodgeCardId" : "BH2028"
+    },
+    "message" : "護駕回應"
+  }, {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-d",
+      "targetPlayerId" : "player-a",
+      "cardId" : "BH2028",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU006",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU005",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "WEI003",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_accept_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_accept_for_player_b.json
@@ -1,0 +1,79 @@
+{
+  "events" : [ {
+    "event" : "HuJiaEffectEvent",
+    "data" : {
+      "playerId" : "player-d",
+      "caoCaoPlayerId" : "player-b",
+      "accepted" : true,
+      "dodgeCardId" : "BH2028"
+    },
+    "message" : "護駕回應"
+  }, {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-d",
+      "targetPlayerId" : "player-a",
+      "cardId" : "BH2028",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU006",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU005",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "WEI003",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_accept_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_accept_for_player_c.json
@@ -1,0 +1,79 @@
+{
+  "events" : [ {
+    "event" : "HuJiaEffectEvent",
+    "data" : {
+      "playerId" : "player-d",
+      "caoCaoPlayerId" : "player-b",
+      "accepted" : true,
+      "dodgeCardId" : "BH2028"
+    },
+    "message" : "護駕回應"
+  }, {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-d",
+      "targetPlayerId" : "player-a",
+      "cardId" : "BH2028",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU006",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU005",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "WEI003",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_accept_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_accept_for_player_d.json
@@ -1,0 +1,79 @@
+{
+  "events" : [ {
+    "event" : "HuJiaEffectEvent",
+    "data" : {
+      "playerId" : "player-d",
+      "caoCaoPlayerId" : "player-b",
+      "accepted" : true,
+      "dodgeCardId" : "BH2028"
+    },
+    "message" : "護駕回應"
+  }, {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-d",
+      "targetPlayerId" : "player-a",
+      "cardId" : "BH2028",
+      "playType" : "active"
+    },
+    "message" : "出牌"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU006",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Monarch",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU005",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "WEI003",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-a",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_decline_then_skip_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_decline_then_skip_for_player_a.json
@@ -1,0 +1,85 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "targetPlayerId" : "player-a",
+      "cardId" : "",
+      "playType" : "skip"
+    },
+    "message" : "不出牌"
+  }, {
+    "event" : "PlayerDamagedEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "from" : 4,
+      "to" : 3
+    },
+    "message" : "扣血"
+  }, {
+    "event" : "AskJianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "BS8008" ]
+    },
+    "message" : "奸雄：是否獲得造成傷害的牌"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU006",
+      "roleId" : "Rebel",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Monarch",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU005",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "WEI003",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-b",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "不出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-a"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_decline_then_skip_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_decline_then_skip_for_player_b.json
@@ -1,0 +1,85 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "targetPlayerId" : "player-a",
+      "cardId" : "",
+      "playType" : "skip"
+    },
+    "message" : "不出牌"
+  }, {
+    "event" : "PlayerDamagedEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "from" : 4,
+      "to" : 3
+    },
+    "message" : "扣血"
+  }, {
+    "event" : "AskJianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "BS8008" ]
+    },
+    "message" : "奸雄：是否獲得造成傷害的牌"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU006",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Monarch",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU005",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "WEI003",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-b",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "不出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-b"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_decline_then_skip_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_decline_then_skip_for_player_c.json
@@ -1,0 +1,85 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "targetPlayerId" : "player-a",
+      "cardId" : "",
+      "playType" : "skip"
+    },
+    "message" : "不出牌"
+  }, {
+    "event" : "PlayerDamagedEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "from" : 4,
+      "to" : 3
+    },
+    "message" : "扣血"
+  }, {
+    "event" : "AskJianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "BS8008" ]
+    },
+    "message" : "奸雄：是否獲得造成傷害的牌"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU006",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Monarch",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU005",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "WEI003",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-b",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "不出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-c"
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_decline_then_skip_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_decline_then_skip_for_player_d.json
@@ -1,0 +1,85 @@
+{
+  "events" : [ {
+    "event" : "PlayCardEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "targetPlayerId" : "player-a",
+      "cardId" : "",
+      "playType" : "skip"
+    },
+    "message" : "不出牌"
+  }, {
+    "event" : "PlayerDamagedEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "from" : 4,
+      "to" : 3
+    },
+    "message" : "扣血"
+  }, {
+    "event" : "AskJianXiongEffectEvent",
+    "data" : {
+      "playerId" : "player-b",
+      "sourceCardIds" : [ "BS8008" ]
+    },
+    "message" : "奸雄：是否獲得造成傷害的牌"
+  } ],
+  "data" : {
+    "seats" : [ {
+      "id" : "player-a",
+      "generalId" : "SHU006",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-b",
+      "generalId" : "WEI001",
+      "roleId" : "Monarch",
+      "hp" : 3,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-c",
+      "generalId" : "SHU005",
+      "roleId" : "",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    }, {
+      "id" : "player-d",
+      "generalId" : "WEI003",
+      "roleId" : "Minister",
+      "hp" : 4,
+      "hand" : {
+        "size" : 0,
+        "cardIds" : [ ]
+      },
+      "equipments" : [ "", "", "", "" ],
+      "delayScrolls" : [ ]
+    } ],
+    "round" : {
+      "roundPhase" : "Judgement",
+      "currentRoundPlayer" : "player-a",
+      "activePlayer" : "player-b",
+      "dyingPlayer" : "",
+      "showKill" : true
+    },
+    "gamePhase" : "Normal"
+  },
+  "message" : "不出牌",
+  "gameId" : "my-id",
+  "playerId" : "player-d"
+}


### PR DESCRIPTION
## Summary
- 護駕（主公技）：當主公曹操需要打出閃時，依座位順序詢問其他存活魏勢力武將是否代閃；任一人 ACCEPT 視為曹操出此閃，全部 DECLINE 則 fallback 回原本的 AskDodge(曹操)。
- 補基礎設施：`Faction` enum（蜀/魏/吳/群）+ `General.faction` 欄位 + `GeneralCardData` 持久化；`BeforeAskDodgeSkill` 通用 trigger + `SkillEngine.beforeAskDodge` hook；`HuJiaCompatibleAskDodgeBehavior` marker。
- 新 endpoint `POST /api/games/{gameId}/player:useHuJiaEffect`（沿用奸雄四層 DTO+UseCase+Controller+Presenter pattern）。
- 三處 AskDodge emitter 接 hook：`NormalActiveKillBehavior` / `ArrowBarrageBehavior` / `HeavenlyDoubleHalberdKillBehavior`，每個 host 實作 `acceptDodgeFromHuJia` 接續 GDCB / 貫石斧 / AOE polling。

## Behavior
- ACCEPT：Wei 棄一張閃到墓地 → `HuJiaEffectEvent(accepted=true)` → pop WaitingHuJia → parent host 走「視為曹操打出」的後續鏈
- DECLINE：`HuJiaEffectEvent(accepted=false)` → 換下一位 Wei；全拒時 emit `AskDodgeEvent(曹操)` 並切回曹操為 activePlayer
- 視為曹操出閃 → 攻擊者的青龍偃月刀 / 貫石斧鏈仍正常觸發（per FAQ）

## Why
PR #197 把奸雄 + 武將技骨架合入 main。護駕同時要建立未來反覆使用的基礎（Faction 模型、AskDodge 前介入 hook、代閃 substitution 機制），所以一起做。Faction enum 為後續其他主公技（蜀 激將、吳 救援）鋪路。

## Scope 限制（follow-up）
- v1 只覆蓋三處主要 AskDodge emitter；其他二次 AskDodge 場景（八卦陣失敗、青龍鏈再次 ask、雌雄雙股劍、丈八蛇矛被動殺、瀕死 resume polling）尚未接 hook
- 其他主公技（激將/救援）待後續實作

## Test plan
- [x] `mvn -pl domain test`：409 → 420 tests，全綠（HuJiaSkillTest 11 case + PlayerDeathTest 兩處 general 改 non-Wei）
- [x] `mvn -pl spring test`：237 → 239 tests，全綠（HuJiaTest 2 e2e case + fixtures）
- [x] `grep "BeforeAskDodge\|HuJia"`：被引用的位置都對齊
- [ ] Reviewer 確認 API_DOC.md #21 文字與 controller / DTO field 一致
- [ ] Reviewer 確認 v1 scope 取捨（其他 AskDodge emitter 為 follow-up）合理

🤖 Generated with [Claude Code](https://claude.com/claude-code)