### PR TITLE
fix: 方天畫戟多目標殺照座位順序結算 (#202)

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -483,7 +483,7 @@ POST /api/games/{gameId}/player:useHeavenlyDoubleHalberdKill
 |------|------|------|
 | playerId | String | 攻擊者玩家 ID（裝備方天畫戟） |
 | cardId | String | 要打出的殺 cardId（必須為攻擊者**最後一張手牌**） |
-| targetPlayerIds | List\<String\> | 全部目標玩家 ID（size 1~3；index 0 為主要目標；不重複、不含自己、皆需在攻擊範圍內） |
+| targetPlayerIds | List\<String\> | 全部目標玩家 ID（size 1~3；不重複、不含自己、皆需在攻擊範圍內）。傳入順序不影響結算 — 系統會以攻擊者下家起的**座位順序**依次詢問各目標 |
 
 **觸發時機**：攻擊者裝備方天畫戟、手上**只剩一張殺**時主動呼叫（不透過 `playCard` API）
 

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -1061,8 +1061,9 @@ public class Game {
             return playerPlayCard(playerId, cardId, targetPlayerIds.get(0), PlayType.ACTIVE.getPlayType());
         }
 
-        // 9. 多目標 — 取得 primary
-        Player primaryTarget = getPlayer(targetPlayerIds.get(0));
+        // 9. 多目標 — 結算依座位（行動）順序而非 request 傳入順序（issue #202）
+        List<String> seatingOrderedTargets = sortBySeatingOrderFrom(attacker, targetPlayerIds);
+        Player primaryTarget = getPlayer(seatingOrderedTargets.get(0));
 
         // 10. 回合出殺次數限制（考慮諸葛連弩——實際上不會同時裝兩把武器，但保留邏輯對稱性）
         if (currentRound.isShowKill() && !(attacker.getEquipmentWeaponCard() instanceof RepeatingCrossbowCard)) {
@@ -1076,12 +1077,30 @@ public class Game {
 
         // 12. push HeavenlyDoubleHalberdKillBehavior
         HeavenlyDoubleHalberdKillBehavior behavior = new HeavenlyDoubleHalberdKillBehavior(
-                this, attacker, targetPlayerIds, primaryTarget, cardId, killCard);
+                this, attacker, seatingOrderedTargets, primaryTarget, cardId, killCard);
         updateTopBehavior(behavior);
 
         List<DomainEvent> events = behavior.playerAction();
         removeCompletedBehaviors();
         return events;
+    }
+
+    /**
+     * 把 targetIds 重排為座位（行動）順序：以 anchor 的下家為起點沿座位鏈走，
+     * 依序收集出現在 targetIds 中的玩家。
+     */
+    private List<String> sortBySeatingOrderFrom(Player anchor, List<String> targetIds) {
+        List<String> ordered = new ArrayList<>();
+        Set<String> remaining = new HashSet<>(targetIds);
+        Player cursor = anchor;
+        int total = seatingChart.getPlayers().size();
+        for (int i = 0; i < total && !remaining.isEmpty(); i++) {
+            cursor = getNextPlayer(cursor);
+            if (remaining.remove(cursor.getId())) {
+                ordered.add(cursor.getId());
+            }
+        }
+        return ordered;
     }
 
     public List<DomainEvent> useBorrowedSwordEffect(String currentPlayerId, String borrowedPlayerId, String attackTargetPlayerId) {

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HeavenlyDoubleHalberdTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HeavenlyDoubleHalberdTest.java
@@ -65,6 +65,38 @@ public class HeavenlyDoubleHalberdTest {
         assertEquals(0, playerA.getHandSize());
     }
 
+    @DisplayName("targetPlayerIds 傳入順序與座位順序相反 → 結算照座位順序（issue #202）")
+    @Test
+    public void testUseHalberdKill_TargetsGivenInReverseOrder_ResolvedInSeatingOrder() {
+        Game game = createGame();
+        Player playerA = game.getPlayer("player-a");
+        equipHalberdWithSingleKill(playerA);
+
+        // 座位 a → b → c → d；request 故意傳 [d, c, b]
+        List<DomainEvent> events = game.playerUseHeavenlyDoubleHalberdKill(
+                "player-a", BS8008.getCardId(), List.of("player-d", "player-c", "player-b"));
+
+        HeavenlyDoubleHalberdKillTriggerEvent trigger = events.stream()
+                .filter(e -> e instanceof HeavenlyDoubleHalberdKillTriggerEvent)
+                .map(e -> (HeavenlyDoubleHalberdKillTriggerEvent) e)
+                .findFirst().orElseThrow(() -> new AssertionError("trigger event missing"));
+        assertEquals(List.of("player-b", "player-c", "player-d"), trigger.getTargetPlayerIds(),
+                "targets should be re-ordered to seating order from attacker's next player");
+
+        // 第一個被問的應是座位順序最先的 b，而不是 request 第一個 d
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent
+                && ((AskDodgeEvent) e).getPlayerId().equals("player-b")));
+
+        // 走完整輪詢：b → c → d 依序 skip，全部扣血
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(3, game.getPlayer("player-b").getHP());
+        assertEquals(3, game.getPlayer("player-c").getHP());
+        assertEquals(3, game.getPlayer("player-d").getHP());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
     @DisplayName("A 用方天畫戟出殺 + 1 個額外目標 → 問 B 出閃（只有 2 個目標）")
     @Test
     public void testUseHalberdKill_OneAdditionalTarget_EmitsAsksFirstTarget() {


### PR DESCRIPTION
## Summary
- `playerUseHeavenlyDoubleHalberdKill` 把 `targetPlayerIds` 以攻擊者下家為起點重排為座位順序後才 push behavior，trigger event 與輪詢順序皆照座位順序
- API_DOC #19 註明「傳入順序不影響結算」

Closes #202

## Test plan
- [x] 新增 domain test：request 傳 [d,c,b] → trigger event 與輪詢為 [b,c,d]，全 skip 各扣 1 血
- [x] domain 412 / spring 239 全綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)