### PR TITLE
fix: 棄牌結束回合後的無懈可擊詢問未個人化（樂不思蜀判定）

### DIFF
--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/DiscardPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/DiscardPresenter.java
@@ -48,6 +48,11 @@ public class DiscardPresenter implements DiscardCardUseCase.DiscardPresenter<Lis
                 return personalViewModel;
             }).collect(Collectors.toList());
 
+            // 使用者回報 bug：棄牌結束回合 → 下一家回合開始判定（樂不思蜀/閃電）可能觸發無懈可擊詢問，
+            // 持有者必須收 AskPlayWardEvent 而非 WaitForWardEvent
+            personalEventToViewModels = PlayCardPresenter.personalizeWardViewModels(
+                    personalEventToViewModels, events, viewModel.getId());
+
             viewModels.add(new GameViewModel(personalEventToViewModels,
                     gameDataViewModel,
                     gameStatusEvent.getMessage(),

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseEquipmentEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseEquipmentEffectPresenter.java
@@ -39,8 +39,9 @@ public class UseEquipmentEffectPresenter implements UseEquipmentUseCase.UseEquip
                     PlayerDataViewModel.hiddenOtherPlayerRoleInformation(
                             playerDataViewModels, viewModel.getId()), roundDataViewModel, gameStatusEvent.getGamePhase());
 
+            // 同 #214 類問題：裝備效果結算（如八卦陣）後續流程可能觸發無懈可擊詢問 — 持有者需個人化
             viewModels.add(new GameViewModel(
-                    eventToViewModels,
+                    PlayCardPresenter.personalizeWardViewModels(eventToViewModels, events, viewModel.getId()),
                     gameDataViewModel,
                     gameStatusEvent.getMessage(),
                     gameStatusEvent.getGameId(),

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseHuJiaEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseHuJiaEffectPresenter.java
@@ -36,8 +36,9 @@ public class UseHuJiaEffectPresenter implements UseHuJiaEffectUseCase.UseHuJiaEf
                     PlayerDataViewModel.hiddenOtherPlayerRoleInformation(
                             playerDataViewModels, viewModel.getId()), roundDataViewModel, gameStatusEvent.getGamePhase());
 
+            // 同 #214 類問題：護駕 resolve 後 AoE 輪詢推進可能觸發無懈可擊詢問 — 持有者需個人化
             viewModels.add(new GameViewModel(
-                    new ArrayList<>(effectViewModels),
+                    PlayCardPresenter.personalizeWardViewModels(effectViewModels, events, viewModel.getId()),
                     gameDataViewModel,
                     gameStatusEvent.getMessage(),
                     gameStatusEvent.getGameId(),

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/scrollcard/ward/WardWithContentmentTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/scrollcard/ward/WardWithContentmentTest.java
@@ -237,6 +237,99 @@ public class WardWithContentmentTest extends AbstractBaseIntegrationTest {
         }
     }
 
+    @Test
+    public void givenPlayerCHasContentmentAndBHasWard_WhenBEndsTurnByDiscard_ThenBReceivesAskPlayWardEvent() throws Exception {
+//        使用者回報 bug：
+//        C 判定區有樂不思蜀，B 手牌有無懈可擊
+//        B 以「棄牌」結束回合（而非 finishAction 直接結束）→ C 回合開始判定前的無懈詢問
+//        走 DiscardPresenter — 修復前 B 只收到 WaitForWardEvent（未個人化成 AskPlayWardEvent）
+        givenPlayerCHasContentmentAndBHasWard();
+
+        // A 結束回合 → B 回合開始摸 2（手牌 6 > HP 4）
+        mockMvcUtil.finishAction(gameId, "player-a")
+                .andExpect(status().isOk()).andReturn();
+        popAllPlayerMessage();
+
+        // B 結束出牌 → 進入棄牌階段
+        mockMvcUtil.finishAction(gameId, "player-b")
+                .andExpect(status().isOk()).andReturn();
+        popAllPlayerMessage();
+
+        // B 棄 2 張（保留無懈可擊）→ B 回合結束 → C 回合開始 → 樂不思蜀判定前的無懈詢問
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .post("/api/games/" + gameId + "/player:discardCards")
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content("""
+                                ["BD2093", "BD3094"]
+                                """))
+                .andExpect(status().isOk());
+
+        String messageA = websocketUtil.getValue("player-a");
+        String messageB = websocketUtil.getValue("player-b");
+        String messageC = websocketUtil.getValue("player-c");
+        String messageD = websocketUtil.getValue("player-d");
+
+        org.junit.jupiter.api.Assertions.assertTrue(messageB.contains("AskPlayWardEvent"),
+                "持有無懈可擊的 B 應收到 AskPlayWardEvent（棄牌路徑）");
+        for (String message : List.of(messageA, messageC, messageD)) {
+            org.junit.jupiter.api.Assertions.assertFalse(message.contains("AskPlayWardEvent"),
+                    "沒有無懈可擊的玩家不應被詢問");
+            org.junit.jupiter.api.Assertions.assertTrue(message.contains("WaitForWardEvent"),
+                    "其他玩家應收到等待無懈可擊 event");
+        }
+    }
+
+    private void givenPlayerCHasContentmentAndBHasWard() {
+        Player playerA = createPlayer(
+                "player-a",
+                4,
+                General.劉備,
+                HealthStatus.ALIVE,
+                Role.MONARCH,
+                new Kill(BS8008), new Peach(BH3029), new Dodge(BH2028), new Kill(BS8008)
+        );
+        Player playerB = createPlayer(
+                "player-b",
+                4,
+                General.劉備,
+                HealthStatus.ALIVE,
+                Role.MINISTER,
+                new Kill(BS8008), new Peach(BH3029), new Peach(BH4030), new Ward(SSJ011)
+        );
+        Player playerC = createPlayer(
+                "player-c",
+                4,
+                General.劉備,
+                HealthStatus.ALIVE,
+                Role.REBEL,
+                new Kill(BS8008), new Peach(BH3029), new Dodge(BH2028), new Dodge(BHK039)
+        );
+        playerC.addDelayScrollCard(new Contentment(SC6071));
+
+        Player playerD = createPlayer(
+                "player-d",
+                4,
+                General.劉備,
+                HealthStatus.ALIVE,
+                Role.TRAITOR,
+                new Kill(BS8008), new Peach(BH3029), new Dodge(BH2028), new Dodge(BHK039)
+        );
+
+        List<Player> players = Arrays.asList(playerA, playerB, playerC, playerD);
+        Game game = new Game(gameId, players);
+        game.setCurrentRound(new Round(playerA));
+        game.enterPhase(new Normal(game));
+        Deck deck = new Deck();
+        // LIFO：最後 add 的先被抽 — B 回合開始摸 BD2093、BD3094（之後棄掉這兩張）
+        deck.add(List.of(
+                new Peach(BH3029), new Peach(BH3029), new Peach(BH3029),
+                new Peach(BH3029), new Peach(BH3029),
+                new Dodge(BD3094), new Dodge(BD2093)
+        ));
+        game.setDeck(deck);
+        repository.save(game);
+    }
+
     private void givenPlayerBHasContentmentAndBHasWard() {
         Player playerA = createPlayer(
                 "player-a",


### PR DESCRIPTION
## 問題（使用者回報）

A 對 C 下樂不思蜀、B 持無懈可擊。第一輪 C 回合開始時 B 正常被詢問；**第二輪**同場景，系統改對所有玩家發 `WaitForWardEvent`，B 沒收到 `AskPlayWardEvent`。

## 根因

與 #214 同型：presenter 層缺 per-player 個人化（WaitForWard → AskPlayWard），domain event 一直是對的。

第一輪 vs 第二輪的差異在**前一家（B）結束回合的路徑**：
- 第一輪：B 手牌 ≤ HP，走 `player:finishAction` → `FinishActionPresenter` **有**個人化 → 正常
- 第二輪：B 手牌超上限，走 `player:discardCards` 結束回合 → `DiscardPresenter` **沒有**個人化 → 下一家回合開始判定觸發的無懈詢問全員都是 WaitForWardEvent

## 修法

全面盤點後，補 `PlayCardPresenter.personalizeWardViewModels`（#215 抽出的共用 helper）於僅剩三個未接的 generic presenter：

| Presenter | 觸發場景 |
|---|---|
| `DiscardPresenter` | 棄牌結束回合 → 下家判定（樂不思蜀/閃電）前的無懈詢問（本次回報） |
| `UseEquipmentEffectPresenter` | 八卦陣等裝備效果結算後續流程的無懈詢問 |
| `UseHuJiaEffectPresenter` | 護駕 resolve 後 AoE 輪詢推進的無懈詢問 |

其餘未接的 presenter（CreateGame / ChooseHorse / RoundStart 等）為固定結構或 setup 流程，不會渲染 WaitForWardEvent。

## 測試

- `WardWithContentmentTest` 新增棄牌路徑 e2e：A finishAction → B 摸 2 超上限 → B finishAction → B discardCards → C 回合開始判定 → 斷言 B 收 `AskPlayWardEvent`、其他人收 `WaitForWardEvent`
- **已驗證修復前此測試失敗**（B 收不到 AskPlayWardEvent，與回報症狀一致）
- spring 247 全綠（domain 無變更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)