### PR TITLE
fix: 統一錯誤回應為精簡 JSON，不再回傳 stack trace 給前端

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -706,6 +706,33 @@ POST /api/games/{gameId}/player:useSkillEffect
 
 ---
 
+## 錯誤回應格式
+
+所有 API 的錯誤回應（400 / 404 / 500）統一為精簡 JSON（issue #200 起，不再回傳 stack trace）：
+
+```json
+{ "error": "DistanceErrorException", "message": "Players are not within range." }
+```
+
+| 欄位 | 說明 |
+|------|------|
+| error | 例外類型（exception simple name），前端可據此 switch 處理 |
+| message | 人類可讀的錯誤原因 |
+
+### 常見 error 類型
+
+| error | HTTP | 常見情境 |
+|-------|------|----------|
+| `DistanceErrorException` | 400 | 殺 / 順手牽羊超出距離 |
+| `IllegalStateException` | 400 | 非法遊戲狀態：不是你的回合、不是當前需回應的玩家、殺次數已用完、技能每回合限一次等 |
+| `IllegalArgumentException` | 400 | 非法參數：卡牌不在手中、目標不合法、棄牌數不足等 |
+| `ValidationError` | 400 | Request body 欄位驗證失敗 |
+| `NotFoundException` | 404 | gameId 不存在 |
+
+Stack trace 僅記錄於 server log。
+
+---
+
 ## WebSocket 事件類型
 
 前端透過 WebSocket 接收以下事件，根據事件類型決定 UI 行為：

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -623,7 +623,8 @@ public class Game {
     public int getCurrentRoundPlayerDiscardCount() {
         Player player = currentRound.getCurrentRoundPlayer();
         if (!currentRound.getRoundPhase().equals(RoundPhase.Discard)) {
-            throw new RuntimeException();
+            throw new IllegalStateException(
+                    "棄牌數查詢僅能在棄牌階段呼叫（目前階段：" + currentRound.getRoundPhase() + "）");
         }
         // 手牌上限預設 = HP；技能可覆寫（英姿 = max(HP, 4)）
         return Math.max(0, player.getHandSize() - SkillEngine.handCardLimit(player));
@@ -632,7 +633,10 @@ public class Game {
     public List<DomainEvent> playerDiscardCard(List<String> cardIds) {
         Player player = currentRound.getCurrentRoundPlayer();
         int needToDiscardSize = player.getHandSize() - SkillEngine.handCardLimit(player);
-        if (cardIds.size() < needToDiscardSize) throw new RuntimeException();
+        if (cardIds.size() < needToDiscardSize) {
+            throw new IllegalArgumentException(
+                    String.format("需棄 %d 張，只給了 %d 張", needToDiscardSize, cardIds.size()));
+        }
         // todo 判斷這個玩家是否有這些牌
         List<HandCard> discardCards = player.discardCards(cardIds);
         graveyard.add(discardCards);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/Behavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/Behavior.java
@@ -93,7 +93,8 @@ public class Behavior {
 
     private void throwExceptionWhenPlayerIsNotInReactionPlayers(String playerId) {
         if (!reactionPlayers.contains(playerId)) {
-            throw new IllegalStateException();
+            throw new IllegalStateException(
+                    String.format("%s 不是當前需要回應的玩家", playerId));
         }
     }
 

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/advices/LegendsOfTheThreeKingdomsAdvice.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/advices/LegendsOfTheThreeKingdomsAdvice.java
@@ -8,48 +8,54 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.util.Map;
 
 import static java.util.stream.Collectors.joining;
 import static org.springframework.http.HttpStatus.*;
 
+/**
+ * 統一錯誤回應格式（issue #200）：
+ * <pre>{ "error": "&lt;ExceptionSimpleName&gt;", "message": "&lt;human readable&gt;" }</pre>
+ * Stack trace 一律留在 server log，不回傳給前端。
+ */
 @RestControllerAdvice
 public class LegendsOfTheThreeKingdomsAdvice {
 
     @ResponseStatus(BAD_REQUEST)
     @ExceptionHandler({RuntimeException.class})
-    public String badRequest(RuntimeException exception) {
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        exception.printStackTrace(pw);
-        return sw.toString();
+    public Map<String, String> badRequest(RuntimeException exception) {
+        exception.printStackTrace();
+        return errorBody(exception);
     }
 
     @ResponseStatus(BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public String handleValidationExceptions(MethodArgumentNotValidException ex) {
-        return ex.getBindingResult()
+    public Map<String, String> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult()
                 .getAllErrors()
                 .stream()
                 .map(ObjectError::getDefaultMessage)
                 .filter(StringUtils::isNotBlank)
                 .collect(joining("\n"));
+        return Map.of("error", "ValidationError", "message", message);
     }
 
     @ResponseStatus(NOT_FOUND)
     @ExceptionHandler({NotFoundException.class})
-    public String notFound(NotFoundException exception) {
-        return exception.getMessage();
+    public Map<String, String> notFound(NotFoundException exception) {
+        return errorBody(exception);
     }
 
     @ResponseStatus(INTERNAL_SERVER_ERROR)
     @ExceptionHandler({Exception.class})
-    public String otherException(Exception exception) {
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        exception.printStackTrace(pw);
-        return sw.toString();
+    public Map<String, String> otherException(Exception exception) {
+        exception.printStackTrace();
+        return errorBody(exception);
     }
 
+    private static Map<String, String> errorBody(Exception exception) {
+        String simpleName = exception.getClass().getSimpleName();
+        String message = exception.getMessage() != null ? exception.getMessage() : simpleName;
+        return Map.of("error", simpleName, "message", message);
+    }
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/ErrorResponseTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/ErrorResponseTest.java
@@ -1,0 +1,75 @@
+package com.gaas.threeKingdoms.e2e;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.scrollcard.Snatch;
+import com.gaas.threeKingdoms.player.HealthStatus;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.rolecard.Role;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Arrays;
+
+import static com.gaas.threeKingdoms.e2e.MockUtil.createPlayer;
+import static com.gaas.threeKingdoms.e2e.MockUtil.initGame;
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 錯誤回應格式（issue #200）— body 必須是精簡 JSON {error, message}，不得洩漏 stack trace。
+ */
+public class ErrorResponseTest extends AbstractBaseIntegrationTest {
+
+    private void givenFourPlayerGame() {
+        Player playerA = createPlayer("player-a", 4, General.甘寧, HealthStatus.ALIVE, Role.MONARCH,
+                new Snatch(SS3016), new Kill(BS8008));
+        Player playerB = createPlayer("player-b", 4, General.甘寧, HealthStatus.ALIVE, Role.MINISTER,
+                new Kill(BS9009));
+        Player playerC = createPlayer("player-c", 4, General.甘寧, HealthStatus.ALIVE, Role.REBEL,
+                new Kill(BS0010));
+        Player playerD = createPlayer("player-d", 4, General.甘寧, HealthStatus.ALIVE, Role.TRAITOR);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        repository.save(game);
+    }
+
+    @Test
+    public void testOutOfRangeSnatch_Returns400WithConciseJsonBody() throws Exception {
+        // 復刻 issue #200 HAR 情境：對距離 2 的玩家出順手牽羊
+        givenFourPlayerGame();
+
+        MvcResult result = mockMvcUtil.playCard(gameId, "player-a", "player-c", SS3016.getCardId(),
+                        PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("DistanceErrorException"))
+                .andExpect(jsonPath("$.message").value("Players are not within range."))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertFalse(body.contains("at com.gaas"), "不得洩漏 stack trace");
+        assertTrue(body.length() < 200, "body 應精簡（實際 " + body.length() + " 字元）");
+    }
+
+    @Test
+    public void testWrongPlayerResponds_Returns400WithNonEmptyMessage() throws Exception {
+        // A 殺 B，但 C（非 reactionPlayers）搶著回應
+        givenFourPlayerGame();
+
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", BS8008.getCardId(), PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+
+        MvcResult result = mockMvcUtil.playCard(gameId, "player-c", "player-a", "", PlayType.SKIP.getPlayType())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("IllegalStateException"))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertTrue(body.contains("player-c"), "message 應指出是哪個玩家的問題");
+        assertFalse(body.contains("at com.gaas"), "不得洩漏 stack trace");
+    }
+}


### PR DESCRIPTION
## Summary
Closes #200

`playcard.har` 顯示 400 回應 body 是 **6847 字元的完整 Java stack trace**（`DistanceErrorException: Players are not within range.` + 整條 call chain），前端無法直覺看出問題。

### Before / After

```
# Before（6847 字元）
com.gaas.threeKingdoms.exception.DistanceErrorException: Players are not within range.
	at com.gaas.threeKingdoms.behavior.handler.SnatchBehaviorHandler.doHandle(SnatchBehaviorHandler.java:41)
	at com.gaas.threeKingdoms.behavior.PlayCardBehaviorHandler.handle(...)
	...（100+ 行）

# After（< 100 字元）
{ "error": "DistanceErrorException", "message": "Players are not within range." }
```

### 變更
- **`LegendsOfTheThreeKingdomsAdvice`**：4 個 handler（400/404/500）統一回傳 `{error, message}` JSON；stack trace 改留 server log
- **3 處空 message 例外補上原因**（修 advice 後這些會回空訊息）：
  - `Game.getCurrentRoundPlayerDiscardCount` → 非棄牌階段呼叫（含目前階段）
  - `Game.playerDiscardCard` → 需棄 N 張只給 M 張
  - `Behavior` reactionPlayers 守門 → `"%s 不是當前需要回應的玩家"`（前端最常撞到）
- **API_DOC** 新增「錯誤回應格式」節：格式 + 常見 error 類型表（前端可據 `error` 欄位 switch）

### 零迴歸依據
既有 spring 測試僅斷言 status code、無任何 body 內容斷言（已 grep 驗證）。

## Test plan
- [x] 新 `ErrorResponseTest` e2e ×2：復刻 HAR 超距順手牽羊 → 斷言 `$.error` / `$.message` / body < 200 字元 / 不含 `at com.gaas`；錯誤玩家回應 → message 含玩家 id
- [x] domain 478 / spring 242 全綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)