### PR TITLE
fix: 奸雄後無懈可擊詢問未發給持有者（closes #214）

### DIFF
--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
@@ -97,17 +97,16 @@ public class BarbarianInvasionBehavior extends Behavior implements com.gaas.thre
         }
         // Phase 2: 跳過這個玩家，繼續輪詢
         List<DomainEvent> events = new ArrayList<>();
-        String currentId = currentReactionPlayer.getId();
-        boolean isLastPlayer = reactionPlayers.get(reactionPlayers.size() - 1).equals(currentId);
+        Player next = nextAliveReactorAfter(currentReactionPlayer.getId());
 
-        if (isLastPlayer) {
+        if (next == null) {
             isOneRound = true;
             game.getCurrentRound().setStage(Stage.Normal);
             game.getCurrentRound().setActivePlayer(game.getCurrentRoundPlayer());
             return events;
         }
 
-        currentReactionPlayer = game.getNextPlayer(currentReactionPlayer);
+        currentReactionPlayer = next;
         events.addAll(askNextPlayerOrWard());
         return events;
     }

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/BarbarianInvasionPollingOrderTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/BarbarianInvasionPollingOrderTest.java
@@ -9,8 +9,10 @@ import com.gaas.threeKingdoms.generalcard.General;
 import com.gaas.threeKingdoms.generalcard.GeneralCard;
 import com.gaas.threeKingdoms.events.AskJianXiongEffectEvent;
 import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.events.WaitForWardEvent;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion;
+import com.gaas.threeKingdoms.handcard.scrollcard.Ward;
 import com.gaas.threeKingdoms.player.*;
 import com.gaas.threeKingdoms.rolecard.Role;
 import com.gaas.threeKingdoms.rolecard.RoleCard;
@@ -19,6 +21,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.gaas.threeKingdoms.handcard.PlayCard.*;
@@ -182,6 +185,70 @@ public class BarbarianInvasionPollingOrderTest {
         assertTrue(game.getTopBehavior().isEmpty(), "d 回應後南蠻應結束");
         assertEquals(4, game.getPlayer("player-c").getHP(), "陸遜不受傷");
         assertEquals(3, game.getPlayer("player-d").getHP());
+    }
+
+    @DisplayName("issue #214：b=曹操（有無懈可擊）奸雄 ACCEPT 後 → 無懈詢問只發給曹操，且目標為 c")
+    @Test
+    public void jianXiongAcceptWithWardHolder_wardAskOnlyToCaoCao() {
+        Game game = createGame(General.甘寧, General.曹操, General.孫權, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(new BarbarianInvasion(SS7007));
+        game.getPlayer("player-b").getHand().addCardToHand(new Ward(SSJ011));
+
+        // Phase 1（可取消整個南蠻）：只問持有無懈的 b
+        List<DomainEvent> e1 = game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        WaitForWardEvent w1 = findWaitForWard(e1);
+        assertEquals(Set.of("player-b"), w1.getPlayerIds());
+
+        // b 放棄 phase 1 → phase 2 對第一個 reactor（b 自己）的無懈詢問
+        List<DomainEvent> e2 = game.playWardCard("player-b", "", PlayType.SKIP.getPlayType());
+        WaitForWardEvent w2 = findWaitForWard(e2);
+        assertEquals(List.of("player-b"), w2.getTargetPlayerIds());
+
+        // b 放棄 → 被問殺 → skip 扣血 → 奸雄詢問
+        List<DomainEvent> e3 = game.playWardCard("player-b", "", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-b"), askKillTargets(e3));
+        List<DomainEvent> e4 = game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(e4.stream().anyMatch(e -> e instanceof AskJianXiongEffectEvent));
+
+        // 奸雄 ACCEPT → 輪詢推進到 c，b 仍持有無懈 → 無懈詢問只發給 b、目標是 c
+        List<DomainEvent> e5 = game.playerUseJianXiongEffect("player-b", AskJianXiongEffectEvent.Choice.ACCEPT);
+        WaitForWardEvent w5 = findWaitForWard(e5);
+        assertEquals(Set.of("player-b"), w5.getPlayerIds(), "issue #214：只有曹操該被問無懈可擊");
+        assertEquals(List.of("player-c"), w5.getTargetPlayerIds(), "此次無懈保護的目標是 c");
+        assertTrue(askKillTargets(e5).isEmpty(), "無懈詢問未解決前不可先問殺");
+
+        // b 放棄 → 問 c 殺，輪詢正常繼續
+        List<DomainEvent> e6 = game.playWardCard("player-b", "", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-c"), askKillTargets(e6));
+    }
+
+    @DisplayName("phase 2 無懈保護 b 成功 + c=陸遜免疫 → 下一個被問的必須是 d（不可問陸遜）")
+    @Test
+    public void wardCancelOnB_withImmuneLuXunNext_asksD() {
+        Game game = createGame(General.甘寧, General.甘寧, General.陸遜, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(new BarbarianInvasion(SS7007));
+        game.getPlayer("player-b").getHand().addCardToHand(new Ward(SSJ011));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        // b 放棄 phase 1 → phase 2 詢問（目標 b 自己）
+        game.playWardCard("player-b", "", PlayType.SKIP.getPlayType());
+        // b 出無懈保護自己 → 南蠻對 b 無效，輪詢推進：陸遜免疫必須跳過，直接問 d
+        List<DomainEvent> e3 = game.playWardCard("player-b", SSJ011.getCardId(), PlayType.ACTIVE.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e3),
+                "無懈取消後座位推進會誤問免疫的陸遜 — 必須依 reactionPlayers 列表推進");
+        assertEquals("player-d", game.getCurrentRound().getActivePlayer().getId());
+
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+        assertEquals(4, game.getPlayer("player-b").getHP(), "b 被無懈保護不扣血");
+        assertEquals(4, game.getPlayer("player-c").getHP(), "陸遜免疫不扣血");
+        assertEquals(3, game.getPlayer("player-d").getHP());
+    }
+
+    private WaitForWardEvent findWaitForWard(List<DomainEvent> events) {
+        return events.stream().filter(e -> e instanceof WaitForWardEvent)
+                .map(e -> (WaitForWardEvent) e).findFirst()
+                .orElseThrow(() -> new AssertionError("expected WaitForWardEvent but none found"));
     }
 
     @DisplayName("b=劉備主公（激將）關羽代殺 → 下一個被問的必須是 c")

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/PlayCardPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/PlayCardPresenter.java
@@ -78,6 +78,22 @@ public class PlayCardPresenter implements PlayCardUseCase.PlayCardPresenter<List
         }
     }
 
+    /**
+     * issue #214：任何可能推進到無懈可擊詢問的 presenter 都須做 per-player 個人化 —
+     * 持有無懈可擊的玩家收 AskPlayWardEvent，其他人維持 WaitForWardEvent。
+     */
+    public static List<ViewModel<?>> personalizeWardViewModels(List<ViewModel<?>> viewModels, List<DomainEvent> events, String playerId) {
+        return viewModels.stream().map(viewModel -> {
+            if (viewModel instanceof WaitForWardViewModel waitForWardViewModel) {
+                WaitForWardEvent waitForWardEvent = getEvent(events, WaitForWardEvent.class).orElseThrow(RuntimeException::new);
+                if (waitForWardEvent.getPlayerIds().contains(playerId)) {
+                    return (ViewModel<?>) new AskPlayWardViewModel(waitForWardViewModel.getData());
+                }
+            }
+            return viewModel;
+        }).collect(Collectors.toList());
+    }
+
     public static GameOverViewModel getGameOverViewModel(List<DomainEvent> events) {
         return getEvent(events, GameOverEvent.class)
                 .map(gameOverEvent -> {

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseJianXiongEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseJianXiongEffectPresenter.java
@@ -36,8 +36,9 @@ public class UseJianXiongEffectPresenter implements UseJianXiongEffectUseCase.Us
                     PlayerDataViewModel.hiddenOtherPlayerRoleInformation(
                             playerDataViewModels, viewModel.getId()), roundDataViewModel, gameStatusEvent.getGamePhase());
 
+            // issue #214：奸雄解決後南蠻/萬箭輪詢推進，可能產生對下一家的無懈可擊詢問
             viewModels.add(new GameViewModel(
-                    new ArrayList<>(effectViewModels),
+                    PlayCardPresenter.personalizeWardViewModels(effectViewModels, events, viewModel.getId()),
                     gameDataViewModel,
                     gameStatusEvent.getMessage(),
                     gameStatusEvent.getGameId(),

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseSkillEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseSkillEffectPresenter.java
@@ -36,8 +36,9 @@ public class UseSkillEffectPresenter implements UseSkillEffectUseCase.UseSkillEf
                     PlayerDataViewModel.hiddenOtherPlayerRoleInformation(
                             playerDataViewModels, viewModel.getId()), roundDataViewModel, gameStatusEvent.getGamePhase());
 
+            // issue #214：技能結算可能推進到無懈可擊詢問（如奸雄/激將 ACCEPT 後南蠻輪詢下一家）
             viewModels.add(new GameViewModel(
-                    new ArrayList<>(effectViewModels),
+                    PlayCardPresenter.personalizeWardViewModels(effectViewModels, events, viewModel.getId()),
                     gameDataViewModel,
                     gameStatusEvent.getMessage(),
                     gameStatusEvent.getGameId(),

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/BarbarianJianXiongWardTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/BarbarianJianXiongWardTest.java
@@ -1,0 +1,105 @@
+package com.gaas.threeKingdoms.e2e.skill;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion;
+import com.gaas.threeKingdoms.handcard.scrollcard.Ward;
+import com.gaas.threeKingdoms.player.HealthStatus;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.rolecard.Role;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.gaas.threeKingdoms.e2e.MockUtil.createPlayer;
+import static com.gaas.threeKingdoms.e2e.MockUtil.initGame;
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Issue #214：南蠻入侵 + 奸雄 + 無懈可擊。
+ * B=曹操 持有無懈可擊，skip 南蠻扣血後奸雄 ACCEPT 取得南蠻牌；
+ * 輪詢推進到 C 時會產生對 C 的無懈可擊詢問 —
+ * 此時只有曹操該收到 AskPlayWardEvent，其他玩家收 WaitForWardEvent。
+ * 根因：UseSkillEffectPresenter 未做 per-player 個人化（WaitForWard → AskPlayWard）。
+ */
+public class BarbarianJianXiongWardTest extends AbstractBaseIntegrationTest {
+
+    @Test
+    public void testJianXiongAcceptThenWardAsk_OnlyCaoCaoGetsAskPlayWardEvent() throws Exception {
+        // A 出南蠻；B=曹操（有無懈可擊、無殺）；C、D 有殺
+        Player playerA = createPlayer("player-a", 4, General.甘寧, HealthStatus.ALIVE, Role.MONARCH,
+                new BarbarianInvasion(SS7007));
+        Player playerB = createPlayer("player-b", 4, General.曹操, HealthStatus.ALIVE, Role.MINISTER,
+                new Ward(SSJ011));
+        Player playerC = createPlayer("player-c", 4, General.甘寧, HealthStatus.ALIVE, Role.REBEL,
+                new Kill(BS8008));
+        Player playerD = createPlayer("player-d", 4, General.甘寧, HealthStatus.ALIVE, Role.TRAITOR,
+                new Kill(BS9009));
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        repository.save(game);
+
+        // A 出南蠻 → Phase 1 無懈詢問（B 持有）
+        mockMvcUtil.playCard(gameId, "player-a", "player-a", SS7007.getCardId(), PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+        // B 放棄 phase 1 → phase 2 無懈詢問（目標 B 自己）
+        mockMvcUtil.playWardCard(gameId, "player-b", "", PlayType.SKIP.getPlayType())
+                .andExpect(status().isOk());
+        // B 放棄 → 被問殺
+        mockMvcUtil.playWardCard(gameId, "player-b", "", PlayType.SKIP.getPlayType())
+                .andExpect(status().isOk());
+        // B 不出殺 → 扣血 → 奸雄詢問
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", PlayType.SKIP.getPlayType())
+                .andExpect(status().isOk());
+
+        // 前面 4 個步驟各廣播一則訊息給每位玩家 — 逐一消費，下一則即奸雄 resolve 的廣播
+        // （不能用 clearAllQueues：廣播非同步送達，清空時機有 race）
+        for (String playerId : List.of("player-a", "player-b", "player-c", "player-d")) {
+            for (int i = 0; i < 4; i++) {
+                assertNotNull(websocketUtil.getValue(playerId), "前置步驟訊息未送達：" + playerId);
+            }
+        }
+
+        // B ACCEPT 奸雄 → 輪詢推進到 C，B 仍持無懈 → 無懈詢問（issue #214 的爆點）
+        mockMvcUtil.useJianXiongEffect(gameId, "player-b", "ACCEPT")
+                .andExpect(status().isOk());
+
+        String messageB = websocketUtil.getValue("player-b");
+        String messageC = websocketUtil.getValue("player-c");
+        String messageD = websocketUtil.getValue("player-d");
+
+        assertTrue(messageB.contains("AskPlayWardEvent"),
+                "issue #214：持有無懈可擊的曹操應收到 AskPlayWardEvent");
+        assertFalse(messageC.contains("AskPlayWardEvent"), "C 沒有無懈可擊，不應被詢問");
+        assertTrue(messageC.contains("WaitForWardEvent"), "C 應收到等待無懈可擊 event");
+        assertFalse(messageD.contains("AskPlayWardEvent"), "D 沒有無懈可擊，不應被詢問");
+        assertTrue(messageD.contains("WaitForWardEvent"), "D 應收到等待無懈可擊 event");
+
+        // B 放棄無懈 → C 被問殺，流程繼續到結束（不卡住）
+        mockMvcUtil.playWardCard(gameId, "player-b", "", PlayType.SKIP.getPlayType())
+                .andExpect(status().isOk());
+        Game saved = repository.findById(gameId).orElseThrow();
+        assertEquals("player-c", saved.getCurrentRound().getActivePlayer().getId());
+
+        mockMvcUtil.playCard(gameId, "player-c", "player-a", BS8008.getCardId(), PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+        // B 手上仍有無懈（skip 不棄牌）→ 輪到 D 前再問一次無懈，B 放棄
+        mockMvcUtil.playWardCard(gameId, "player-b", "", PlayType.SKIP.getPlayType())
+                .andExpect(status().isOk());
+        mockMvcUtil.playCard(gameId, "player-d", "player-a", BS9009.getCardId(), PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+
+        saved = repository.findById(gameId).orElseThrow();
+        assertTrue(saved.getTopBehavior().isEmpty(), "南蠻流程應完整結束");
+        assertTrue(saved.getPlayer("player-b").getHand().getCards().stream()
+                .anyMatch(c -> c.getId().equals(SS7007.getCardId())), "奸雄取得南蠻牌");
+        assertEquals(3, saved.getPlayer("player-b").getHP());
+        assertEquals(4, saved.getPlayer("player-c").getHP());
+        assertEquals(4, saved.getPlayer("player-d").getHP());
+    }
+}


### PR DESCRIPTION
## Summary
Closes #214：南蠻 + 奸雄 + 無懈可擊 — 奸雄 ACCEPT 後輪詢推進產生的無懈詢問，所有玩家都只收到 `WaitForWardEvent`，持有無懈的曹操沒收到 `AskPlayWardEvent`。

**根因**：`UseJianXiongEffectPresenter` / `UseSkillEffectPresenter` 缺 per-player 個人化（WaitForWard → AskPlayWard）— 其他 12 個 presenter 都有這段。domain 端 event 的 `playerIds` 本來就正確，純 presenter 層問題。

**修法**：
- `PlayCardPresenter.personalizeWardViewModels()` 共用 helper，兩個缺漏 presenter 套用
- 同場補 #213 漏網：`BarbarianInvasionBehavior.doWardCancelledAction`（無懈取消後推進）仍用座位序 → 改 `nextAliveReactorAfter` 列表推進（免疫者破口同 #213）

## 測試
- domain ×2（PollingOrderTest 累計 9）：奸雄 ACCEPT 後 `WaitForWardEvent.playerIds` 只含曹操、目標 c；無懈保護 b 後跳過免疫陸遜直接問 d
- spring e2e `BarbarianJianXiongWardTest`：復刻 issue 場景，斷言曹操收 `AskPlayWardEvent`、C/D 收 `WaitForWardEvent`，並走完全流程驗證不卡住（websocket 訊息逐則消費，無 race）

## Test plan
- [x] domain 504 / spring 244 全綠（e2e 單測 3 連跑穩定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)