### PR TITLE
feat: 武將技 Batch 4 — 武聖/龍膽/傾國/奇襲/國色（轉化牌技）

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -681,6 +681,18 @@ POST /api/games/{gameId}/player:useSkillEffect
 | 觀星（諸葛亮）第一段 | 每回合 1 次 | `ACCEPT` | — | — |
 | 觀星 第二段 | — | `ARRANGE` | 回堆頂的順序（未列出 → 置堆底） | — |
 
+### 轉化牌技（choice = 轉化目標型別）
+
+| 技能 | choice | cardIds | targetPlayerId | 使用情境 |
+|---|---|---|---|---|
+| 武聖（關羽） | `KILL` | [紅色手牌 id] | 主動殺必填 | 主動出殺（topBehavior 空）或回應南蠻/決鬥（KILL response） |
+| 龍膽（趙雲） | `KILL` / `DODGE` | [閃 id] / [殺 id] | 主動殺必填 | 殺↔閃雙向；回應問閃用 DODGE、回應需殺用 KILL |
+| 傾國（甄姬） | `DODGE` | [黑色手牌 id] | — | 被問閃時（被殺/萬箭/方天畫戟） |
+| 奇襲（甘寧） | `DISMANTLE` | [黑色手牌 id] | 必填 | 主動；後續走 useDismantleEffect |
+| 國色（大喬） | `CONTENTMENT` | [方塊手牌 id] | 必填 | 主動；牌以樂不思蜀身份進判定區 |
+
+轉化殺計入出殺次數限制（咆哮/諸葛連弩豁免照常）；轉化殺對空城/謙遜的目標限制照常套用。
+
 **v1 範圍備註**：
 - 反饋 / 遺計 / 剛烈在 AOE polling（南蠻 / 萬箭）中不觸發（defer-resume 整合 follow-up）；瀕死不觸發
 - 剛烈 DAMAGE 反傷不進瀕死流程整合（follow-up）
@@ -689,6 +701,8 @@ POST /api/games/{gameId}/player:useSkillEffect
 - 苦肉 v1 需 HP ≥ 2（瀕死整合 follow-up）；反間目標受傷不進瀕死流程（follow-up）
 - 觀星 issue 時機為回合開始；v1 以出牌階段主動發動實作（時機整合 follow-up）
 - 突襲 issue 時機為出牌階段開始；v1 出牌階段任意時點可發動（每回合一次）
+- 武聖/奇襲 v1 限手牌（裝備區紅/黑牌轉化 follow-up）；轉化殺的奸雄取牌為 follow-up
+- 轉化殺的傷害結算以 VirtualKill 進行；事件中 cardId 為來源真實牌
 
 ---
 

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -947,11 +947,18 @@ public class Game {
     public List<DomainEvent> playerUseSkillEffect(String playerId, String skillName, String choice,
                                                   List<String> cardIds, String targetPlayerId) {
         if (topBehavior.isEmpty()) {
-            // proactive 分支：出牌階段主動發動技能（制衡 / 苦肉 / 仁德 / 觀星...）
+            // proactive 分支：出牌階段主動發動（轉化技 / 制衡 / 苦肉 / 仁德 / 觀星...）
+            if (findConversionSkill(playerId, skillName) != null) {
+                return applyConversionActive(playerId, skillName, choice, cardIds, targetPlayerId);
+            }
             return activatePhaseSkill(playerId, skillName, choice, cardIds, targetPlayerId);
         }
         Behavior behavior = topBehavior.peek();
         if (!(behavior instanceof com.gaas.threeKingdoms.behavior.behavior.WaitingSkillEffectBehavior waiting)) {
+            // 轉化技 response 分支：被殺問閃時當閃打出 / 南蠻決鬥需殺時當殺打出
+            if (findConversionSkill(playerId, skillName) != null) {
+                return applyConversionResponse(playerId, skillName, choice, cardIds, targetPlayerId);
+            }
             throw new IllegalStateException("Current behavior is not WaitingSkillEffectBehavior");
         }
         if (!waiting.getSkillName().equals(skillName)) {
@@ -961,6 +968,159 @@ public class Game {
         List<DomainEvent> events = waiting.resolveChoice(playerId, choice, cardIds, targetPlayerId);
         removeCompletedBehaviors();
         return events;
+    }
+
+    private com.gaas.threeKingdoms.skill.trigger.CardConversionSkill findConversionSkill(String playerId, String skillName) {
+        Player self = getPlayer(playerId);
+        return com.gaas.threeKingdoms.skill.registry.SkillRegistry.of(self.getGeneralCard().getGeneralId()).stream()
+                .filter(sk -> sk instanceof com.gaas.threeKingdoms.skill.trigger.CardConversionSkill
+                        && sk.getSkillName().equals(skillName))
+                .map(sk -> (com.gaas.threeKingdoms.skill.trigger.CardConversionSkill) sk)
+                .findFirst().orElse(null);
+    }
+
+    /** 轉化技主動使用（KILL / DISMANTLE / CONTENTMENT）— choice = 轉化目標型別。 */
+    private List<DomainEvent> applyConversionActive(String playerId, String skillName, String as,
+                                                    List<String> cardIds, String targetPlayerId) {
+        checkIsCurrentRoundValid(playerId);
+        Player self = getPlayer(playerId);
+        com.gaas.threeKingdoms.skill.trigger.CardConversionSkill skill = findConversionSkill(playerId, skillName);
+        if (cardIds == null || cardIds.size() != 1) {
+            throw new IllegalArgumentException("Conversion requires exactly 1 source card");
+        }
+        String sourceId = cardIds.get(0);
+        HandCard source = self.getHand().getCard(sourceId)
+                .orElseThrow(() -> new IllegalArgumentException("Source card not in hand: " + sourceId));
+        if (!skill.canConvert(source, as)) {
+            throw new IllegalArgumentException(String.format("%s 不能把 %s 當 %s", skillName, sourceId, as));
+        }
+        if (targetPlayerId == null) {
+            throw new IllegalArgumentException("Conversion active play requires targetPlayerId");
+        }
+        Player target = getPlayer(targetPlayerId);
+
+        switch (as) {
+            case com.gaas.threeKingdoms.skill.trigger.CardConversionSkill.AS_KILL -> {
+                if (playerId.equals(targetPlayerId)) {
+                    throw new IllegalArgumentException("Cannot target self");
+                }
+                if (!isInAttackRange(self, target)) {
+                    throw new IllegalStateException("target is not in attack range");
+                }
+                if (SkillEngine.isImmuneToCard(target, new VirtualKill())) {
+                    throw new IllegalStateException("target cannot be targeted by Kill (immunity skill)");
+                }
+                if (currentRound.isShowKill() && !(self.getEquipmentWeaponCard() instanceof RepeatingCrossbowCard)
+                        && !SkillEngine.isKillCountUnlimited(self)) {
+                    throw new IllegalStateException("Player already played Kill Card");
+                }
+                currentRound.setShowKill(true);
+                // card = VirtualKill（傷害結算用），cardId = 來源牌（事件顯示真實牌、手牌→墓地）
+                NormalActiveKillBehavior killBehavior = new NormalActiveKillBehavior(
+                        this, self, new ArrayList<>(List.of(targetPlayerId)), self,
+                        sourceId, PlayType.ACTIVE.getPlayType(), new VirtualKill());
+                updateTopBehavior(killBehavior);
+                List<DomainEvent> events = new ArrayList<>();
+                events.add(new com.gaas.threeKingdoms.events.SkillEffectEvent(
+                        skillName, playerId, true, List.of(sourceId), targetPlayerId));
+                events.addAll(killBehavior.playerAction());
+                removeCompletedBehaviors();
+                return events;
+            }
+            case com.gaas.threeKingdoms.skill.trigger.CardConversionSkill.AS_DISMANTLE -> {
+                if (playerId.equals(targetPlayerId)) {
+                    throw new IllegalArgumentException("不可以對自己出過河拆橋");
+                }
+                if (target.getHandSize() == 0 && !target.getEquipment().hasAnyEquipment()
+                        && !target.hasAnyDelayScrollCard()) {
+                    throw new IllegalArgumentException("對象沒手牌、裝備或者判定區的牌");
+                }
+                List<String> reaction = new ArrayList<>(List.of(playerId, targetPlayerId));
+                HandCard converted = new com.gaas.threeKingdoms.handcard.scrollcard.Dismantle(PlayCard.valueOf(sourceId));
+                Behavior dismantle = new com.gaas.threeKingdoms.behavior.behavior.DismantleBehavior(
+                        this, self, reaction, target, sourceId, PlayType.ACTIVE.getPlayType(), converted);
+                updateTopBehavior(dismantle);
+                List<DomainEvent> events = new ArrayList<>();
+                events.add(new com.gaas.threeKingdoms.events.SkillEffectEvent(
+                        skillName, playerId, true, List.of(sourceId), targetPlayerId));
+                events.addAll(dismantle.playerAction());
+                removeCompletedBehaviors();
+                return events;
+            }
+            case com.gaas.threeKingdoms.skill.trigger.CardConversionSkill.AS_CONTENTMENT -> {
+                if (playerId.equals(targetPlayerId)) {
+                    throw new IllegalArgumentException("不可以對自己出樂不思蜀");
+                }
+                HandCard converted = new Contentment(PlayCard.valueOf(sourceId));
+                if (SkillEngine.isImmuneToCard(target, converted)) {
+                    throw new IllegalStateException("target cannot be targeted by Contentment (immunity skill)");
+                }
+                if (target.hasAnyContentmentCard()) {
+                    throw new IllegalArgumentException(target.getId() + " 已經有樂不思蜀");
+                }
+                Behavior contentment = new com.gaas.threeKingdoms.behavior.behavior.ContentmentBehavior(
+                        this, self, new ArrayList<>(List.of(targetPlayerId)), target,
+                        sourceId, PlayType.ACTIVE.getPlayType(), converted);
+                updateTopBehavior(contentment);
+                List<DomainEvent> events = new ArrayList<>();
+                events.add(new com.gaas.threeKingdoms.events.SkillEffectEvent(
+                        skillName, playerId, true, List.of(sourceId), targetPlayerId));
+                events.addAll(contentment.playerAction());
+                removeCompletedBehaviors();
+                return events;
+            }
+            default -> throw new IllegalArgumentException("Unsupported active conversion: " + as);
+        }
+    }
+
+    /** 轉化技 response 使用（DODGE 回應問閃 / KILL 回應南蠻、決鬥）。 */
+    private List<DomainEvent> applyConversionResponse(String playerId, String skillName, String as,
+                                                      List<String> cardIds, String targetPlayerId) {
+        Player self = getPlayer(playerId);
+        com.gaas.threeKingdoms.skill.trigger.CardConversionSkill skill = findConversionSkill(playerId, skillName);
+        if (cardIds == null || cardIds.size() != 1) {
+            throw new IllegalArgumentException("Conversion requires exactly 1 source card");
+        }
+        String sourceId = cardIds.get(0);
+        HandCard source = self.getHand().getCard(sourceId)
+                .orElseThrow(() -> new IllegalArgumentException("Source card not in hand: " + sourceId));
+        if (!skill.canConvert(source, as)) {
+            throw new IllegalArgumentException(String.format("%s 不能把 %s 當 %s", skillName, sourceId, as));
+        }
+        Behavior top = topBehavior.peek();
+
+        switch (as) {
+            case com.gaas.threeKingdoms.skill.trigger.CardConversionSkill.AS_DODGE -> {
+                if (!(top instanceof com.gaas.threeKingdoms.behavior.HuJiaCompatibleAskDodgeBehavior dodgeHost)) {
+                    throw new IllegalStateException("Current behavior does not accept dodge response: "
+                            + top.getClass().getSimpleName());
+                }
+                if (!top.getReactionPlayers().contains(playerId)) {
+                    throw new IllegalStateException(playerId + " is not asked to dodge");
+                }
+                // 來源牌棄到墓地，視為打出閃（與護駕代閃同一個 host hook）
+                HandCard discarded = self.playCard(sourceId);
+                graveyard.add(discarded);
+                List<DomainEvent> events = new ArrayList<>();
+                events.add(new com.gaas.threeKingdoms.events.SkillEffectEvent(
+                        skillName, playerId, true, List.of(sourceId), null));
+                events.addAll(dodgeHost.acceptDodgeFromHuJia(playerId, playerId, sourceId));
+                removeCompletedBehaviors();
+                return events;
+            }
+            case com.gaas.threeKingdoms.skill.trigger.CardConversionSkill.AS_KILL -> {
+                // 南蠻入侵 / 決鬥需要殺 — 走 ViperSpear 的 virtual kill response 通道
+                HandCard discarded = self.playCard(sourceId);
+                graveyard.add(discarded);
+                List<DomainEvent> events = new ArrayList<>();
+                events.add(new com.gaas.threeKingdoms.events.SkillEffectEvent(
+                        skillName, playerId, true, List.of(sourceId), null));
+                events.addAll(top.acceptVirtualKillResponse(playerId, targetPlayerId, new VirtualKill(), List.of(sourceId)));
+                removeCompletedBehaviors();
+                return events;
+            }
+            default -> throw new IllegalArgumentException("Unsupported response conversion: " + as);
+        }
     }
 
     private List<DomainEvent> activatePhaseSkill(String playerId, String skillName, String choice,

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillRegistry.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillRegistry.java
@@ -2,6 +2,8 @@ package com.gaas.threeKingdoms.skill.registry;
 
 import com.gaas.threeKingdoms.skill.Skill;
 import com.gaas.threeKingdoms.skill.shu.GuanXingSkill;
+import com.gaas.threeKingdoms.skill.shu.LongDanSkill;
+import com.gaas.threeKingdoms.skill.shu.WuShengSkill;
 import com.gaas.threeKingdoms.skill.shu.JiZhiSkill;
 import com.gaas.threeKingdoms.skill.shu.RenDeSkill;
 import com.gaas.threeKingdoms.skill.shu.TieQiSkill;
@@ -16,9 +18,12 @@ import com.gaas.threeKingdoms.skill.wei.GangLieSkill;
 import com.gaas.threeKingdoms.skill.wei.LuoShenSkill;
 import com.gaas.threeKingdoms.skill.wei.LuoYiSkill;
 import com.gaas.threeKingdoms.skill.wei.TianDuSkill;
+import com.gaas.threeKingdoms.skill.wei.QingGuoSkill;
 import com.gaas.threeKingdoms.skill.wei.TuXiSkill;
 import com.gaas.threeKingdoms.skill.wei.YiJiSkill;
 import com.gaas.threeKingdoms.skill.wu.FanJianSkill;
+import com.gaas.threeKingdoms.skill.wu.GuoSeSkill;
+import com.gaas.threeKingdoms.skill.wu.QiXiSkill;
 import com.gaas.threeKingdoms.skill.wu.JieYinSkill;
 import com.gaas.threeKingdoms.skill.wu.KuRouSkill;
 import com.gaas.threeKingdoms.skill.wu.LianYingSkill;
@@ -46,6 +51,7 @@ public final class SkillRegistry {
         register(new YiJiSkill());
         register(new LuoShenSkill());
         register(new TuXiSkill());
+        register(new QingGuoSkill());
         // 蜀
         register(new PaoXiaoSkill());
         register(new KongChengSkill());
@@ -55,6 +61,8 @@ public final class SkillRegistry {
         register(new TieQiSkill());
         register(new RenDeSkill());
         register(new GuanXingSkill());
+        register(new WuShengSkill());
+        register(new LongDanSkill());
         // 吳
         register(new YingZiSkill());
         register(new QianXunSkill());
@@ -64,6 +72,8 @@ public final class SkillRegistry {
         register(new KuRouSkill());
         register(new FanJianSkill());
         register(new JieYinSkill());
+        register(new QiXiSkill());
+        register(new GuoSeSkill());
     }
 
     private SkillRegistry() {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/shu/LongDanSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/shu/LongDanSkill.java
@@ -1,0 +1,37 @@
+package com.gaas.threeKingdoms.skill.shu;
+
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.skill.trigger.CardConversionSkill;
+
+/**
+ * 趙雲 (SHU005) 龍膽 — 可將殺當閃、閃當殺使用或打出（issue #178）。
+ */
+public class LongDanSkill implements CardConversionSkill {
+
+    public static final String GENERAL_ID = General.趙雲.getGeneralId();
+    public static final String SKILL_NAME = "龍膽";
+
+    @Override
+    public String getGeneralId() {
+        return GENERAL_ID;
+    }
+
+    @Override
+    public String getSkillName() {
+        return SKILL_NAME;
+    }
+
+    @Override
+    public boolean canConvert(HandCard source, String as) {
+        if (AS_DODGE.equals(as)) {
+            return source instanceof Kill;
+        }
+        if (AS_KILL.equals(as)) {
+            return source instanceof Dodge;
+        }
+        return false;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/shu/WuShengSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/shu/WuShengSkill.java
@@ -1,0 +1,32 @@
+package com.gaas.threeKingdoms.skill.shu;
+
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.Suit;
+import com.gaas.threeKingdoms.skill.trigger.CardConversionSkill;
+
+/**
+ * 關羽 (SHU002) 武聖 — 可將一張紅色牌當殺使用或打出（issue #174）。
+ * v1：紅色「手牌」（紅心/方塊）；裝備區紅牌轉化為 follow-up。
+ */
+public class WuShengSkill implements CardConversionSkill {
+
+    public static final String GENERAL_ID = General.關羽.getGeneralId();
+    public static final String SKILL_NAME = "武聖";
+
+    @Override
+    public String getGeneralId() {
+        return GENERAL_ID;
+    }
+
+    @Override
+    public String getSkillName() {
+        return SKILL_NAME;
+    }
+
+    @Override
+    public boolean canConvert(HandCard source, String as) {
+        return AS_KILL.equals(as)
+                && (source.getSuit() == Suit.HEART || source.getSuit() == Suit.DIAMOND);
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/trigger/CardConversionSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/trigger/CardConversionSkill.java
@@ -1,0 +1,24 @@
+package com.gaas.threeKingdoms.skill.trigger;
+
+import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.skill.Skill;
+
+/**
+ * 轉化牌技（武聖 / 龍膽 / 傾國 / 奇襲 / 國色）— 把一張來源牌當另一種牌使用或打出。
+ *
+ * 透過通用 endpoint `player:useSkillEffect`：
+ *   choice = 轉化目標型別（"KILL" / "DODGE" / "DISMANTLE" / "CONTENTMENT"）
+ *   cardIds = [來源牌 id]、targetPlayerId = 出牌目標（KILL/DISMANTLE/CONTENTMENT 必填）
+ *
+ * 實際轉化流程由 Game.applyConversion 集中處理；本 interface 只回答
+ * 「此來源牌可否被本技能轉成 as 型別」。
+ */
+public interface CardConversionSkill extends Skill {
+
+    String AS_KILL = "KILL";
+    String AS_DODGE = "DODGE";
+    String AS_DISMANTLE = "DISMANTLE";
+    String AS_CONTENTMENT = "CONTENTMENT";
+
+    boolean canConvert(HandCard source, String as);
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/QingGuoSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/QingGuoSkill.java
@@ -1,0 +1,31 @@
+package com.gaas.threeKingdoms.skill.wei;
+
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.Suit;
+import com.gaas.threeKingdoms.skill.trigger.CardConversionSkill;
+
+/**
+ * 甄姬 (WEI007) 傾國 — 可將一張黑色手牌當閃使用或打出（issue #170）。
+ */
+public class QingGuoSkill implements CardConversionSkill {
+
+    public static final String GENERAL_ID = General.甄姬.getGeneralId();
+    public static final String SKILL_NAME = "傾國";
+
+    @Override
+    public String getGeneralId() {
+        return GENERAL_ID;
+    }
+
+    @Override
+    public String getSkillName() {
+        return SKILL_NAME;
+    }
+
+    @Override
+    public boolean canConvert(HandCard source, String as) {
+        return AS_DODGE.equals(as)
+                && (source.getSuit() == Suit.SPADE || source.getSuit() == Suit.CLUB);
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wu/GuoSeSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wu/GuoSeSkill.java
@@ -1,0 +1,30 @@
+package com.gaas.threeKingdoms.skill.wu;
+
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.Suit;
+import com.gaas.threeKingdoms.skill.trigger.CardConversionSkill;
+
+/**
+ * 大喬 (WU006) 國色 — 可將一張方塊牌當樂不思蜀使用（issue #190）。
+ */
+public class GuoSeSkill implements CardConversionSkill {
+
+    public static final String GENERAL_ID = General.大喬.getGeneralId();
+    public static final String SKILL_NAME = "國色";
+
+    @Override
+    public String getGeneralId() {
+        return GENERAL_ID;
+    }
+
+    @Override
+    public String getSkillName() {
+        return SKILL_NAME;
+    }
+
+    @Override
+    public boolean canConvert(HandCard source, String as) {
+        return AS_CONTENTMENT.equals(as) && source.getSuit() == Suit.DIAMOND;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wu/QiXiSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wu/QiXiSkill.java
@@ -1,0 +1,32 @@
+package com.gaas.threeKingdoms.skill.wu;
+
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.Suit;
+import com.gaas.threeKingdoms.skill.trigger.CardConversionSkill;
+
+/**
+ * 甘寧 (WU002) 奇襲 — 可將一張黑色牌當過河拆橋使用（issue #185）。
+ * v1：黑色「手牌」；裝備區黑牌轉化為 follow-up。
+ */
+public class QiXiSkill implements CardConversionSkill {
+
+    public static final String GENERAL_ID = General.甘寧.getGeneralId();
+    public static final String SKILL_NAME = "奇襲";
+
+    @Override
+    public String getGeneralId() {
+        return GENERAL_ID;
+    }
+
+    @Override
+    public String getSkillName() {
+        return SKILL_NAME;
+    }
+
+    @Override
+    public boolean canConvert(HandCard source, String as) {
+        return AS_DISMANTLE.equals(as)
+                && (source.getSuit() == Suit.SPADE || source.getSuit() == Suit.CLUB);
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch4ConversionSkillsTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch4ConversionSkillsTest.java
@@ -1,0 +1,193 @@
+package com.gaas.threeKingdoms.skill;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.events.AskDodgeEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.PlayCardEvent;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion;
+import com.gaas.threeKingdoms.player.Player;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Batch 4：武聖 / 龍膽 / 傾國 / 奇襲 / 國色（轉化牌技，走通用 useSkillEffect）。
+ */
+public class Batch4ConversionSkillsTest extends PassiveSkillTestBase {
+
+    @DisplayName("關羽武聖：紅色牌（桃）當殺主動使用 → 目標被問閃、skip 扣 1 血")
+    @Test
+    public void wuShengRedCardAsActiveKill() {
+        Game game = createGame(General.關羽, General.劉備, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(new Peach(BH3029)); // 紅心
+
+        List<DomainEvent> events = game.playerUseSkillEffect(
+                "player-a", "武聖", "KILL", List.of(BH3029.getCardId()), "player-b");
+
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent
+                && ((AskDodgeEvent) e).getPlayerId().equals("player-b")));
+        assertEquals(0, a.getHandSize());
+        assertTrue(game.getGraveyard().contains(BH3029.getCardId()));
+
+        game.playerPlayCard("player-b", "", "player-a", "skip");
+        assertEquals(3, game.getPlayer("player-b").getHP(), "視為殺：扣 1 血（非桃回血）");
+    }
+
+    @DisplayName("武聖殺計入出殺次數：第二次武聖殺 → 拋例外")
+    @Test
+    public void wuShengKillCountsTowardsKillLimit() {
+        Game game = createGame(General.關羽, General.劉備, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(java.util.Arrays.asList(new Peach(BH3029), new Peach(BH4030)));
+
+        game.playerUseSkillEffect("player-a", "武聖", "KILL", List.of(BH3029.getCardId()), "player-b");
+        game.playerPlayCard("player-b", "", "player-a", "skip");
+
+        assertThrows(IllegalStateException.class, () ->
+                game.playerUseSkillEffect("player-a", "武聖", "KILL", List.of(BH4030.getCardId()), "player-b"));
+    }
+
+    @DisplayName("武聖不能轉黑色牌")
+    @Test
+    public void wuShengRejectsBlackCard() {
+        Game game = createGame(General.關羽, General.劉備, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(new Kill(BS8008)); // 黑桃（已是殺但測 canConvert 拒非紅）
+
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseSkillEffect("player-a", "武聖", "KILL", List.of(BS8008.getCardId()), "player-b"));
+    }
+
+    @DisplayName("趙雲龍膽：被殺時把殺當閃打出 → 不扣血")
+    @Test
+    public void longDanKillAsDodgeResponse() {
+        Game game = createGame(General.劉備, General.趙雲, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(new Kill(BS9009));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerUseSkillEffect("player-b", "龍膽", "DODGE", List.of(BS9009.getCardId()), null);
+
+        assertEquals(4, b.getHP(), "龍膽當閃 → 不扣血");
+        assertEquals(0, b.getHandSize());
+        assertTrue(game.getGraveyard().contains(BS9009.getCardId()));
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("趙雲龍膽：閃當殺主動使用")
+    @Test
+    public void longDanDodgeAsActiveKill() {
+        Game game = createGame(General.趙雲, General.劉備, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(new Dodge(BH2028));
+
+        List<DomainEvent> events = game.playerUseSkillEffect(
+                "player-a", "龍膽", "KILL", List.of(BH2028.getCardId()), "player-b");
+
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent));
+        game.playerPlayCard("player-b", "", "player-a", "skip");
+        assertEquals(3, game.getPlayer("player-b").getHP());
+    }
+
+    @DisplayName("趙雲龍膽：南蠻入侵需殺時把閃當殺打出")
+    @Test
+    public void longDanDodgeAsKillResponseToBarbarianInvasion() {
+        Game game = createGame(General.劉備, General.趙雲, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new BarbarianInvasion(SS7007));
+        b.getHand().addCardToHand(new Dodge(BH2028));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        // b 是第一個 reactor，用龍膽把閃當殺
+        game.playerUseSkillEffect("player-b", "龍膽", "KILL", List.of(BH2028.getCardId()), null);
+
+        assertEquals(4, b.getHP(), "龍膽當殺回應南蠻 → 不扣血");
+        assertEquals(0, b.getHandSize());
+    }
+
+    @DisplayName("甄姬傾國：被殺時黑色手牌當閃")
+    @Test
+    public void qingGuoBlackCardAsDodge() {
+        Game game = createGame(General.劉備, General.甄姬, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(new Kill(BS9009)); // 黑桃手牌
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerUseSkillEffect("player-b", "傾國", "DODGE", List.of(BS9009.getCardId()), null);
+
+        assertEquals(4, b.getHP());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("傾國不能轉紅色牌")
+    @Test
+    public void qingGuoRejectsRedCard() {
+        Game game = createGame(General.劉備, General.甄姬, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(new Peach(BH3029));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseSkillEffect("player-b", "傾國", "DODGE", List.of(BH3029.getCardId()), null));
+    }
+
+    @DisplayName("甘寧奇襲：黑色牌當過河拆橋 → 拆目標裝備")
+    @Test
+    public void qiXiBlackCardAsDismantle() {
+        Game game = createGame(General.甘寧, General.劉備, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008)); // 黑桃
+        b.getEquipment().setWeapon(new com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.QilinBowCard(EH5031));
+
+        game.playerUseSkillEffect("player-a", "奇襲", "DISMANTLE", List.of(BS8008.getCardId()), "player-b");
+        game.useDismantleEffect("player-a", "player-b", EH5031.getCardId(), null);
+
+        assertFalse(b.getEquipment().hasAnyEquipment(), "裝備被拆");
+        assertEquals(0, a.getHandSize());
+        assertTrue(game.getGraveyard().contains(BS8008.getCardId()));
+    }
+
+    @DisplayName("大喬國色：方塊牌當樂不思蜀 → 進目標判定區")
+    @Test
+    public void guoSeDiamondCardAsContentment() {
+        Game game = createGame(General.大喬, General.劉備, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Dodge(BD2080)); // 方塊
+
+        game.playerUseSkillEffect("player-a", "國色", "CONTENTMENT", List.of(BD2080.getCardId()), "player-b");
+
+        assertTrue(b.getDelayScrollCardIds().contains(BD2080.getCardId()), "方塊牌以樂不思蜀身份進判定區");
+        assertEquals(0, a.getHandSize());
+    }
+
+    @DisplayName("國色不能對已有樂不思蜀的目標使用")
+    @Test
+    public void guoSeRejectsTargetWithContentment() {
+        Game game = createGame(General.大喬, General.劉備, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(java.util.Arrays.asList(new Dodge(BD2080), new Dodge(BDK091)));
+
+        game.playerUseSkillEffect("player-a", "國色", "CONTENTMENT", List.of(BD2080.getCardId()), "player-b");
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerUseSkillEffect("player-a", "國色", "CONTENTMENT", List.of(BDK091.getCardId()), "player-b"));
+    }
+}


### PR DESCRIPTION
## Summary
Epic #160 Batch 4：5 個轉化牌技，復用通用 `useSkillEffect`（choice = KILL/DODGE/DISMANTLE/CONTENTMENT）。

Closes #174 #178 #170 #185 #190

| 武將 | 技 | 轉化 |
|---|---|---|
| 關羽 | 武聖 | 紅色手牌 → 殺（主動 + 回應南蠻/決鬥） |
| 趙雲 | 龍膽 | 殺 ↔ 閃 雙向 |
| 甄姬 | 傾國 | 黑色手牌 → 閃 |
| 甘寧 | 奇襲 | 黑色手牌 → 過河拆橋 |
| 大喬 | 國色 | 方塊手牌 → 樂不思蜀 |

### 設計重點
- 轉化殺：`card=VirtualKill`（傷害結算）+ `cardId=來源牌`（事件顯示真實牌、手牌→墓地）；計入出殺次數限制、受空城/謙遜目標限制
- DODGE 回應復用護駕的 `acceptDodgeFromHuJia` host hook → 被殺/萬箭/方天畫戟三處皆可傾國/龍膽
- KILL 回應復用丈八蛇矛的 `acceptVirtualKillResponse` 通道 → 南蠻/決鬥皆可武聖/龍膽
- 國色/奇襲：來源牌以 `new Contentment/Dismantle(PlayCard.valueOf(sourceId))` 同 id 包裝，判定/拆牌流程無感

### v1 範圍
- 武聖/奇襲限手牌（裝備區紅/黑牌 follow-up）；轉化殺的奸雄取牌 follow-up

## Test plan
- [x] domain 478（+11 Batch4ConversionSkillsTest：主動/回應/負向/次數限制/judgement 區互動）全綠
- [x] spring 240 全綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)