### PR TITLE
feat: 武將技 — 鬼才（司馬懿 WEI002）

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -659,6 +659,7 @@ POST /api/games/{gameId}/player:useSkillEffect
 | 剛烈 第二段（問傷害來源） | 判定非紅桃後 | `DISCARD` / `DAMAGE` | DISCARD 必填 2 張手牌 | — |
 | 激將（劉備主公技） | 主公劉備被南蠻/決鬥要求出殺時，依座位順序詢問蜀將 | `ACCEPT` / `DECLINE` | ACCEPT 必填 [殺 id]（蜀將手中） | — |
 | 流離（大喬） | 大喬成為殺目標、被問閃之前 | `ACCEPT` / `SKIP` | ACCEPT 必填 [要棄的手牌 id] | ACCEPT 必填：轉移目標（距離 1 內、非攻擊者） |
+| 鬼才（司馬懿） | 任意角色閃電判定牌抽出後、生效前（dataCardIds = [原判定牌]） | `ACCEPT` / `SKIP` | ACCEPT 必填 [替換用手牌 id] | — |
 
 ### 自動觸發技（無需呼叫本 API，僅廣播 `SkillEffectEvent`）
 
@@ -707,6 +708,7 @@ POST /api/games/{gameId}/player:useSkillEffect
 - 激將 v1 覆蓋南蠻入侵/決鬥的 AskKill；主動出殺與借刀殺人代出為 follow-up
 - 流離 v1 只攔普通殺（方天畫戟/AOE 轉移 follow-up）；棄牌限手牌
 - 救援採官方標準版語意（桃效果 +1）；issue 原文描述的「可出桃給其」即既有瀕死求桃流程
+- 鬼才 v1 覆蓋閃電判定（含 Ward 路徑）；樂不思蜀/八卦陣/洛神/鐵騎/剛烈判定替換 follow-up
 - 武聖/奇襲 v1 限手牌（裝備區紅/黑牌轉化 follow-up）；轉化殺的奸雄取牌為 follow-up
 - 轉化殺的傷害結算以 VirtualKill 進行；事件中 cardId 為來源真實牌
 

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -564,6 +564,32 @@ public class Game {
         List<HandCard> cards = drawCardForCardEffect(1);
         HandCard drawnCard = cards.get(0);
 
+        // 鬼才：判定牌生效前，場上存活且有手牌的司馬懿可打手牌替換（v1 只覆蓋閃電判定）
+        Player guiCaiHolder = players.stream()
+                .filter(p -> !p.isAlreadyDeath()
+                        && com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.GENERAL_ID
+                                .equals(p.getGeneralCard().getGeneralId())
+                        && p.getHandSize() > 0)
+                .findFirst().orElse(null);
+        if (guiCaiHolder != null) {
+            com.gaas.threeKingdoms.behavior.behavior.WaitingSkillEffectBehavior waiting =
+                    new com.gaas.threeKingdoms.behavior.behavior.WaitingSkillEffectBehavior(
+                            this, guiCaiHolder, com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.SKILL_NAME);
+            waiting.putParam(com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.PARAM_LIGHTNING_CARD_ID, card.getId());
+            waiting.putParam(com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.PARAM_OWNER_ID, player.getId());
+            waiting.putParam(com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.PARAM_DRAWN_CARD_ID, drawnCard.getId());
+            updateTopBehavior(waiting);
+            currentRound.setActivePlayer(guiCaiHolder);
+            return List.of(new com.gaas.threeKingdoms.events.AskSkillEffectEvent(
+                            com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.SKILL_NAME,
+                            guiCaiHolder.getId(), List.of(drawnCard.getId()), player.getId()),
+                    getGameStatusEvent("鬼才：" + guiCaiHolder.getId() + " 可替換 " + player.getId() + " 的閃電判定牌"));
+        }
+        return resolveLightningJudgement(card, player, drawnCard);
+    }
+
+    /** 以指定判定牌結算閃電（鬼才替換後 / 無鬼才直接）。 */
+    public List<DomainEvent> resolveLightningJudgement(ScrollCard card, Player player, HandCard drawnCard) {
         // 判定牌是否為黑桃2~9
         boolean isLightningSuccess = Suit.SPADE == drawnCard.getSuit() &&
                 drawnCard.getRank().getValue() >= Rank.TWO.getValue() &&

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/LightningJudgementBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/LightningJudgementBehavior.java
@@ -60,6 +60,12 @@ public class LightningJudgementBehavior extends Behavior implements com.gaas.thr
         List<DomainEvent> lightningEvents = game.handleLightningJudgement((ScrollCard) card, behaviorPlayer);
         events.addAll(lightningEvents);
 
+        // 鬼才介入：判定暫停等司馬懿選擇；GuiCaiSkill.resolveChoice 會 pop 本 behavior 並 resume
+        if (!game.isTopBehaviorEmpty()
+                && game.peekTopBehavior() instanceof WaitingSkillEffectBehavior) {
+            return events;
+        }
+
         // Remove self from stack before resuming judgement flow
         isOneRound = true;
         game.removeCompletedBehaviors();

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillRegistry.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillRegistry.java
@@ -16,6 +16,7 @@ import com.gaas.threeKingdoms.skill.wei.HuJiaSkill;
 import com.gaas.threeKingdoms.skill.wei.JianXiongSkill;
 import com.gaas.threeKingdoms.skill.wei.FanKuiSkill;
 import com.gaas.threeKingdoms.skill.wei.GangLieSkill;
+import com.gaas.threeKingdoms.skill.wei.GuiCaiSkill;
 import com.gaas.threeKingdoms.skill.wei.LuoShenSkill;
 import com.gaas.threeKingdoms.skill.wei.LuoYiSkill;
 import com.gaas.threeKingdoms.skill.wei.TianDuSkill;
@@ -49,6 +50,7 @@ public final class SkillRegistry {
         register(new HuJiaSkill());
         register(new LuoYiSkill());
         register(new FanKuiSkill());
+        register(new GuiCaiSkill());
         register(new GangLieSkill());
         register(new TianDuSkill());
         register(new YiJiSkill());

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/GuiCaiSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/GuiCaiSkill.java
@@ -1,0 +1,96 @@
+package com.gaas.threeKingdoms.skill.wei;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.behavior.Behavior;
+import com.gaas.threeKingdoms.behavior.behavior.LightningJudgementBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.WaitingSkillEffectBehavior;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.SkillEffectEvent;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.PlayCard;
+import com.gaas.threeKingdoms.handcard.scrollcard.ScrollCard;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.round.Stage;
+import com.gaas.threeKingdoms.skill.trigger.ChoiceResolvableSkill;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 司馬懿 (WEI002) 鬼才 — 任意角色的判定牌生效前，可打出一張手牌代替之（issue #164）。
+ *
+ * v1 範圍：閃電判定路徑（含 Ward 路徑 LightningJudgementBehavior）。
+ * 樂不思蜀 / 八卦陣 / 洛神 / 鐵騎 / 剛烈判定的替換為 follow-up。
+ *
+ * 觸發：Game.handleLightningJudgement 抽出判定牌後，若場上有存活且有手牌的司馬懿
+ * → push WaitingSkillEffect(鬼才) 暫停結算（原判定牌已在墓地）。
+ * ACCEPT（cardIds[0] = 司馬懿手牌）→ 該牌成為判定牌（進墓地），原判定牌留墓地；
+ * SKIP → 原判定牌生效。之後 resume：結算閃電 → 恢復判定/摸牌流程。
+ */
+public class GuiCaiSkill implements ChoiceResolvableSkill {
+
+    public static final String GENERAL_ID = General.司馬懿.getGeneralId();
+    public static final String SKILL_NAME = "鬼才";
+    public static final String PARAM_LIGHTNING_CARD_ID = "GUICAI_LIGHTNING_CARD_ID";
+    public static final String PARAM_OWNER_ID = "GUICAI_OWNER_ID";
+    public static final String PARAM_DRAWN_CARD_ID = "GUICAI_DRAWN_CARD_ID";
+
+    @Override
+    public String getGeneralId() {
+        return GENERAL_ID;
+    }
+
+    @Override
+    public String getSkillName() {
+        return SKILL_NAME;
+    }
+
+    @Override
+    public List<DomainEvent> resolveChoice(Game game, WaitingSkillEffectBehavior waiting,
+                                           String choice, List<String> cardIds, String targetPlayerId) {
+        Player simaYi = waiting.getBehaviorPlayer();
+        ScrollCard lightning = (ScrollCard) PlayCard.findById((String) waiting.getParam(PARAM_LIGHTNING_CARD_ID));
+        Player owner = game.getPlayer((String) waiting.getParam(PARAM_OWNER_ID));
+        HandCard drawn = PlayCard.findById((String) waiting.getParam(PARAM_DRAWN_CARD_ID));
+
+        List<DomainEvent> events = new ArrayList<>();
+        HandCard judgementCard;
+        if ("ACCEPT".equals(choice)) {
+            if (cardIds == null || cardIds.size() != 1) {
+                throw new IllegalArgumentException("鬼才 ACCEPT requires exactly 1 hand card");
+            }
+            String replacementId = cardIds.get(0);
+            if (simaYi.getHand().getCard(replacementId).isEmpty()) {
+                throw new IllegalArgumentException("Card not in hand: " + replacementId);
+            }
+            judgementCard = simaYi.playCard(replacementId);
+            game.getGraveyard().add(judgementCard);
+            events.add(new SkillEffectEvent(SKILL_NAME, simaYi.getId(), true,
+                    List.of(replacementId), owner.getId()));
+            events.add(game.getGameStatusEvent(String.format(
+                    "%s 發動鬼才，以 %s 替換判定牌", simaYi.getId(), replacementId)));
+        } else if ("SKIP".equals(choice)) {
+            judgementCard = drawn;
+            events.add(new SkillEffectEvent(SKILL_NAME, simaYi.getId(), false, List.of(), owner.getId()));
+        } else {
+            throw new IllegalArgumentException("Invalid GuiCai choice: " + choice);
+        }
+
+        // pop waiting；若下層是 Ward 路徑的 LightningJudgementBehavior 一併標記完成
+        waiting.setIsOneRound(true);
+        game.removeCompletedBehaviors();
+        Behavior top = game.isTopBehaviorEmpty() ? null : game.peekTopBehavior();
+        if (top instanceof LightningJudgementBehavior ljb) {
+            ljb.setIsOneRound(true);
+            game.removeCompletedBehaviors();
+        }
+
+        // 以（可能被替換的）判定牌結算閃電，然後恢復判定/摸牌流程
+        events.addAll(game.resolveLightningJudgement(lightning, owner, judgementCard));
+        game.getCurrentRound().setStage(Stage.Normal);
+        game.getCurrentRound().setActivePlayer(owner);
+        events.addAll(game.continueJudgementAndDraw(owner, false));
+        return events;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/GuiCaiSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/GuiCaiSkillTest.java
@@ -1,0 +1,118 @@
+package com.gaas.threeKingdoms.skill;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.events.AskSkillEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.LightningEvent;
+import com.gaas.threeKingdoms.events.LightningTransferredEvent;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.scrollcard.Lightning;
+import com.gaas.threeKingdoms.player.Player;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 司馬懿 鬼才（#164）— v1：閃電判定路徑。
+ */
+public class GuiCaiSkillTest extends PassiveSkillTestBase {
+
+    @DisplayName("場上有司馬懿（有手牌）→ 閃電判定抽牌後暫停，詢問鬼才")
+    @Test
+    public void guiCaiAskedBeforeLightningJudgementResolves() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        game.getPlayer("player-b").getHand().addCardToHand(new Peach(BH3029));
+        Lightning lightning = new Lightning(SSA014);
+        a.addDelayScrollCard(lightning);
+
+        // 判定牌：黑桃 8（原本會命中）
+        game.getDeck().add(List.of(new Kill(BS8008)));
+        List<DomainEvent> events = game.handleLightningJudgement(lightning, a);
+
+        AskSkillEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskSkillEffectEvent).map(e -> (AskSkillEffectEvent) e)
+                .findFirst().orElseThrow();
+        assertEquals("鬼才", ask.getSkillName());
+        assertEquals("player-b", ask.getPlayerId());
+        assertEquals(List.of(BS8008.getCardId()), ask.getDataCardIds());
+        assertFalse(events.stream().anyMatch(e -> e instanceof LightningEvent), "判定尚未結算");
+        assertEquals(4, a.getHP());
+    }
+
+    @DisplayName("鬼才 ACCEPT 以紅心替換黑桃判定 → 閃電不中，轉移下家")
+    @Test
+    public void guiCaiReplaceSavesOwnerFromLightning() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        b.getHand().addCardToHand(new Peach(BH3029)); // 紅心 — 替換用
+        Lightning lightning = new Lightning(SSA014);
+        a.addDelayScrollCard(lightning);
+
+        game.getDeck().add(List.of(new Kill(BS8008))); // 黑桃 8 原判定：命中
+        game.handleLightningJudgement(lightning, a);
+
+        List<DomainEvent> events = game.playerUseSkillEffect(
+                "player-b", "鬼才", "ACCEPT", List.of(BH3029.getCardId()), null);
+
+        assertEquals(4, a.getHP(), "替換成紅心 → 閃電不中");
+        assertTrue(events.stream().anyMatch(e -> e instanceof LightningTransferredEvent), "閃電轉移");
+        assertEquals(0, b.getHandSize(), "替換牌已打出");
+        assertTrue(game.getGraveyard().contains(BH3029.getCardId()));
+    }
+
+    @DisplayName("鬼才 SKIP → 原黑桃判定生效，閃電命中扣 3 血")
+    @Test
+    public void guiCaiSkipOriginalJudgementApplies() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        game.getPlayer("player-b").getHand().addCardToHand(new Peach(BH3029));
+        Lightning lightning = new Lightning(SSA014);
+        a.addDelayScrollCard(lightning);
+
+        game.getDeck().add(List.of(new Kill(BS8008)));
+        game.handleLightningJudgement(lightning, a);
+
+        game.playerUseSkillEffect("player-b", "鬼才", "SKIP", null, null);
+
+        assertEquals(1, a.getHP(), "黑桃 8 判定生效 → 閃電 3 點傷害");
+    }
+
+    @DisplayName("司馬懿無手牌 → 鬼才不觸發，判定直接結算")
+    @Test
+    public void guiCaiNotTriggeredWithoutHandCards() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Lightning lightning = new Lightning(SSA014);
+        a.addDelayScrollCard(lightning);
+
+        game.getDeck().add(List.of(new Kill(BS8008)));
+        List<DomainEvent> events = game.handleLightningJudgement(lightning, a);
+
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskSkillEffectEvent));
+        assertTrue(events.stream().anyMatch(e -> e instanceof LightningEvent));
+        assertEquals(1, a.getHP(), "直接結算命中");
+    }
+
+    @DisplayName("場上無司馬懿 → 判定直接結算（迴歸保護）")
+    @Test
+    public void noGuiCaiHolderJudgementResolvesDirectly() {
+        Game game = createGame(General.甘寧, General.孫權, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Lightning lightning = new Lightning(SSA014);
+        a.addDelayScrollCard(lightning);
+
+        game.getDeck().add(List.of(new Peach(BH3029))); // 紅心：不中
+        List<DomainEvent> events = game.handleLightningJudgement(lightning, a);
+
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskSkillEffectEvent));
+        assertTrue(events.stream().anyMatch(e -> e instanceof LightningTransferredEvent));
+    }
+}


### PR DESCRIPTION
## Summary
Epic #160 最後一技。Closes #164

司馬懿：任意角色的判定牌生效前，可打出一張手牌代替之。

### 設計
- `handleLightningJudgement` 拆為「抽牌 → 鬼才暫停點 → `resolveLightningJudgement`」
- 判定暫停以 `WaitingSkillEffectBehavior`（通用 useSkillEffect endpoint）詢問司馬懿；`AskSkillEffectEvent.dataCardIds` = [原判定牌]，前端可展示
- ACCEPT：手牌成為判定牌（原判定牌留墓地）；SKIP：原判定牌生效 — 之後結算並以 `continueJudgementAndDraw` 恢復流程
- Ward 路徑（LightningJudgementBehavior）偵測鬼才介入即暫停，resolve 時一併 pop resume

### v1 範圍
閃電判定（含 Ward 路徑）。樂不思蜀/八卦陣/洛神/鐵騎/剛烈的判定替換為 follow-up（各有不同的結算 continuation，逐一接入）。

## Test plan
- [x] GuiCaiSkillTest ×5：詢問暫停（判定未結算）/ ACCEPT 紅心替換救人（閃電轉移）/ SKIP 黑桃生效扣 3 血 / 司馬懿無手牌不觸發 / 場上無司馬懿迴歸
- [x] domain 492 / spring 242 全綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)