### PR TITLE
fix: 奸雄後出無懈可擊 NPE（stack 殘留 card=null behavior）

### DIFF
--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WardBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WardBehavior.java
@@ -4,6 +4,7 @@ import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.behavior.Behavior;
 import com.gaas.threeKingdoms.events.*;
 import com.gaas.threeKingdoms.handcard.HandCard;
+import com.gaas.threeKingdoms.handcard.PlayCard;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.handcard.scrollcard.Ward;
 import com.gaas.threeKingdoms.player.Player;
@@ -115,6 +116,19 @@ public class WardBehavior extends Behavior {
     }
 
 
+    private String getBehaviorSourceName(Behavior behavior) {
+        return behavior.getBehaviorPlayer() != null ? behavior.getBehaviorPlayer().getGeneralName() : "";
+    }
+
+    // card 可能為 null（系統 behavior，或 VirtualKill 經 MongoDB reload 後 findById 查無）— 以 cardId 反查兜底
+    private String getBehaviorCardName(Behavior behavior) {
+        if (behavior.getCard() != null) {
+            return behavior.getCard().getName();
+        }
+        HandCard card = behavior.getCardId() != null ? PlayCard.findById(behavior.getCardId()) : null;
+        return card != null ? card.getName() : "";
+    }
+
     @Override
     public List<DomainEvent> doBehaviorAction() {
         List<DomainEvent> domainEvents = new ArrayList<>();
@@ -127,9 +141,15 @@ public class WardBehavior extends Behavior {
         for (int i = topBehaviors.size() - 1; i >= 0; i--) {
             Behavior behavior = topBehaviors.get(i);
             if (!(behavior instanceof WardBehavior)) {
+                // 已完成待移除的殘留（如奸雄 resolve 後被新 WardBehavior 壓住、
+                // 來不及被 removeCompletedBehaviors 清掉的 WaitingJianXiongResponseBehavior，
+                // card 為 null）— 跳過，繼續往下找真正的效果來源
+                if (behavior.isOneRound()) {
+                    continue;
+                }
                 if (wardEvent != null) {
                     domainEvents.add(new WardEvent(wardEvent.getPlayerId(), behavior.getCardId(), wardEvent.getWardCardId(), wardEvent.getMessage()
-                            + String.format("%s 的 %s", behavior.getBehaviorPlayer().getGeneralName(), behavior.getCard().getName())));
+                            + String.format("%s 的 %s", getBehaviorSourceName(behavior), getBehaviorCardName(behavior))));
                 }
                 break;
             }
@@ -145,7 +165,7 @@ public class WardBehavior extends Behavior {
                     wardEvent = new WardEvent(wardPlayer.getId(), null, behavior.getCardId(), unDoneMessage);
                 } else if (StringUtils.isBlank(wardEvent.getCardId())) {
                     domainEvents.add(new WardEvent(wardEvent.getPlayerId(), behavior.getCardId(), wardEvent.getWardCardId(), wardEvent.getMessage()
-                            + String.format("%s 的 %s", behavior.getBehaviorPlayer().getGeneralName(), behavior.getCard().getName())));
+                            + String.format("%s 的 %s", getBehaviorSourceName(behavior), getBehaviorCardName(behavior))));
                     wardEvent = null;
                 }
 

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/BarbarianInvasionPollingOrderTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/BarbarianInvasionPollingOrderTest.java
@@ -10,6 +10,7 @@ import com.gaas.threeKingdoms.generalcard.GeneralCard;
 import com.gaas.threeKingdoms.events.AskJianXiongEffectEvent;
 import com.gaas.threeKingdoms.handcard.PlayType;
 import com.gaas.threeKingdoms.events.WaitForWardEvent;
+import com.gaas.threeKingdoms.events.WardEvent;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion;
 import com.gaas.threeKingdoms.handcard.scrollcard.Ward;
@@ -220,6 +221,52 @@ public class BarbarianInvasionPollingOrderTest {
         // b 放棄 → 問 c 殺，輪詢正常繼續
         List<DomainEvent> e6 = game.playWardCard("player-b", "", PlayType.SKIP.getPlayType());
         assertEquals(List.of("player-c"), askKillTargets(e6));
+    }
+
+    @DisplayName("奸雄 ACCEPT 後 b 出無懈保護 c → 不 NPE、抵銷訊息指向南蠻、輪詢推進到 d")
+    @Test
+    public void jianXiongAcceptThenActiveWard_noNPE() {
+        Game game = createGame(General.甘寧, General.曹操, General.孫權, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(new BarbarianInvasion(SS7007));
+        game.getPlayer("player-b").getHand().addCardToHand(new Ward(SSJ011));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        game.playWardCard("player-b", "", PlayType.SKIP.getPlayType());
+        game.playWardCard("player-b", "", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        game.playerUseJianXiongEffect("player-b", AskJianXiongEffectEvent.Choice.ACCEPT);
+
+        // b 確定發動無懈可擊保護 c —— 奸雄 behavior（card=null）殘留在 stack 中間，曾在此 NPE
+        List<DomainEvent> e6 = game.playWardCard("player-b", SSJ011.getCardId(), PlayType.ACTIVE.getPlayType());
+        WardEvent wardEvent = e6.stream().filter(e -> e instanceof WardEvent)
+                .map(e -> (WardEvent) e).findFirst()
+                .orElseThrow(() -> new AssertionError("expected WardEvent but none found"));
+        assertTrue(wardEvent.getMessage().contains("南蠻入侵"),
+                "抵銷訊息須指向真正的效果來源南蠻，而非 stack 中殘留的奸雄 behavior：" + wardEvent.getMessage());
+        assertEquals(List.of("player-d"), askKillTargets(e6), "c 被無懈保護後輪詢推進到 d");
+
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty(), "南蠻流程完整結束");
+        assertEquals(4, game.getPlayer("player-c").getHP(), "c 被無懈保護不扣血");
+        assertEquals(3, game.getPlayer("player-d").getHP());
+    }
+
+    @DisplayName("奸雄 SKIP 後 b 出無懈保護 c → 不 NPE、輪詢推進到 d")
+    @Test
+    public void jianXiongSkipThenActiveWard_noNPE() {
+        Game game = createGame(General.甘寧, General.曹操, General.孫權, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(new BarbarianInvasion(SS7007));
+        game.getPlayer("player-b").getHand().addCardToHand(new Ward(SSJ011));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        game.playWardCard("player-b", "", PlayType.SKIP.getPlayType());
+        game.playWardCard("player-b", "", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        game.playerUseJianXiongEffect("player-b", AskJianXiongEffectEvent.Choice.SKIP);
+
+        List<DomainEvent> e6 = game.playWardCard("player-b", SSJ011.getCardId(), PlayType.ACTIVE.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e6), "c 被無懈保護後輪詢推進到 d");
+        assertEquals(4, game.getPlayer("player-c").getHP(), "c 被無懈保護不扣血");
     }
 
     @DisplayName("phase 2 無懈保護 b 成功 + c=陸遜免疫 → 下一個被問的必須是 d（不可問陸遜）")

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/BarbarianJianXiongWardTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/BarbarianJianXiongWardTest.java
@@ -102,4 +102,50 @@ public class BarbarianJianXiongWardTest extends AbstractBaseIntegrationTest {
         assertEquals(4, saved.getPlayer("player-c").getHP());
         assertEquals(4, saved.getPlayer("player-d").getHP());
     }
+
+    /**
+     * 奸雄 resolve 後 WaitingJianXiongResponseBehavior（card=null）會被新的無懈詢問
+     * 壓在 stack 中間、來不及移除；此時 B「確定發動」無懈可擊曾觸發
+     * NPE：getCard() is null（WardBehavior 組抵銷訊息時撞到殘留 behavior）。
+     */
+    @Test
+    public void testJianXiongAcceptThenPlayWardActive_NoNPE() throws Exception {
+        Player playerA = createPlayer("player-a", 4, General.甘寧, HealthStatus.ALIVE, Role.MONARCH,
+                new BarbarianInvasion(SS7007));
+        Player playerB = createPlayer("player-b", 4, General.曹操, HealthStatus.ALIVE, Role.MINISTER,
+                new Ward(SSJ011));
+        Player playerC = createPlayer("player-c", 4, General.甘寧, HealthStatus.ALIVE, Role.REBEL,
+                new Kill(BS8008));
+        Player playerD = createPlayer("player-d", 4, General.甘寧, HealthStatus.ALIVE, Role.TRAITOR,
+                new Kill(BS9009));
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        repository.save(game);
+
+        mockMvcUtil.playCard(gameId, "player-a", "player-a", SS7007.getCardId(), PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+        mockMvcUtil.playWardCard(gameId, "player-b", "", PlayType.SKIP.getPlayType())
+                .andExpect(status().isOk());
+        mockMvcUtil.playWardCard(gameId, "player-b", "", PlayType.SKIP.getPlayType())
+                .andExpect(status().isOk());
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", PlayType.SKIP.getPlayType())
+                .andExpect(status().isOk());
+        mockMvcUtil.useJianXiongEffect(gameId, "player-b", "ACCEPT")
+                .andExpect(status().isOk());
+
+        // B 確定發動無懈可擊保護 C —— 修復前此步 500（NPE）
+        mockMvcUtil.playWardCard(gameId, "player-b", SSJ011.getCardId(), PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+
+        Game saved = repository.findById(gameId).orElseThrow();
+        assertEquals("player-d", saved.getCurrentRound().getActivePlayer().getId(), "C 被無懈保護後輪詢推進到 D");
+
+        mockMvcUtil.playCard(gameId, "player-d", "player-a", BS9009.getCardId(), PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+
+        saved = repository.findById(gameId).orElseThrow();
+        assertTrue(saved.getTopBehavior().isEmpty(), "南蠻流程應完整結束");
+        assertEquals(3, saved.getPlayer("player-b").getHP());
+        assertEquals(4, saved.getPlayer("player-c").getHP(), "C 被無懈保護不扣血");
+        assertEquals(4, saved.getPlayer("player-d").getHP(), "D 出殺不扣血");
+    }
 }


### PR DESCRIPTION
## 問題

使用者回報：南蠻入侵 → 曹操扣血奸雄 → 之後「確定發動」無懈可擊時 500：

```
Cannot invoke "HandCard.getName()" because the return value of "Behavior.getCard()" is null
```

## 根因

1. 奸雄 resolve（`WaitingJianXiongResponseBehavior.resolveChoice`）先跑 polling resume，把下一家的無懈詢問（新 `WardBehavior`）push 到 stack 頂，之後才標記自己 `isOneRound=true`。
2. `Game.removeCompletedBehaviors()` 只從頂端往下清 — 頂端是未完成的新 WardBehavior，**已完成的奸雄 behavior（card=null by design）被埋在 stack 中間清不掉**：`[南蠻, 奸雄(完成,card=null), Ward]`。
3. 玩家 ACTIVE 出無懈 → `WardBehavior.doBehaviorAction()` 組「XX 的無懈可擊抵銷了 YY 的 ZZ」訊息時從頂端走訪、取第一個非 Ward behavior 的 `getCard().getName()` → 撞到殘留奸雄 → NPE。
4. 先前測試只蓋到奸雄後無懈 **SKIP**（skip 不組抵銷訊息，不會走到 `getCard()`），所以沒抓到。

## 修法

- `WardBehavior` 訊息迴圈：遇到已完成（`isOneRound()`）的非 Ward 殘留 → 跳過續往下找真正效果來源（南蠻）
- `getCard()` / `getBehaviorPlayer()` 補 null 兜底（cardId 反查 `PlayCard.findById` fallback，同時涵蓋 VirtualKill 經 MongoDB reload 後 findById 為 null 的潛在路徑）

## 測試

- domain：`BarbarianInvasionPollingOrderTest` +2（奸雄 ACCEPT / SKIP 後 ACTIVE 出無懈；修復前精確重現同一 NPE），並斷言抵銷訊息指向南蠻、輪詢正確推進到 d、HP 正確
- spring e2e：`BarbarianJianXiongWardTest` +1（完整 HTTP + MongoDB reload 路徑，修復前此步 500）
- domain 506 / spring 245 全綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)