### PR TITLE
fix: 南蠻/萬箭輪詢依 reactionPlayers 列表推進（修免疫者誤問與跳人）

### DIFF
--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
@@ -107,17 +107,16 @@ public class ArrowBarrageBehavior extends Behavior
         }
         // Phase 2: 跳過這個玩家，繼續輪詢
         List<DomainEvent> events = new ArrayList<>();
-        String currentId = currentReactionPlayer.getId();
-        boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(currentId);
+        Player next = nextAliveReactorAfter(currentReactionPlayer.getId());
 
-        if (isLastPlayer) {
+        if (next == null) {
             isOneRound = true;
             game.getCurrentRound().setStage(Stage.Normal);
             game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
             return events;
         }
 
-        currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
+        currentReactionPlayer = next;
         events.addAll(askNextPlayerOrWard());
         return events;
     }
@@ -179,12 +178,13 @@ public class ArrowBarrageBehavior extends Behavior
         } else if (isDodgeCard(cardId)) {
             playerPlayCardNotUpdateActivePlayer(game.getPlayer(playerId), cardId);
             List<DomainEvent> events = new ArrayList<>();
-            currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
-            boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId);
+            Player next = nextAliveReactorAfter(playerId);
+            boolean isLastPlayer = next == null;
             if (isLastPlayer) {
                 isOneRound = true;
                 game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
             } else {
+                currentReactionPlayer = next;
                 game.getCurrentRound().setActivePlayer(currentReactionPlayer);
             }
             events.add(game.getGameStatusEvent(playerId + "出閃"));
@@ -204,6 +204,21 @@ public class ArrowBarrageBehavior extends Behavior
     }
 
     /**
+     * 依 reactionPlayers 列表順序找 playerId 之後第一個存活 reactor；null = 沒有了。
+     * 不可用座位 getNextPlayer：謙遜等免疫技會把玩家從列表排除（同南蠻的跳人/亂序修正）。
+     */
+    private Player nextAliveReactorAfter(String playerId) {
+        int idx = reactionPlayers.indexOf(playerId);
+        for (int i = idx + 1; i < reactionPlayers.size(); i++) {
+            Player candidate = game.getPlayer(reactionPlayers.get(i));
+            if (!candidate.isAlreadyDeath()) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    /**
      * AskDodge 前先讓 SkillEngine 介入（護駕等）。
      */
     private void emitAskDodgeOrHuJia(List<DomainEvent> events, Player targetPlayer) {
@@ -219,12 +234,13 @@ public class ArrowBarrageBehavior extends Behavior
     public List<DomainEvent> acceptDodgeFromHuJia(String dodgedPlayerId, String weiPlayerId, String dodgeCardId) {
         // dodge 已在 WaitingHuJia 中由 Wei 棄入墓地；這裡推進 polling
         List<DomainEvent> events = new ArrayList<>();
-        currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
-        boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(dodgedPlayerId);
+        Player next = nextAliveReactorAfter(dodgedPlayerId);
+        boolean isLastPlayer = next == null;
         if (isLastPlayer) {
             isOneRound = true;
             game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
         } else {
+            currentReactionPlayer = next;
             game.getCurrentRound().setActivePlayer(currentReactionPlayer);
         }
         events.add(game.getGameStatusEvent(dodgedPlayerId + "出閃"));
@@ -247,27 +263,29 @@ public class ArrowBarrageBehavior extends Behavior
     }
 
     private List<DomainEvent> advanceAfterDamage(String playerId) {
-        currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
+        Player next = nextAliveReactorAfter(playerId);
 
         List<DomainEvent> events = new ArrayList<>();
         if (!game.getGamePhase().getPhaseName().equals("GeneralDying")) {
-            boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId);
-            if (isLastPlayer) {
+            if (next == null) {
                 isOneRound = true;
                 game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
             } else {
                 isOneRound = false;
+                currentReactionPlayer = next;
                 game.getCurrentRound().setActivePlayer(currentReactionPlayer);
             }
             events.add(game.getGameStatusEvent("扣血但還活著"));
-            if (!isLastPlayer) {
+            if (next != null) {
                 events.addAll(askNextPlayerOrWard());
             }
         } else {
             events.add(game.getGameStatusEvent("扣血已瀕臨死亡"));
-            // 最後一個人
-            if (reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId)) {
+            if (next == null) {
                 isOneRound = true;
+            } else {
+                // 瀕死 resume hook 讀取 currentReactionPlayer；先推進到下一位
+                currentReactionPlayer = next;
             }
         }
         return events;

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
@@ -182,12 +182,13 @@ public class BarbarianInvasionBehavior extends Behavior implements com.gaas.thre
 
     private List<DomainEvent> advanceAfterKillResponse(String playerId, String statusMessage, List<DomainEvent> insertEvents) {
         List<DomainEvent> events = new ArrayList<>();
-        currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
-        boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId);
+        Player next = nextAliveReactorAfter(playerId);
+        boolean isLastPlayer = next == null;
         if (isLastPlayer) {
             isOneRound = true;
             game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
         } else {
+            currentReactionPlayer = next;
             game.getCurrentRound().setActivePlayer(currentReactionPlayer);
         }
         events.add(game.getGameStatusEvent(statusMessage));
@@ -213,28 +214,46 @@ public class BarbarianInvasionBehavior extends Behavior implements com.gaas.thre
         return advanceAfterDamage(damagedPlayerId);
     }
 
+    /**
+     * 依 reactionPlayers 列表順序找 playerId 之後第一個存活 reactor；null = 沒有了。
+     * 不可用座位 getNextPlayer：謙遜等免疫技會把玩家從列表排除（座位上仍存在），
+     * 座位推進會誤問免疫者、且免疫者在列表尾時 isLast 判斷失效（issue：南蠻跳人/亂序）。
+     */
+    private Player nextAliveReactorAfter(String playerId) {
+        int idx = reactionPlayers.indexOf(playerId);
+        for (int i = idx + 1; i < reactionPlayers.size(); i++) {
+            Player candidate = game.getPlayer(reactionPlayers.get(i));
+            if (!candidate.isAlreadyDeath()) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
     private List<DomainEvent> advanceAfterDamage(String playerId) {
-        currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
+        Player next = nextAliveReactorAfter(playerId);
 
         List<DomainEvent> events = new ArrayList<>();
         if (!game.getGamePhase().getPhaseName().equals("GeneralDying")) {
-            boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId);
-            if (isLastPlayer) {
+            if (next == null) {
                 isOneRound = true;
                 game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
             } else {
                 isOneRound = false;
+                currentReactionPlayer = next;
                 game.getCurrentRound().setActivePlayer(currentReactionPlayer);
             }
             events.add(game.getGameStatusEvent("扣血但還活著"));
-            if (!isLastPlayer) {
+            if (next != null) {
                 events.addAll(askNextPlayerOrWard());
             }
         } else {
             events.add(game.getGameStatusEvent("扣血已瀕臨死亡"));
-            // 最後一個人
-            if (reactionPlayers.get(reactionPlayers.size() - 1).equals(playerId)) {
+            if (next == null) {
                 isOneRound = true;
+            } else {
+                // 瀕死 resume hook 讀取 currentReactionPlayer；先推進到下一位
+                currentReactionPlayer = next;
             }
         }
         return events;

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/BarbarianInvasionPollingOrderTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/BarbarianInvasionPollingOrderTest.java
@@ -1,0 +1,219 @@
+package com.gaas.threeKingdoms;
+
+import com.gaas.threeKingdoms.builders.PlayerBuilder;
+import com.gaas.threeKingdoms.events.AskKillEvent;
+import com.gaas.threeKingdoms.events.AskSkillEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.gamephase.Normal;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.generalcard.GeneralCard;
+import com.gaas.threeKingdoms.events.AskJianXiongEffectEvent;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion;
+import com.gaas.threeKingdoms.player.*;
+import com.gaas.threeKingdoms.rolecard.Role;
+import com.gaas.threeKingdoms.rolecard.RoleCard;
+import com.gaas.threeKingdoms.round.Round;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 南蠻入侵輪詢順序驗證（使用者回報：最新版本疑似跳過一人）。
+ * 座位 a → b → c → d（a 出南蠻）；正確順序 = 從出牌者下家起逆時針：b → c → d。
+ * 每步斷言 AskKillEvent 目標與 activePlayer。
+ */
+public class BarbarianInvasionPollingOrderTest {
+
+    private Game createGame(General gA, General gB, General gC, General gD) {
+        Game game = new Game();
+        game.initDeck();
+        Player a = build("player-a", gA, Role.MONARCH);
+        Player b = build("player-b", gB, Role.MINISTER);
+        Player c = build("player-c", gC, Role.REBEL);
+        Player d = build("player-d", gD, Role.TRAITOR);
+        game.setPlayers(asList(a, b, c, d));
+        game.setCurrentRound(new Round(a));
+        game.enterPhase(new Normal(game));
+        return game;
+    }
+
+    private Player build(String id, General general, Role role) {
+        return PlayerBuilder.construct().withId(id)
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(general))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(role))
+                .withHand(new Hand()).withEquipment(new Equipment()).build();
+    }
+
+    private List<String> askKillTargets(List<DomainEvent> events) {
+        return events.stream().filter(e -> e instanceof AskKillEvent)
+                .map(e -> ((AskKillEvent) e).getPlayerId()).collect(Collectors.toList());
+    }
+
+    @DisplayName("全部 skip：詢問順序必須是 b → c → d，無跳過")
+    @Test
+    public void allSkip_orderIsBCD() {
+        Game game = createGame(General.甘寧, General.甘寧, General.孫權, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(new BarbarianInvasion(SS7007));
+
+        List<DomainEvent> e1 = game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        assertEquals(List.of("player-b"), askKillTargets(e1), "第一個被問的是 b");
+        assertEquals("player-b", game.getCurrentRound().getActivePlayer().getId());
+
+        List<DomainEvent> e2 = game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-c"), askKillTargets(e2), "b skip 後問 c（不可跳到 d）");
+        assertEquals("player-c", game.getCurrentRound().getActivePlayer().getId());
+
+        List<DomainEvent> e3 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e3), "c skip 後問 d");
+        assertEquals("player-d", game.getCurrentRound().getActivePlayer().getId());
+
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+        assertEquals(3, game.getPlayer("player-b").getHP());
+        assertEquals(3, game.getPlayer("player-c").getHP());
+        assertEquals(3, game.getPlayer("player-d").getHP());
+    }
+
+    @DisplayName("全部出殺：詢問順序 b → c → d，無人扣血")
+    @Test
+    public void allKill_orderIsBCD() {
+        Game game = createGame(General.甘寧, General.甘寧, General.孫權, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(new BarbarianInvasion(SS7007));
+        game.getPlayer("player-b").getHand().addCardToHand(new Kill(BS8008));
+        game.getPlayer("player-c").getHand().addCardToHand(new Kill(BS9009));
+        game.getPlayer("player-d").getHand().addCardToHand(new Kill(BS0010));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        List<DomainEvent> e2 = game.playerPlayCard("player-b", BS8008.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
+        assertEquals(List.of("player-c"), askKillTargets(e2), "b 出殺後問 c");
+        List<DomainEvent> e3 = game.playerPlayCard("player-c", BS9009.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e3), "c 出殺後問 d");
+        game.playerPlayCard("player-d", BS0010.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
+
+        assertTrue(game.getTopBehavior().isEmpty());
+        assertEquals(4, game.getPlayer("player-b").getHP());
+        assertEquals(4, game.getPlayer("player-c").getHP());
+        assertEquals(4, game.getPlayer("player-d").getHP());
+    }
+
+    @DisplayName("混合（b 殺、c skip、d 殺）：順序 b → c → d")
+    @Test
+    public void mixed_orderIsBCD() {
+        Game game = createGame(General.甘寧, General.甘寧, General.孫權, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(new BarbarianInvasion(SS7007));
+        game.getPlayer("player-b").getHand().addCardToHand(new Kill(BS8008));
+        game.getPlayer("player-d").getHand().addCardToHand(new Kill(BS0010));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        List<DomainEvent> e2 = game.playerPlayCard("player-b", BS8008.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
+        assertEquals(List.of("player-c"), askKillTargets(e2));
+        List<DomainEvent> e3 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e3), "c skip（扣血）後問 d");
+        game.playerPlayCard("player-d", BS0010.getCardId(), "player-a", PlayType.ACTIVE.getPlayType());
+
+        assertTrue(game.getTopBehavior().isEmpty());
+        assertEquals(3, game.getPlayer("player-c").getHP());
+        assertEquals(4, game.getPlayer("player-d").getHP());
+    }
+
+    @DisplayName("b=曹操 skip 受傷 → 奸雄 ACCEPT → 下一個被問的必須是 c（不可跳到 d）")
+    @Test
+    public void jianXiongAccept_nextAskedIsC() {
+        Game game = createGame(General.甘寧, General.曹操, General.孫權, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(new BarbarianInvasion(SS7007));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        List<DomainEvent> e2 = game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(e2.stream().anyMatch(e -> e instanceof AskJianXiongEffectEvent));
+        assertTrue(askKillTargets(e2).isEmpty(), "奸雄詢問中，不應先問下一個 reactor");
+
+        List<DomainEvent> e3 = game.playerUseJianXiongEffect("player-b", AskJianXiongEffectEvent.Choice.ACCEPT);
+        assertEquals(List.of("player-c"), askKillTargets(e3), "奸雄解決後問 c — 跳到 d 即為 bug");
+        assertEquals("player-c", game.getCurrentRound().getActivePlayer().getId());
+
+        List<DomainEvent> e4 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e4), "c skip 後問 d");
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("b=曹操 奸雄 SKIP → 下一個被問的也必須是 c")
+    @Test
+    public void jianXiongSkip_nextAskedIsC() {
+        Game game = createGame(General.甘寧, General.曹操, General.孫權, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(new BarbarianInvasion(SS7007));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        List<DomainEvent> e3 = game.playerUseJianXiongEffect("player-b", AskJianXiongEffectEvent.Choice.SKIP);
+
+        assertEquals(List.of("player-c"), askKillTargets(e3), "奸雄放棄後問 c");
+        List<DomainEvent> e4 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e4), "接著問 d");
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("c=陸遜（謙遜免疫）→ 只問 b、d；b 回應後直接問 d，且陸遜不被問")
+    @Test
+    public void qianXunImmuneMiddle_asksOnlyBandD() {
+        Game game = createGame(General.甘寧, General.甘寧, General.陸遜, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(new BarbarianInvasion(SS7007));
+
+        List<DomainEvent> e1 = game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        assertEquals(List.of("player-b"), askKillTargets(e1));
+
+        List<DomainEvent> e2 = game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e2),
+                "陸遜免疫應被跳過 — 問 c 或直接結束皆為 bug");
+        assertEquals("player-d", game.getCurrentRound().getActivePlayer().getId());
+
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty(), "d 回應後南蠻應結束");
+        assertEquals(4, game.getPlayer("player-c").getHP(), "陸遜不受傷");
+        assertEquals(3, game.getPlayer("player-d").getHP());
+    }
+
+    @DisplayName("b=劉備主公（激將）關羽代殺 → 下一個被問的必須是 c")
+    @Test
+    public void jiJiangAccept_nextAskedIsC() {
+        // 激將是主公技：b=劉備 必須是 MONARCH
+        Game game = new Game();
+        game.initDeck();
+        Player pa = build("player-a", General.甘寧, Role.TRAITOR);
+        Player pb = build("player-b", General.劉備, Role.MONARCH);
+        Player pc = build("player-c", General.關羽, Role.MINISTER);
+        Player pd = build("player-d", General.孫權, Role.REBEL);
+        game.setPlayers(asList(pa, pb, pc, pd));
+        game.setCurrentRound(new Round(pa));
+        game.enterPhase(new Normal(game));
+        game.getPlayer("player-a").getHand().addCardToHand(new BarbarianInvasion(SS7007));
+        game.getPlayer("player-c").getHand().addCardToHand(new Kill(BS8008));
+
+        List<DomainEvent> e1 = game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        // 激將攔截：問蜀將關羽（c）而非直接 AskKill(b)
+        assertTrue(e1.stream().anyMatch(e -> e instanceof AskSkillEffectEvent
+                && ((AskSkillEffectEvent) e).getSkillName().equals("激將")));
+
+        List<DomainEvent> e2 = game.playerUseSkillEffect("player-c", "激將", "ACCEPT",
+                List.of(BS8008.getCardId()), null);
+        assertEquals(List.of("player-c"), askKillTargets(e2),
+                "劉備（第一 reactor）被代殺後，輪到 c 被問南蠻 — 跳到 d 即為 bug");
+        assertEquals(4, game.getPlayer("player-b").getHP(), "劉備被代殺不扣血");
+
+        List<DomainEvent> e3 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e3));
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_a_play_ArrowBarrage_and_player_d_dead_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_a_play_ArrowBarrage_and_player_d_dead_for_player_a.json
@@ -15,6 +15,12 @@
       "role" : "Minister"
     },
     "message" : "劉備 死亡，身分是 忠臣"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-d"
+    },
+    "message" : "請問 player-d 要否要出閃"
   } ],
   "data" : {
     "seats" : [ {
@@ -65,7 +71,7 @@
     "round" : {
       "roundPhase" : "Judgement",
       "currentRoundPlayer" : "player-a",
-      "activePlayer" : "player-a",
+      "activePlayer" : "player-d",
       "dyingPlayer" : "player-d",
       "showKill" : false
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_a_play_ArrowBarrage_and_player_d_dead_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_a_play_ArrowBarrage_and_player_d_dead_for_player_b.json
@@ -15,6 +15,12 @@
       "role" : "Minister"
     },
     "message" : "劉備 死亡，身分是 忠臣"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-d"
+    },
+    "message" : "請問 player-d 要否要出閃"
   } ],
   "data" : {
     "seats" : [ {
@@ -65,7 +71,7 @@
     "round" : {
       "roundPhase" : "Judgement",
       "currentRoundPlayer" : "player-a",
-      "activePlayer" : "player-a",
+      "activePlayer" : "player-d",
       "dyingPlayer" : "player-d",
       "showKill" : false
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_a_play_ArrowBarrage_and_player_d_dead_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_a_play_ArrowBarrage_and_player_d_dead_for_player_c.json
@@ -15,6 +15,12 @@
       "role" : "Minister"
     },
     "message" : "劉備 死亡，身分是 忠臣"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-d"
+    },
+    "message" : "請問 player-d 要否要出閃"
   } ],
   "data" : {
     "seats" : [ {
@@ -65,7 +71,7 @@
     "round" : {
       "roundPhase" : "Judgement",
       "currentRoundPlayer" : "player-a",
-      "activePlayer" : "player-a",
+      "activePlayer" : "player-d",
       "dyingPlayer" : "player-d",
       "showKill" : false
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_a_play_ArrowBarrage_and_player_d_dead_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_a_play_ArrowBarrage_and_player_d_dead_for_player_d.json
@@ -15,6 +15,12 @@
       "role" : "Minister"
     },
     "message" : "劉備 死亡，身分是 忠臣"
+  }, {
+    "event" : "AskDodgeEvent",
+    "data" : {
+      "playerId" : "player-d"
+    },
+    "message" : "請問 player-d 要否要出閃"
   } ],
   "data" : {
     "seats" : [ {
@@ -65,7 +71,7 @@
     "round" : {
       "roundPhase" : "Judgement",
       "currentRoundPlayer" : "player-a",
-      "activePlayer" : "player-a",
+      "activePlayer" : "player-d",
       "dyingPlayer" : "player-d",
       "showKill" : false
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_a.json
@@ -10,9 +10,9 @@
   }, {
     "event" : "AskKillEvent",
     "data" : {
-      "playerId" : "player-d"
+      "playerId" : "player-c"
     },
-    "message" : "請問 player-d 要否要出殺"
+    "message" : "請問 player-c 要否要出殺"
   } ],
   "data" : {
     "seats" : [ {

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_b.json
@@ -10,9 +10,9 @@
   }, {
     "event" : "AskKillEvent",
     "data" : {
-      "playerId" : "player-d"
+      "playerId" : "player-c"
     },
-    "message" : "請問 player-d 要否要出殺"
+    "message" : "請問 player-c 要否要出殺"
   } ],
   "data" : {
     "seats" : [ {

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_c.json
@@ -10,9 +10,9 @@
   }, {
     "event" : "AskKillEvent",
     "data" : {
-      "playerId" : "player-d"
+      "playerId" : "player-c"
     },
-    "message" : "請問 player-d 要否要出殺"
+    "message" : "請問 player-c 要否要出殺"
   } ],
   "data" : {
     "seats" : [ {

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_d.json
@@ -10,9 +10,9 @@
   }, {
     "event" : "AskKillEvent",
     "data" : {
-      "playerId" : "player-d"
+      "playerId" : "player-c"
     },
-    "message" : "請問 player-d 要否要出殺"
+    "message" : "請問 player-c 要否要出殺"
   } ],
   "data" : {
     "seats" : [ {


### PR DESCRIPTION
## Summary
使用者回報南蠻入侵輪詢疑似跳人。寫了 7 個順序斷言測試，抓到真 bug：

**根因**：南蠻/萬箭輪詢推進用**座位順序**（`getNextPlayer`），但 `reactionPlayers` 列表可能被謙遜等免疫技排除玩家（座位上仍在）：
1. 免疫者（陸遜）仍被詢問並可被 damage — 謙遜破口
2. 免疫者在列表尾時 `isLastPlayer`（比對列表最後 id）失效 → 輪詢繞回出牌者/不結束

**修法**：`nextAliveReactorAfter(playerId)` — 依 reactionPlayers **列表 index** 推進 + 跳過已死者（方天畫戟既有模式），改寫 BI×2 + AB×4 共 6 個推進點。

## 測試（依回報要求多寫確認）
`BarbarianInvasionPollingOrderTest` ×7 — 每步斷言 `AskKillEvent` 目標 + activePlayer：
- 全 skip / 全出殺 / 混合 → 順序恆為 b→c→d
- 奸雄 ACCEPT / SKIP 後 → 下一個必須是 c（不可跳 d）
- **謙遜免疫者在中間 → 修前紅**（誤問陸遜），修後正確跳過且不受傷
- 激將代殺後 → 繼續問 c

JianXiong lethal-BI fixture 隨瀕死分支推進時點重產。

## Test plan
- [x] domain 502 / spring 243 全綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)