### PR TITLE
feat: 護駕改為主動觸發 — 先詢問曹操是否發動 (closes #217)

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -572,7 +572,17 @@ POST /api/games/{gameId}/player:useHuJiaEffect
 | choice | String | `ACCEPT`（代替主公出閃）或 `DECLINE`（拒絕） |
 | cardId | String? | `ACCEPT` 必填，為要打出的閃 cardId；`DECLINE` 時可為 null |
 
-**觸發時機**：曹操（`WEI001`）為主公（`MONARCH`）且 stack 頂為 emit `AskDodgeEvent` 的 behavior 時，系統不發 `AskDodgeEvent`，改為依座位順序（曹操下家起）對每位存活魏勢力武將 broadcast `AskHuJiaEffectEvent`。任一人 ACCEPT → 視為曹操打出此閃；全部 DECLINE → fallback emit 原本的 `AskDodgeEvent(曹操)`。
+**觸發時機**（issue #217 起為主動觸發）：曹操（`WEI001`）為主公（`MONARCH`）且 stack 頂為 emit `AskDodgeEvent` 的 behavior 時，系統不發 `AskDodgeEvent`，改為**先對曹操本人** broadcast `AskSkillEffectEvent`（`skillName="護駕"`）詢問是否發動：
+
+- 曹操 **ACCEPT** → 依座位順序（曹操下家起）對每位存活魏勢力武將 broadcast `AskHuJiaEffectEvent`。任一人 ACCEPT → 視為曹操打出此閃；全部 DECLINE → fallback emit 原本的 `AskDodgeEvent(曹操)`
+- 曹操 **SKIP** → 直接 emit `AskDodgeEvent(曹操)` 自己出閃，不詢問魏將
+
+曹操回應「是否發動」走通用 endpoint（見 §23 useSkillEffect）：
+
+```
+POST /api/games/{gameId}/player:useSkillEffect
+{ "playerId": "<曹操>", "skillName": "護駕", "choice": "ACCEPT" | "SKIP" }
+```
 
 **啟動條件**（同時成立）：
 1. 受詢問玩家武將為曹操（WEI001）
@@ -586,7 +596,10 @@ POST /api/games/{gameId}/player:useHuJiaEffect
 **流程**：
 ```
 A 對曹操 (B) 出殺（或萬箭齊發/方天畫戟瞄到曹操）
-  → 系統 push WaitingHuJiaResponseBehavior 並 broadcast AskHuJiaEffectEvent(座位次序下一位 Wei)
+  → 系統 broadcast AskSkillEffectEvent(skillName=護駕, playerId=曹操)、activePlayer = 曹操
+  → 曹操呼叫 player:useSkillEffect：
+    - SKIP:   AskDodgeEvent(曹操) 自己出閃（不詢問魏將）
+    - ACCEPT: 系統 push WaitingHuJiaResponseBehavior 並 broadcast AskHuJiaEffectEvent(座位次序下一位 Wei)
   → activePlayer 切到該 Wei 武將
   → Wei 武將呼叫本 API：
     - ACCEPT: Wei 棄一張閃到墓地 → HuJiaEffectEvent(accepted=true)
@@ -662,6 +675,7 @@ POST /api/games/{gameId}/player:useSkillEffect
 | 激將（劉備主公技） | 主公劉備被南蠻/決鬥要求出殺時，依座位順序詢問蜀將 | `ACCEPT` / `DECLINE` | ACCEPT 必填 [殺 id]（蜀將手中） | — |
 | 流離（大喬） | 大喬成為殺目標、被問閃之前 | `ACCEPT` / `SKIP` | ACCEPT 必填 [要棄的手牌 id] | ACCEPT 必填：轉移目標（距離 1 內、非攻擊者） |
 | 鬼才（司馬懿） | 任意角色閃電判定牌抽出後、生效前（dataCardIds = [原判定牌]） | `ACCEPT` / `SKIP` | ACCEPT 必填 [替換用手牌 id] | — |
+| 護駕（曹操主公技）發動詢問 | 主公曹操被要求出閃、且有其他存活魏將時（issue #217） | `ACCEPT`（開始魏將輪詢，見 §21）/ `SKIP`（自己出閃） | — | — |
 
 ### 自動觸發技（無需呼叫本 API，僅廣播 `SkillEffectEvent`）
 

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/HuJiaSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/HuJiaSkill.java
@@ -3,13 +3,18 @@ package com.gaas.threeKingdoms.skill.wei;
 import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.behavior.Behavior;
 import com.gaas.threeKingdoms.behavior.behavior.WaitingHuJiaResponseBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.WaitingSkillEffectBehavior;
+import com.gaas.threeKingdoms.events.AskDodgeEvent;
 import com.gaas.threeKingdoms.events.AskHuJiaEffectEvent;
+import com.gaas.threeKingdoms.events.AskSkillEffectEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.SkillEffectEvent;
 import com.gaas.threeKingdoms.generalcard.Faction;
 import com.gaas.threeKingdoms.generalcard.General;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.rolecard.Role;
 import com.gaas.threeKingdoms.skill.trigger.BeforeAskDodgeSkill;
+import com.gaas.threeKingdoms.skill.trigger.ChoiceResolvableSkill;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,11 +30,13 @@ import java.util.Optional;
  *   - 曹操必須是 MONARCH（非主公的曹操不觸發）
  *   - 必須有其他存活的 Wei 武將
  *
- * 觸發後：push {@link WaitingHuJiaResponseBehavior} 並 emit {@link AskHuJiaEffectEvent} 給第一位 Wei；
- * caller 跳過原本的 AskDodgeEvent。所有 Wei 拒絕 → WaitingHuJia 在收最後一個 DECLINE 時自動 fallback
- * emit AskDodgeEvent(曹操)。
+ * 主動觸發（issue #217）：護駕非鎖定技，通過守門後先對曹操 emit {@link AskSkillEffectEvent}
+ * 詢問是否發動（回應走通用 `player:useSkillEffect`）：
+ *   - ACCEPT → push {@link WaitingHuJiaResponseBehavior} 並 emit {@link AskHuJiaEffectEvent} 給第一位 Wei；
+ *     所有 Wei 拒絕 → WaitingHuJia 在收最後一個 DECLINE 時自動 fallback emit AskDodgeEvent(曹操)
+ *   - SKIP → 直接 emit 原本的 AskDodgeEvent(曹操) 自己出閃
  */
-public class HuJiaSkill implements BeforeAskDodgeSkill {
+public class HuJiaSkill implements BeforeAskDodgeSkill, ChoiceResolvableSkill {
 
     public static final String GENERAL_ID = General.曹操.getGeneralId();
     public static final String SKILL_NAME = "護駕";
@@ -55,16 +62,51 @@ public class HuJiaSkill implements BeforeAskDodgeSkill {
             return Optional.empty();
         }
 
-        List<String> weiOrder = weiHelpers.stream().map(Player::getId).toList();
-        WaitingHuJiaResponseBehavior waiting = new WaitingHuJiaResponseBehavior(game, damaged, weiOrder);
+        WaitingSkillEffectBehavior waiting = new WaitingSkillEffectBehavior(game, damaged, SKILL_NAME);
         game.updateTopBehavior(waiting);
+        game.getCurrentRound().setActivePlayer(damaged);
 
-        Player firstWei = weiHelpers.get(0);
-        game.getCurrentRound().setActivePlayer(firstWei);
+        return Optional.of(List.of(new AskSkillEffectEvent(SKILL_NAME, damaged.getId(), List.of(), null)));
+    }
 
-        return Optional.of(List.of(new AskHuJiaEffectEvent(
-                firstWei.getId(), damaged.getId(),
-                WaitingHuJiaResponseBehavior.dodgeCardIdsInHand(firstWei))));
+    @Override
+    public List<DomainEvent> resolveChoice(Game game, WaitingSkillEffectBehavior waiting,
+                                           String choice, List<String> cardIds, String targetPlayerId) {
+        Player caoCao = waiting.getBehaviorPlayer();
+
+        if ("ACCEPT".equals(choice)) {
+            List<Player> weiHelpers = otherAliveWeiInSeatingOrder(game, caoCao);
+            if (!weiHelpers.isEmpty()) {
+                // pop 詢問層，維持 [host, WaitingHuJia] 的 stack 假設
+                // （WaitingHuJia ACCEPT 時 peek parent 必須是 HuJiaCompatibleAskDodgeBehavior）
+                game.removeTopBehavior();
+
+                List<String> weiOrder = weiHelpers.stream().map(Player::getId).toList();
+                WaitingHuJiaResponseBehavior waitingHuJia = new WaitingHuJiaResponseBehavior(game, caoCao, weiOrder);
+                game.updateTopBehavior(waitingHuJia);
+
+                Player firstWei = weiHelpers.get(0);
+                game.getCurrentRound().setActivePlayer(firstWei);
+
+                List<DomainEvent> events = new ArrayList<>();
+                events.add(new SkillEffectEvent(SKILL_NAME, caoCao.getId(), true, List.of(), null));
+                events.add(new AskHuJiaEffectEvent(
+                        firstWei.getId(), caoCao.getId(),
+                        WaitingHuJiaResponseBehavior.dodgeCardIdsInHand(firstWei)));
+                events.add(game.getGameStatusEvent(caoCao.getId() + " 發動護駕，詢問魏勢力代閃"));
+                return events;
+            }
+            // 守門通過後到回應之間魏將全滅的極端情況：視同 SKIP fallback
+        } else if (!"SKIP".equals(choice)) {
+            throw new IllegalArgumentException("Invalid HuJia choice: " + choice);
+        }
+
+        game.getCurrentRound().setActivePlayer(caoCao);
+        List<DomainEvent> events = new ArrayList<>();
+        events.add(new SkillEffectEvent(SKILL_NAME, caoCao.getId(), false, List.of(), null));
+        events.add(new AskDodgeEvent(caoCao.getId()));
+        events.add(game.getGameStatusEvent("放棄護駕，回到主公出閃"));
+        return events;
     }
 
     private List<Player> otherAliveWeiInSeatingOrder(Game game, Player caoCao) {

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HuJiaSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/HuJiaSkillTest.java
@@ -4,9 +4,11 @@ import com.gaas.threeKingdoms.behavior.behavior.ArrowBarrageBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.HeavenlyDoubleHalberdKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.WaitingHuJiaResponseBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.WaitingSkillEffectBehavior;
 import com.gaas.threeKingdoms.builders.PlayerBuilder;
 import com.gaas.threeKingdoms.events.AskDodgeEvent;
 import com.gaas.threeKingdoms.events.AskHuJiaEffectEvent;
+import com.gaas.threeKingdoms.events.AskSkillEffectEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
 import com.gaas.threeKingdoms.events.HuJiaEffectEvent;
 import com.gaas.threeKingdoms.gamephase.Normal;
@@ -108,15 +110,45 @@ public class HuJiaSkillTest {
     @DisplayName("""
             Given 曹操為主公，C 為 Wei（夏侯惇）、D 為非 Wei
             When  A 對曹操 (B) 出殺
-            Then  emit AskHuJiaEffectEvent 給 C；不 emit AskDodgeEvent；stack 頂為 WaitingHuJiaResponseBehavior；activePlayer = C
+            Then  先 emit AskSkillEffectEvent(護駕) 詢問曹操本人（issue #217：主動觸發）；
+                  不 emit AskHuJiaEffectEvent / AskDodgeEvent；stack 頂為 WaitingSkillEffectBehavior；activePlayer = 曹操
             """)
     @Test
-    public void givenMonarchCaoCaoAndOneWei_WhenKilled_ThenAskHuJiaToWei() {
+    public void givenMonarchCaoCaoAndOneWei_WhenKilled_ThenAskCaoCaoFirst() {
         Game game = setupMonarchCaoCaoWithOneWei();
         Player playerC = game.getPlayer("player-c");
         giveDodge(playerC, BH2028);
 
         List<DomainEvent> events = game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        AskSkillEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskSkillEffectEvent)
+                .map(e -> (AskSkillEffectEvent) e)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected AskSkillEffectEvent"));
+        assertEquals("護駕", ask.getSkillName());
+        assertEquals("player-b", ask.getPlayerId(), "先詢問曹操本人是否發動護駕");
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskHuJiaEffectEvent),
+                "曹操未 ACCEPT 前不可先詢問魏將");
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskDodgeEvent),
+                "AskDodgeEvent should be replaced by HuJia ask");
+        assertTrue(game.peekTopBehavior() instanceof WaitingSkillEffectBehavior);
+        assertEquals("player-b", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("""
+            Given 曹操為主公，C 為 Wei、有閃
+            When  曹操 ACCEPT 發動護駕
+            Then  emit AskHuJiaEffectEvent 給 C；stack 為 [殺, WaitingHuJia]；activePlayer = C
+            """)
+    @Test
+    public void givenCaoCaoAcceptHuJia_ThenAskWei() {
+        Game game = setupMonarchCaoCaoWithOneWei();
+        Player playerC = game.getPlayer("player-c");
+        giveDodge(playerC, BH2028);
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        List<DomainEvent> events = game.playerUseSkillEffect("player-b", "護駕", "ACCEPT", null, null);
 
         AskHuJiaEffectEvent ask = events.stream()
                 .filter(e -> e instanceof AskHuJiaEffectEvent)
@@ -126,10 +158,42 @@ public class HuJiaSkillTest {
         assertEquals("player-c", ask.getPlayerId());
         assertEquals("player-b", ask.getCaoCaoPlayerId());
         assertEquals(List.of(BH2028.getCardId()), ask.getDodgeCardIdsInHand());
-        assertFalse(events.stream().anyMatch(e -> e instanceof AskDodgeEvent),
-                "AskDodgeEvent should be replaced by HuJia ask");
         assertTrue(game.peekTopBehavior() instanceof WaitingHuJiaResponseBehavior);
+        assertTrue(game.peekTopBehaviorSecondElement()
+                        .map(b -> b instanceof NormalActiveKillBehavior).orElse(false),
+                "詢問層必須已 pop，維持 [host, WaitingHuJia] 假設");
         assertEquals("player-c", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("""
+            Given 曹操為主公，C 為 Wei、有閃
+            When  曹操 SKIP 放棄護駕
+            Then  emit AskDodgeEvent(曹操) 自己出閃；不詢問魏將；stack 頂回到殺；activePlayer = 曹操
+            """)
+    @Test
+    public void givenCaoCaoSkipHuJia_ThenAskCaoCaoDodgeDirectly() {
+        Game game = setupMonarchCaoCaoWithOneWei();
+        Player playerB = game.getPlayer("player-b");
+        giveDodge(playerB, BHK039);
+        giveDodge(game.getPlayer("player-c"), BH2028);
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        List<DomainEvent> events = game.playerUseSkillEffect("player-b", "護駕", "SKIP", null, null);
+
+        AskDodgeEvent ask = events.stream()
+                .filter(e -> e instanceof AskDodgeEvent)
+                .map(e -> (AskDodgeEvent) e)
+                .findFirst().orElseThrow(() -> new AssertionError("expected AskDodgeEvent"));
+        assertEquals("player-b", ask.getPlayerId());
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskHuJiaEffectEvent),
+                "SKIP 後不可再詢問魏將");
+        assertTrue(game.peekTopBehavior() instanceof NormalActiveKillBehavior);
+        assertEquals("player-b", game.getCurrentRound().getActivePlayer().getId());
+
+        // 曹操自己出閃 → 結算完成、不扣血
+        game.playerPlayCard("player-b", BHK039.getCardId(), "player-a", "active");
+        assertEquals(4, playerB.getHP());
+        assertTrue(game.isTopBehaviorEmpty());
     }
 
     @DisplayName("""
@@ -145,6 +209,7 @@ public class HuJiaSkillTest {
         giveDodge(playerC, BH2028);
 
         game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerUseSkillEffect("player-b", "護駕", "ACCEPT", null, null);
         List<DomainEvent> events = game.playerUseHuJiaEffect(
                 "player-c", AskHuJiaEffectEvent.Choice.ACCEPT, BH2028.getCardId());
 
@@ -169,6 +234,7 @@ public class HuJiaSkillTest {
     public void givenFirstWeiDecline_ThenAskNextWei() {
         Game game = setupMonarchCaoCaoWithTwoWei();
         game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerUseSkillEffect("player-b", "護駕", "ACCEPT", null, null);
 
         List<DomainEvent> events = game.playerUseHuJiaEffect(
                 "player-c", AskHuJiaEffectEvent.Choice.DECLINE, null);
@@ -191,6 +257,7 @@ public class HuJiaSkillTest {
     public void givenAllWeiDecline_ThenFallbackToAskCaoCaoDodge() {
         Game game = setupMonarchCaoCaoWithOneWei();
         game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerUseSkillEffect("player-b", "護駕", "ACCEPT", null, null);
 
         List<DomainEvent> events = game.playerUseHuJiaEffect(
                 "player-c", AskHuJiaEffectEvent.Choice.DECLINE, null);
@@ -217,6 +284,8 @@ public class HuJiaSkillTest {
 
         List<DomainEvent> events = game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
 
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskSkillEffectEvent),
+                "不應詢問曹操發動護駕");
         assertFalse(events.stream().anyMatch(e -> e instanceof AskHuJiaEffectEvent));
         assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent));
     }
@@ -232,6 +301,8 @@ public class HuJiaSkillTest {
 
         List<DomainEvent> events = game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
 
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskSkillEffectEvent),
+                "不應詢問曹操發動護駕");
         assertFalse(events.stream().anyMatch(e -> e instanceof AskHuJiaEffectEvent));
         assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent));
     }
@@ -247,6 +318,8 @@ public class HuJiaSkillTest {
 
         List<DomainEvent> events = game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
 
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskSkillEffectEvent),
+                "不應詢問曹操發動護駕");
         assertFalse(events.stream().anyMatch(e -> e instanceof AskHuJiaEffectEvent));
         assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent));
     }
@@ -259,6 +332,7 @@ public class HuJiaSkillTest {
     public void givenAcceptWithCardNotInHand_Throws() {
         Game game = setupMonarchCaoCaoWithOneWei();
         game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerUseSkillEffect("player-b", "護駕", "ACCEPT", null, null);
 
         assertThrows(IllegalArgumentException.class, () ->
                 game.playerUseHuJiaEffect("player-c", AskHuJiaEffectEvent.Choice.ACCEPT, BH2028.getCardId()));
@@ -273,6 +347,7 @@ public class HuJiaSkillTest {
         Game game = setupMonarchCaoCaoWithOneWei();
         game.getPlayer("player-c").getHand().addCardToHand(new Kill(BS9009));
         game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerUseSkillEffect("player-b", "護駕", "ACCEPT", null, null);
 
         assertThrows(IllegalArgumentException.class, () ->
                 game.playerUseHuJiaEffect("player-c", AskHuJiaEffectEvent.Choice.ACCEPT, BS9009.getCardId()));
@@ -280,8 +355,8 @@ public class HuJiaSkillTest {
 
     @DisplayName("""
             Given 萬箭齊發瞄到曹操主公 + 其他 Wei 存活
-            When  輪詢到曹操這 reactor
-            Then  emit AskHuJiaEffectEvent（不 emit AskDodge），stack 頂為 WaitingHuJia 在 ArrowBarrage 上
+            When  輪詢到曹操這 reactor、曹操 ACCEPT 護駕
+            Then  詢問時 stack 頂為 WaitingSkillEffect；ACCEPT 後為 WaitingHuJia 在 ArrowBarrage 上
             """)
     @Test
     public void givenArrowBarrageWithMonarchCaoCao_HuJiaFiresOnCaoCaoTurn() {
@@ -289,10 +364,12 @@ public class HuJiaSkillTest {
         Player playerA = game.getPlayer("player-a");
         playerA.getHand().addCardToHand(new ArrowBarrage(SS7007));
 
-        // A 出萬箭，假設 B 第一個被詢問（座位順序）
+        // A 出萬箭，假設 B 第一個被詢問（座位順序）→ 先問曹操是否發動護駕
         game.playerPlayCard("player-a", SS7007.getCardId(), "player-b", "active");
+        assertTrue(game.peekTopBehavior() instanceof WaitingSkillEffectBehavior,
+                "issue #217：先詢問曹操本人");
 
-        // ArrowBarrage 應已 push；驗證 stack 頂是 WaitingHuJia，next-second 是 ArrowBarrage
+        game.playerUseSkillEffect("player-b", "護駕", "ACCEPT", null, null);
         assertTrue(game.peekTopBehavior() instanceof WaitingHuJiaResponseBehavior,
                 "WaitingHuJia should be top while polling Cao Cao");
         assertTrue(game.peekTopBehaviorSecondElement()
@@ -315,7 +392,10 @@ public class HuJiaSkillTest {
 
         game.playerUseHeavenlyDoubleHalberdKill(
                 "player-a", BS8008.getCardId(), List.of("player-b", "player-c"));
+        assertTrue(game.peekTopBehavior() instanceof WaitingSkillEffectBehavior,
+                "issue #217：先詢問曹操本人");
 
+        game.playerUseSkillEffect("player-b", "護駕", "ACCEPT", null, null);
         assertTrue(game.peekTopBehavior() instanceof WaitingHuJiaResponseBehavior);
         assertTrue(game.peekTopBehaviorSecondElement()
                 .map(b -> b instanceof HeavenlyDoubleHalberdKillBehavior).orElse(false),
@@ -339,6 +419,7 @@ public class HuJiaSkillTest {
         giveDodge(playerC, BH2028);
 
         game.playerPlayCard("player-a", SS7007.getCardId(), "player-b", "active");
+        game.playerUseSkillEffect("player-b", "護駕", "ACCEPT", null, null);
         // ACCEPT 代替曹操出閃
         List<DomainEvent> events = game.playerUseHuJiaEffect(
                 "player-c", AskHuJiaEffectEvent.Choice.ACCEPT, BH2028.getCardId());
@@ -377,6 +458,7 @@ public class HuJiaSkillTest {
 
         game.playerUseHeavenlyDoubleHalberdKill(
                 "player-a", BS8008.getCardId(), List.of("player-b", "player-c"));
+        game.playerUseSkillEffect("player-b", "護駕", "ACCEPT", null, null);
 
         List<DomainEvent> events = game.playerUseHuJiaEffect(
                 "player-c", AskHuJiaEffectEvent.Choice.ACCEPT, BH2028.getCardId());

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/HuJiaTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/HuJiaTest.java
@@ -12,6 +12,7 @@ import com.gaas.threeKingdoms.player.HealthStatus;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.rolecard.Role;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 
 import java.util.Arrays;
 import java.util.List;
@@ -19,6 +20,9 @@ import java.util.List;
 import static com.gaas.threeKingdoms.e2e.MockUtil.createPlayer;
 import static com.gaas.threeKingdoms.e2e.MockUtil.initGame;
 import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class HuJiaTest extends AbstractBaseIntegrationTest {
@@ -47,9 +51,13 @@ public class HuJiaTest extends AbstractBaseIntegrationTest {
         game.setDeck(deck);
         repository.save(game);
 
-        // When A 出殺打 B → 觸發護駕，活躍轉到 D（唯一其他 Wei）
+        // When A 出殺打 B → 先詢問曹操是否發動護駕（issue #217：主動觸發）
         mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
                 .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+
+        // 曹操 ACCEPT 發動護駕 → 活躍轉到 D（唯一其他 Wei）
+        useHuJiaSkillEffect("player-b", "ACCEPT");
         websocketUtil.popAllPlayerMessage();
 
         // D ACCEPT 出閃代替曹操
@@ -79,9 +87,11 @@ public class HuJiaTest extends AbstractBaseIntegrationTest {
         game.setDeck(deck);
         repository.save(game);
 
-        // When A 出殺打 B → 護駕 ask D
+        // When A 出殺打 B → 先詢問曹操，ACCEPT 後護駕 ask D
         mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
                 .andExpect(status().isOk()).andReturn();
+        websocketUtil.popAllPlayerMessage();
+        useHuJiaSkillEffect("player-b", "ACCEPT");
         websocketUtil.popAllPlayerMessage();
 
         // D DECLINE → 應 fallback emit AskDodge(B)
@@ -95,5 +105,53 @@ public class HuJiaTest extends AbstractBaseIntegrationTest {
 
         // Then 曹操 HP=3
         assertAllPlayerJson("src/test/resources/TestJsonFile/SkillTest/HuJia/hujia_decline_then_skip_for_%s.json");
+    }
+
+    /**
+     * issue #217：曹操 SKIP 放棄護駕 → 不詢問魏將，直接回到曹操自己出閃
+     */
+    @Test
+    public void testCaoCaoSkipsHuJia_ThenDodgesHimself() throws Exception {
+        Player playerA = createPlayer("player-a", 4, General.甘寧, HealthStatus.ALIVE, Role.REBEL,
+                new Kill(BS8008));
+        Player playerB = createPlayer("player-b", 4, General.曹操, HealthStatus.ALIVE, Role.MONARCH,
+                new Dodge(BHK039));
+        Player playerC = createPlayer("player-c", 4, General.趙雲, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerD = createPlayer("player-d", 4, General.夏侯惇, HealthStatus.ALIVE, Role.MINISTER,
+                new Dodge(BH2028));
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Peach(BH3029)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+
+        // 曹操放棄護駕 → activePlayer 回到曹操，自己被問閃
+        useHuJiaSkillEffect("player-b", "SKIP");
+        Game saved = repository.findById(gameId).orElseThrow();
+        assertEquals("player-b", saved.getCurrentRound().getActivePlayer().getId());
+
+        // 曹操自己出閃 → 不扣血、D 的閃保留、流程結束
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", BHK039.getCardId(), PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+
+        saved = repository.findById(gameId).orElseThrow();
+        assertEquals(4, saved.getPlayer("player-b").getHP(), "曹操自己出閃不扣血");
+        assertTrue(saved.getPlayer("player-d").getHand().getCards().stream()
+                .anyMatch(c -> c.getId().equals(BH2028.getCardId())), "SKIP 後不可動用魏將的閃");
+        assertTrue(saved.getTopBehavior().isEmpty());
+    }
+
+    private void useHuJiaSkillEffect(String playerId, String choice) throws Exception {
+        mockMvc.perform(post("/api/games/" + gameId + "/player:useSkillEffect")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "playerId": "%s",
+                                  "skillName": "護駕",
+                                  "choice": "%s"
+                                }""".formatted(playerId, choice)))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## 變更

護駕為主公技但**非鎖定技**（issue #217）：原實作在曹操被要求出閃時**自動**開始魏將輪詢，曹操本人未被詢問、也無法選擇自己出閃。本 PR 改為先問曹操。

### 新流程

1. 曹操（主公）被要求出閃、有其他存活魏將 → broadcast `AskSkillEffectEvent`（`skillName="護駕"`）給曹操
2. 曹操回 `POST /player:useSkillEffect`（複用通用 endpoint，**不新增 API**）：
   - `ACCEPT` → 進入現行魏將輪詢（`AskHuJiaEffectEvent` 起，後續完全不變）
   - `SKIP` → 直接 `AskDodgeEvent(曹操)` 自己出閃

### 實作

- `HuJiaSkill` 加實作 `ChoiceResolvableSkill`；`beforeAskDodge` 改 push `WaitingSkillEffectBehavior`（既有持久化管線自動支援）
- ACCEPT 時先 pop 詢問層再 push `WaitingHuJiaResponseBehavior`，維持該 behavior 文件註明的 `[host, WaitingHuJia]` stack 假設
- 守門條件（主公 + 有存活魏將）不變；不成立時行為與原本相同（直接 AskDodge）

## 測試

- domain `HuJiaSkillTest` 15/15：詢問層 event/stack/activePlayer 斷言、ACCEPT 後輪詢、SKIP 後自閃結算、萬箭/方天畫戟觸發路徑、非主公/無魏將/魏將已死不觸發
- spring e2e `HuJiaTest` 3/3：ACCEPT 代閃、全 DECLINE fallback（fixtures 重產）、新增曹操 SKIP 自閃（HTTP + MongoDB reload 路徑）
- domain 508 / spring 246 全綠

## API_DOC

§21 觸發時機改寫 + 流程圖補曹操詢問步驟；§23 payload 表加護駕列。

closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)