### PR TITLE
feat: 鬼才覆蓋全部判定路徑（樂不思蜀/八卦陣/鐵騎/剛烈/洛神）

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -674,7 +674,7 @@ POST /api/games/{gameId}/player:useSkillEffect
 | 剛烈 第二段（問傷害來源） | 判定非紅桃後 | `DISCARD` / `DAMAGE` | DISCARD 必填 2 張手牌 | — |
 | 激將（劉備主公技） | 主公劉備被南蠻/決鬥要求出殺時，依座位順序詢問蜀將 | `ACCEPT` / `DECLINE` | ACCEPT 必填 [殺 id]（蜀將手中） | — |
 | 流離（大喬） | 大喬成為殺目標、被問閃之前 | `ACCEPT` / `SKIP` | ACCEPT 必填 [要棄的手牌 id] | ACCEPT 必填：轉移目標（距離 1 內、非攻擊者） |
-| 鬼才（司馬懿） | 任意角色閃電判定牌抽出後、生效前（dataCardIds = [原判定牌]） | `ACCEPT` / `SKIP` | ACCEPT 必填 [替換用手牌 id] | — |
+| 鬼才（司馬懿） | 任意角色判定牌抽出後、生效前（閃電 / 樂不思蜀 / 八卦陣 / 鐵騎 / 剛烈 / 洛神；dataCardIds = [原判定牌]、dataPlayerId = 判定所屬玩家） | `ACCEPT` / `SKIP` | ACCEPT 必填 [替換用手牌 id] | — |
 | 護駕（曹操主公技）發動詢問 | 主公曹操被要求出閃、且有其他存活魏將時（issue #217） | `ACCEPT`（開始魏將輪詢，見 §21）/ `SKIP`（自己出閃） | — | — |
 
 ### 自動觸發技（無需呼叫本 API，僅廣播 `SkillEffectEvent`）
@@ -724,7 +724,8 @@ POST /api/games/{gameId}/player:useSkillEffect
 - 激將 v1 覆蓋南蠻入侵/決鬥的 AskKill；主動出殺與借刀殺人代出為 follow-up
 - 流離 v1 只攔普通殺（方天畫戟/AOE 轉移 follow-up）；棄牌限手牌
 - 救援採官方標準版語意（桃效果 +1）；issue 原文描述的「可出桃給其」即既有瀕死求桃流程
-- 鬼才 v1 覆蓋閃電判定（含 Ward 路徑）；樂不思蜀/八卦陣/洛神/鐵騎/剛烈判定替換 follow-up
+- 鬼才覆蓋全部判定路徑：閃電 / 樂不思蜀（皆含 Ward 路徑）/ 八卦陣 / 鐵騎 / 剛烈 / 洛神；
+  洛神多張判定牌逐張詢問；同一次判定僅詢問一次（官方 FAQ）
 - 武聖/奇襲 v1 限手牌（裝備區紅/黑牌轉化 follow-up）；轉化殺的奸雄取牌為 follow-up
 - 轉化殺的傷害結算以 VirtualKill 進行；事件中 cardId 為來源真實牌
 

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -173,6 +173,10 @@ public class Game {
         if (RoundPhase.Judgement.equals(currentRound.getRoundPhase())) {
             // 洛神：回合開始（延遲錦囊判定之前）黑色判定牌全收
             events.addAll(SkillEngine.luoShenJudgementLoop(this, currentRoundPlayer));
+            if (!topBehavior.isEmpty()
+                    && topBehavior.peek() instanceof WaitingSkillEffectBehavior) { // 鬼才介入洛神判定 → 暫停
+                return events;
+            }
             List<DomainEvent> judgeEvents = judgePlayerShouldDelay();
             events.addAll(judgeEvents);
             boolean contentmentEventSuccess = judgeEvents.stream()
@@ -528,11 +532,8 @@ public class Game {
                         topBehavior.push(cjb);
                         judgementEvents.addAll(cjb.playerAction());
                     } else {
-                        ContentmentEvent contentmentEvent = handleContentmentJudgement(player);
-                        judgementEvents.add(contentmentEvent);
-                        // 天妒等：判定牌生效後技能
-                        judgementEvents.addAll(SkillEngine.afterJudgement(this, player,
-                                PlayCard.findById(contentmentEvent.getDrawCardId())));
+                        // 判定（含鬼才暫停點與天妒等判定後技能）
+                        judgementEvents.addAll(handleContentmentJudgement(player));
                     }
                 } else if (card instanceof Lightning) {
                     if (doesAnyPlayerHaveWard(null)) {
@@ -564,26 +565,13 @@ public class Game {
         List<HandCard> cards = drawCardForCardEffect(1);
         HandCard drawnCard = cards.get(0);
 
-        // 鬼才：判定牌生效前，場上存活且有手牌的司馬懿可打手牌替換（v1 只覆蓋閃電判定）
-        Player guiCaiHolder = players.stream()
-                .filter(p -> !p.isAlreadyDeath()
-                        && com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.GENERAL_ID
-                                .equals(p.getGeneralCard().getGeneralId())
-                        && p.getHandSize() > 0)
-                .findFirst().orElse(null);
-        if (guiCaiHolder != null) {
-            com.gaas.threeKingdoms.behavior.behavior.WaitingSkillEffectBehavior waiting =
-                    new com.gaas.threeKingdoms.behavior.behavior.WaitingSkillEffectBehavior(
-                            this, guiCaiHolder, com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.SKILL_NAME);
-            waiting.putParam(com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.PARAM_LIGHTNING_CARD_ID, card.getId());
-            waiting.putParam(com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.PARAM_OWNER_ID, player.getId());
-            waiting.putParam(com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.PARAM_DRAWN_CARD_ID, drawnCard.getId());
-            updateTopBehavior(waiting);
-            currentRound.setActivePlayer(guiCaiHolder);
-            return List.of(new com.gaas.threeKingdoms.events.AskSkillEffectEvent(
-                            com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.SKILL_NAME,
-                            guiCaiHolder.getId(), List.of(drawnCard.getId()), player.getId()),
-                    getGameStatusEvent("鬼才：" + guiCaiHolder.getId() + " 可替換 " + player.getId() + " 的閃電判定牌"));
+        // 鬼才：判定牌生效前，場上存活且有手牌的司馬懿可打手牌替換
+        Optional<List<DomainEvent>> paused = com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.tryPause(
+                this, player, drawnCard,
+                com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.TYPE_LIGHTNING, "閃電",
+                Map.of(com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.PARAM_LIGHTNING_CARD_ID, card.getId()));
+        if (paused.isPresent()) {
+            return paused.get();
         }
         return resolveLightningJudgement(card, player, drawnCard);
     }
@@ -634,16 +622,31 @@ public class Game {
         return domainEvents;
     }
 
-    public ContentmentEvent handleContentmentJudgement(Player player) {
+    public List<DomainEvent> handleContentmentJudgement(Player player) {
         // 抽一張卡判定
         List<HandCard> cards = drawCardForCardEffect(1);
         HandCard drawnCard = cards.get(0);
 
-        // 判定牌的花色
+        // 鬼才：判定牌生效前，場上存活且有手牌的司馬懿可打手牌替換
+        Optional<List<DomainEvent>> paused = com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.tryPause(
+                this, player, drawnCard,
+                com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.TYPE_CONTENTMENT, "樂不思蜀", Map.of());
+        if (paused.isPresent()) {
+            return paused.get();
+        }
+        return resolveContentmentJudgement(player, drawnCard);
+    }
+
+    /** 以指定判定牌結算樂不思蜀（鬼才替換後 / 無鬼才直接）；含天妒等判定後技能。 */
+    public List<DomainEvent> resolveContentmentJudgement(Player player, HandCard drawnCard) {
+        // 判定牌的花色（非紅桃 = 生效 → 跳過出牌階段）
         boolean contentmentSuccess = Suit.HEART != drawnCard.getSuit();
 
-        // 回傳 Contentment 事件
-        return new ContentmentEvent(contentmentSuccess, player.getId(), drawnCard.getId(), drawnCard.getSuit());
+        List<DomainEvent> events = new ArrayList<>();
+        events.add(new ContentmentEvent(contentmentSuccess, player.getId(), drawnCard.getId(), drawnCard.getSuit()));
+        // 天妒等：判定牌生效後技能
+        events.addAll(SkillEngine.afterJudgement(this, player, drawnCard));
+        return events;
     }
 
     public int getCurrentRoundPlayerDiscardCount() {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ContentmentJudgementBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ContentmentJudgementBehavior.java
@@ -47,9 +47,18 @@ public class ContentmentJudgementBehavior extends Behavior {
     @Override
     public List<DomainEvent> doBehaviorAction() {
         // Ward count is EVEN -> effect proceeds -> execute judgement
-        List<DomainEvent> events = new ArrayList<>();
-        ContentmentEvent contentmentEvent = game.handleContentmentJudgement(behaviorPlayer);
-        events.add(contentmentEvent);
+        List<DomainEvent> events = new ArrayList<>(game.handleContentmentJudgement(behaviorPlayer));
+
+        // 鬼才介入：判定暫停等司馬懿選擇；GuiCaiSkill.resolveChoice 會 pop 本 behavior 並 resume
+        if (!game.isTopBehaviorEmpty()
+                && game.peekTopBehavior() instanceof WaitingSkillEffectBehavior) {
+            return events;
+        }
+
+        boolean contentmentSuccess = events.stream()
+                .filter(e -> e instanceof ContentmentEvent)
+                .map(ContentmentEvent.class::cast)
+                .anyMatch(ContentmentEvent::isSuccess);
 
         // Remove self from stack before resuming judgement flow
         isOneRound = true;
@@ -58,7 +67,7 @@ public class ContentmentJudgementBehavior extends Behavior {
         game.getCurrentRound().setStage(Stage.Normal);
         game.getCurrentRound().setActivePlayer(behaviorPlayer);
 
-        events.addAll(game.continueJudgementAndDraw(behaviorPlayer, contentmentEvent.isSuccess()));
+        events.addAll(game.continueJudgementAndDraw(behaviorPlayer, contentmentSuccess));
 
         return events;
     }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
@@ -79,18 +79,44 @@ public class NormalActiveKillBehavior extends Behavior
     /**
      * AskDodge 前先讓 SkillEngine 介入：
      * 1. 鐵騎（攻擊者側）：判定生效 → 目標不能出閃，直接結算傷害
+     *    （判定牌抽出後過鬼才暫停點；司馬懿介入時暫停，resume 走 {@link #resumeTieQiJudgement}）
      * 2. 護駕（目標側）：主公曹操 → 改問 Wei 武將代閃
      */
     private void emitAskDodgeOrHuJia(List<DomainEvent> events, Player targetPlayer) {
+        if (SkillEngine.hasTieQi(behaviorPlayer)) {
+            HandCard judgement = game.drawCardForCardEffect(1).get(0);
+            Optional<List<DomainEvent>> paused = com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.tryPause(
+                    game, behaviorPlayer, judgement,
+                    com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.TYPE_TIE_QI, "鐵騎",
+                    java.util.Map.of(com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.PARAM_TIEQI_TARGET_ID,
+                            targetPlayer.getId()));
+            if (paused.isPresent()) {
+                events.addAll(paused.get());
+                return;
+            }
+            events.addAll(resumeTieQiJudgement(judgement, targetPlayer));
+            return;
+        }
+        emitAskDodgeAfterTieQi(events, targetPlayer);
+    }
+
+    /** 以指定判定牌結算鐵騎並接續問閃流程（鬼才 resume 亦由此進入）。 */
+    public List<DomainEvent> resumeTieQiJudgement(HandCard judgement, Player targetPlayer) {
+        List<DomainEvent> events = new ArrayList<>();
         boolean[] tieQiSuccess = new boolean[1];
-        events.addAll(SkillEngine.tieQiJudgementEvents(game, behaviorPlayer, targetPlayer, tieQiSuccess));
+        events.addAll(SkillEngine.tieQiResolvedEvents(game, behaviorPlayer, targetPlayer, judgement, tieQiSuccess));
         if (tieQiSuccess[0]) {
             int originalHp = targetPlayer.getHP();
             events.addAll(game.getDamagedEvent(targetPlayer.getId(), behaviorPlayer.getId(),
                     this.cardId, this.card, PlayType.SYSTEM_INTERNAL.getPlayType(),
                     originalHp, targetPlayer, game.getCurrentRound(), Optional.of(this)));
-            return;
+            return events;
         }
+        emitAskDodgeAfterTieQi(events, targetPlayer);
+        return events;
+    }
+
+    private void emitAskDodgeAfterTieQi(List<DomainEvent> events, Player targetPlayer) {
         Optional<List<DomainEvent>> intercepted = SkillEngine.beforeAskDodge(game, targetPlayer, this);
         if (intercepted.isPresent()) {
             events.addAll(intercepted.get());

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/effect/EightDiagramTacticEquipmentEffectHandler.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/effect/EightDiagramTacticEquipmentEffectHandler.java
@@ -18,9 +18,11 @@ import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.StonePiercingAxe
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.round.Round;
 import com.gaas.threeKingdoms.round.Stage;
+import com.gaas.threeKingdoms.skill.wei.GuiCaiSkill;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class EightDiagramTacticEquipmentEffectHandler extends EquipmentEffectHandler {
@@ -51,9 +53,24 @@ public class EightDiagramTacticEquipmentEffectHandler extends EquipmentEffectHan
             return new ArrayList<>(List.of(gameStatusEvent, skipEquipmentEffectEvent, new AskDodgeEvent(playerId)));
         }
         Player player = getPlayer(playerId);
+
+        // 抽判定牌（鬼才：判定牌生效前，司馬懿可打手牌替換）
+        HandCard judgementCard = game.drawCardForCardEffect(1).get(0);
+        Optional<List<DomainEvent>> paused = GuiCaiSkill.tryPause(
+                game, player, judgementCard, GuiCaiSkill.TYPE_EIGHT_DIAGRAM, "八卦陣", Map.of());
+        if (paused.isPresent()) {
+            return paused.get();
+        }
+        return resolveJudgementOutcome(playerId, judgementCard);
+    }
+
+    /** 以指定判定牌結算八卦陣並分派後續（鬼才 resume 亦由此進入）。 */
+    public List<DomainEvent> resolveJudgementOutcome(String playerId, HandCard judgementCard) {
+        Player player = getPlayer(playerId);
         ArmorCard armorCard = player.getEquipment().getArmor();
 
-        List<DomainEvent> domainEvents = armorCard.equipmentEffect(game);
+        List<DomainEvent> domainEvents = ((EightDiagramTactic) armorCard)
+                .resolveEquipmentEffect(game, judgementCard);
 
         boolean isEightDiagramTacticEffectSuccess = domainEvents.stream()
                 .filter(event -> event instanceof EffectEvent)

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/handcard/equipmentcard/armorcard/EightDiagramTactic.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/handcard/equipmentcard/armorcard/EightDiagramTactic.java
@@ -20,7 +20,11 @@ public class EightDiagramTactic extends ArmorCard {
     @Override
     public List<DomainEvent> equipmentEffect(Game game) {
         List<HandCard> cards = game.drawCardForCardEffect(1);
-        HandCard card = cards.get(0);
+        return resolveEquipmentEffect(game, cards.get(0));
+    }
+
+    /** 以指定判定牌結算八卦陣（鬼才替換後 / 無鬼才直接）。 */
+    public List<DomainEvent> resolveEquipmentEffect(Game game, HandCard card) {
         boolean isEffectSuccess = isEffectSuccess(card);
         List<DomainEvent> events = new ArrayList<>();
         Round currentRound = game.getCurrentRound();

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillEngine.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillEngine.java
@@ -221,7 +221,7 @@ public final class SkillEngine {
 
     /**
      * 洛神：回合開始判定 loop — 黑色（黑桃/梅花）收入手牌續判，紅色停。
-     * 非甄姬回 empty list；v1 自動觸發。
+     * 非甄姬回 empty list；含鬼才暫停點（暫停時 caller 應檢查 topBehavior 並中止回合開始流程）。
      */
     public static List<DomainEvent> luoShenJudgementLoop(Game game, Player roundPlayer) {
         boolean hasLuoShen = skillsOf(roundPlayer).stream()
@@ -229,37 +229,57 @@ public final class SkillEngine {
         if (!hasLuoShen) {
             return List.of();
         }
+        return luoShenContinueLoop(game, roundPlayer);
+    }
+
+    /** 洛神判定 loop 本體（鬼才 resume 後續判亦由此進入）；每張判定牌抽出後先過鬼才暫停點。 */
+    public static List<DomainEvent> luoShenContinueLoop(Game game, Player roundPlayer) {
         List<DomainEvent> events = new ArrayList<>();
         while (true) {
             com.gaas.threeKingdoms.handcard.HandCard judgement = game.drawCardForCardEffect(1).get(0);
-            boolean black = judgement.getSuit() == com.gaas.threeKingdoms.handcard.Suit.SPADE
-                    || judgement.getSuit() == com.gaas.threeKingdoms.handcard.Suit.CLUB;
-            events.add(new com.gaas.threeKingdoms.events.SkillEffectEvent(
-                    com.gaas.threeKingdoms.skill.wei.LuoShenSkill.SKILL_NAME,
-                    roundPlayer.getId(), black, List.of(judgement.getId()), null));
-            if (!black) {
-                break;
+            java.util.Optional<List<DomainEvent>> paused = com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.tryPause(
+                    game, roundPlayer, judgement,
+                    com.gaas.threeKingdoms.skill.wei.GuiCaiSkill.TYPE_LUO_SHEN, "洛神", java.util.Map.of());
+            if (paused.isPresent()) {
+                events.addAll(paused.get());
+                return events;
             }
+            if (!luoShenResolveOne(game, roundPlayer, judgement, events)) {
+                return events;
+            }
+        }
+    }
+
+    /** 以指定判定牌結算一次洛神判定；黑色 → 收入手牌並回 true（續判），紅色 → 回 false（停）。 */
+    public static boolean luoShenResolveOne(Game game, Player roundPlayer,
+                                            com.gaas.threeKingdoms.handcard.HandCard judgement,
+                                            List<DomainEvent> events) {
+        boolean black = judgement.getSuit() == com.gaas.threeKingdoms.handcard.Suit.SPADE
+                || judgement.getSuit() == com.gaas.threeKingdoms.handcard.Suit.CLUB;
+        events.add(new com.gaas.threeKingdoms.events.SkillEffectEvent(
+                com.gaas.threeKingdoms.skill.wei.LuoShenSkill.SKILL_NAME,
+                roundPlayer.getId(), black, List.of(judgement.getId()), null));
+        if (black) {
             game.getGraveyard().removeCard(judgement.getId())
                     .ifPresent(card -> roundPlayer.getHand().addCardToHand(card));
         }
-        return events;
+        return black;
+    }
+
+    /** 鐵騎：攻擊者是否持有鐵騎（馬超）。 */
+    public static boolean hasTieQi(Player attacker) {
+        return skillsOf(attacker).stream()
+                .anyMatch(s -> s instanceof com.gaas.threeKingdoms.skill.shu.TieQiSkill);
     }
 
     /**
-     * 鐵騎：馬超指定殺目標後自動判定（v1 自動，非紅桃 = 目標不能出閃）。
+     * 鐵騎：以指定判定牌結算（判定牌已抽出、已過鬼才暫停點）。
      * 判定事件一律回傳（成功或失敗都要廣播）；successOut[0] 告知 caller 是否生效
-     * （生效 → 跳過 AskDodge 直接結算傷害）。非馬超 → 回 empty list 且 successOut[0]=false。
+     * （生效 → 跳過 AskDodge 直接結算傷害）。
      */
-    public static List<DomainEvent> tieQiJudgementEvents(Game game, Player attacker, Player target,
-                                                         boolean[] successOut) {
-        boolean hasTieQi = skillsOf(attacker).stream()
-                .anyMatch(s -> s instanceof com.gaas.threeKingdoms.skill.shu.TieQiSkill);
-        if (!hasTieQi) {
-            successOut[0] = false;
-            return List.of();
-        }
-        com.gaas.threeKingdoms.handcard.HandCard judgement = game.drawCardForCardEffect(1).get(0);
+    public static List<DomainEvent> tieQiResolvedEvents(Game game, Player attacker, Player target,
+                                                        com.gaas.threeKingdoms.handcard.HandCard judgement,
+                                                        boolean[] successOut) {
         boolean success = judgement.getSuit() != com.gaas.threeKingdoms.handcard.Suit.HEART;
         successOut[0] = success;
         List<DomainEvent> events = new ArrayList<>();

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/GangLieSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/GangLieSkill.java
@@ -97,8 +97,23 @@ public class GangLieSkill implements OnDamagedSkill, ChoiceResolvableSkill {
             throw new IllegalArgumentException("Invalid GangLie choice: " + choice);
         }
 
-        // 判定
+        // 判定（判定牌抽出後過鬼才暫停點；司馬懿介入時暫停，resume 走 resolveJudgementOutcome）
         HandCard judgement = game.drawCardForCardEffect(1).get(0);
+        java.util.Optional<List<DomainEvent>> paused = GuiCaiSkill.tryPause(
+                game, xiaHou, judgement, GuiCaiSkill.TYPE_GANG_LIE, "剛烈",
+                java.util.Map.of(GuiCaiSkill.PARAM_GANGLIE_SOURCE_ID, sourceId));
+        if (paused.isPresent()) {
+            events.addAll(paused.get());
+            return events;
+        }
+        events.addAll(resolveJudgementOutcome(game, xiaHou, sourceId, judgement));
+        return events;
+    }
+
+    /** 以指定判定牌結算剛烈（鬼才 resume 亦由此進入）：非紅桃 → 問來源棄兩張或受 1 傷。 */
+    public static List<DomainEvent> resolveJudgementOutcome(Game game, Player xiaHou, String sourceId,
+                                                            HandCard judgement) {
+        List<DomainEvent> events = new ArrayList<>();
         boolean success = judgement.getSuit() != Suit.HEART;
         events.add(new SkillEffectEvent(SKILL_NAME, xiaHou.getId(), success,
                 List.of(judgement.getId()), sourceId));

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/GuiCaiSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/GuiCaiSkill.java
@@ -2,8 +2,13 @@ package com.gaas.threeKingdoms.skill.wei;
 
 import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.behavior.Behavior;
+import com.gaas.threeKingdoms.behavior.behavior.ContentmentJudgementBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.LightningJudgementBehavior;
+import com.gaas.threeKingdoms.behavior.behavior.NormalActiveKillBehavior;
 import com.gaas.threeKingdoms.behavior.behavior.WaitingSkillEffectBehavior;
+import com.gaas.threeKingdoms.effect.EightDiagramTacticEquipmentEffectHandler;
+import com.gaas.threeKingdoms.events.AskSkillEffectEvent;
+import com.gaas.threeKingdoms.events.ContentmentEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
 import com.gaas.threeKingdoms.events.SkillEffectEvent;
 import com.gaas.threeKingdoms.generalcard.General;
@@ -12,29 +17,44 @@ import com.gaas.threeKingdoms.handcard.PlayCard;
 import com.gaas.threeKingdoms.handcard.scrollcard.ScrollCard;
 import com.gaas.threeKingdoms.player.Player;
 import com.gaas.threeKingdoms.round.Stage;
+import com.gaas.threeKingdoms.skill.registry.SkillEngine;
 import com.gaas.threeKingdoms.skill.trigger.ChoiceResolvableSkill;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * 司馬懿 (WEI002) 鬼才 — 任意角色的判定牌生效前，可打出一張手牌代替之（issue #164）。
  *
- * v1 範圍：閃電判定路徑（含 Ward 路徑 LightningJudgementBehavior）。
- * 樂不思蜀 / 八卦陣 / 洛神 / 鐵騎 / 剛烈判定的替換為 follow-up。
+ * 覆蓋全部判定路徑（依 wiki 標準版敘述「當一名角色的判定牌生效前」）：
+ * 閃電 / 樂不思蜀（含 Ward 路徑）/ 八卦陣 / 鐵騎 / 剛烈 / 洛神。
+ * 判定型別以 {@link #PARAM_JUDGEMENT_TYPE} 存於 behavior params，resolve 時 dispatch
+ * 到對應的 resume 路徑。同一次判定僅詢問一次（官方 FAQ）。
  *
- * 觸發：Game.handleLightningJudgement 抽出判定牌後，若場上有存活且有手牌的司馬懿
- * → push WaitingSkillEffect(鬼才) 暫停結算（原判定牌已在墓地）。
+ * 觸發：各判定點抽出判定牌後，若場上有存活且有手牌的司馬懿
+ * → {@link #tryPause} push WaitingSkillEffect(鬼才) 暫停結算（原判定牌已在墓地）。
  * ACCEPT（cardIds[0] = 司馬懿手牌）→ 該牌成為判定牌（進墓地），原判定牌留墓地；
- * SKIP → 原判定牌生效。之後 resume：結算閃電 → 恢復判定/摸牌流程。
+ * SKIP → 原判定牌生效。之後依判定型別 resume 對應流程。
  */
 public class GuiCaiSkill implements ChoiceResolvableSkill {
 
     public static final String GENERAL_ID = General.司馬懿.getGeneralId();
     public static final String SKILL_NAME = "鬼才";
+    public static final String PARAM_JUDGEMENT_TYPE = "GUICAI_JUDGEMENT_TYPE";
     public static final String PARAM_LIGHTNING_CARD_ID = "GUICAI_LIGHTNING_CARD_ID";
     public static final String PARAM_OWNER_ID = "GUICAI_OWNER_ID";
     public static final String PARAM_DRAWN_CARD_ID = "GUICAI_DRAWN_CARD_ID";
+    public static final String PARAM_TIEQI_TARGET_ID = "GUICAI_TIEQI_TARGET_ID";
+    public static final String PARAM_GANGLIE_SOURCE_ID = "GUICAI_GANGLIE_SOURCE_ID";
+
+    public static final String TYPE_LIGHTNING = "LIGHTNING";
+    public static final String TYPE_CONTENTMENT = "CONTENTMENT";
+    public static final String TYPE_EIGHT_DIAGRAM = "EIGHT_DIAGRAM";
+    public static final String TYPE_TIE_QI = "TIE_QI";
+    public static final String TYPE_GANG_LIE = "GANG_LIE";
+    public static final String TYPE_LUO_SHEN = "LUO_SHEN";
 
     @Override
     public String getGeneralId() {
@@ -46,11 +66,46 @@ public class GuiCaiSkill implements ChoiceResolvableSkill {
         return SKILL_NAME;
     }
 
+    /**
+     * 判定暫停點共用入口：抽出判定牌後呼叫。場上有存活且有手牌的司馬懿
+     * → push WaitingSkillEffect(鬼才) 並回傳詢問事件（caller 應直接 return，不結算）；
+     * 否則回 empty，caller 以 drawnCard 同步結算。
+     *
+     * @param judgementTypeName 判定名稱（訊息用，如「閃電」「樂不思蜀」）
+     */
+    public static Optional<List<DomainEvent>> tryPause(Game game, Player owner, HandCard drawnCard,
+                                                       String type, String judgementTypeName,
+                                                       Map<String, String> extraParams) {
+        Player guiCaiHolder = game.getPlayers().stream()
+                .filter(p -> !p.isAlreadyDeath()
+                        && GENERAL_ID.equals(p.getGeneralCard().getGeneralId())
+                        && p.getHandSize() > 0)
+                .findFirst().orElse(null);
+        if (guiCaiHolder == null) {
+            return Optional.empty();
+        }
+        WaitingSkillEffectBehavior waiting = new WaitingSkillEffectBehavior(game, guiCaiHolder, SKILL_NAME);
+        waiting.putParam(PARAM_JUDGEMENT_TYPE, type);
+        waiting.putParam(PARAM_OWNER_ID, owner.getId());
+        waiting.putParam(PARAM_DRAWN_CARD_ID, drawnCard.getId());
+        extraParams.forEach(waiting::putParam);
+        game.updateTopBehavior(waiting);
+        game.getCurrentRound().setActivePlayer(guiCaiHolder);
+        return Optional.of(List.of(
+                new AskSkillEffectEvent(SKILL_NAME, guiCaiHolder.getId(),
+                        List.of(drawnCard.getId()), owner.getId()),
+                game.getGameStatusEvent("鬼才：" + guiCaiHolder.getId() + " 可替換 "
+                        + owner.getId() + " 的" + judgementTypeName + "判定牌")));
+    }
+
     @Override
     public List<DomainEvent> resolveChoice(Game game, WaitingSkillEffectBehavior waiting,
                                            String choice, List<String> cardIds, String targetPlayerId) {
         Player simaYi = waiting.getBehaviorPlayer();
-        ScrollCard lightning = (ScrollCard) PlayCard.findById((String) waiting.getParam(PARAM_LIGHTNING_CARD_ID));
+        String type = (String) waiting.getParam(PARAM_JUDGEMENT_TYPE);
+        if (type == null) {
+            type = TYPE_LIGHTNING;
+        }
         Player owner = game.getPlayer((String) waiting.getParam(PARAM_OWNER_ID));
         HandCard drawn = PlayCard.findById((String) waiting.getParam(PARAM_DRAWN_CARD_ID));
 
@@ -77,17 +132,105 @@ public class GuiCaiSkill implements ChoiceResolvableSkill {
             throw new IllegalArgumentException("Invalid GuiCai choice: " + choice);
         }
 
-        // pop waiting；若下層是 Ward 路徑的 LightningJudgementBehavior 一併標記完成
+        switch (type) {
+            case TYPE_LIGHTNING -> events.addAll(resumeLightning(game, waiting, owner, judgementCard));
+            case TYPE_CONTENTMENT -> events.addAll(resumeContentment(game, waiting, owner, judgementCard));
+            case TYPE_EIGHT_DIAGRAM -> events.addAll(resumeEightDiagram(game, waiting, owner, judgementCard));
+            case TYPE_TIE_QI -> events.addAll(resumeTieQi(game, waiting, owner, judgementCard));
+            case TYPE_GANG_LIE -> events.addAll(resumeGangLie(game, waiting, owner, judgementCard));
+            case TYPE_LUO_SHEN -> events.addAll(resumeLuoShen(game, waiting, owner, judgementCard));
+            default -> throw new IllegalStateException("Unknown GuiCai judgement type: " + type);
+        }
+        return events;
+    }
+
+    /** pop 鬼才 waiting；若下層是 Ward 路徑的判定 behavior（閃電/樂不思蜀）一併標記完成。 */
+    private void popWaitingAndWardJudgementBehavior(Game game, WaitingSkillEffectBehavior waiting) {
         waiting.setIsOneRound(true);
         game.removeCompletedBehaviors();
         Behavior top = game.isTopBehaviorEmpty() ? null : game.peekTopBehavior();
-        if (top instanceof LightningJudgementBehavior ljb) {
-            ljb.setIsOneRound(true);
+        if (top instanceof LightningJudgementBehavior || top instanceof ContentmentJudgementBehavior) {
+            top.setIsOneRound(true);
             game.removeCompletedBehaviors();
         }
+    }
 
-        // 以（可能被替換的）判定牌結算閃電，然後恢復判定/摸牌流程
-        events.addAll(game.resolveLightningJudgement(lightning, owner, judgementCard));
+    private List<DomainEvent> resumeLightning(Game game, WaitingSkillEffectBehavior waiting,
+                                              Player owner, HandCard judgementCard) {
+        ScrollCard lightning = (ScrollCard) PlayCard.findById((String) waiting.getParam(PARAM_LIGHTNING_CARD_ID));
+        popWaitingAndWardJudgementBehavior(game, waiting);
+
+        List<DomainEvent> events = new ArrayList<>(
+                game.resolveLightningJudgement(lightning, owner, judgementCard));
+        game.getCurrentRound().setStage(Stage.Normal);
+        game.getCurrentRound().setActivePlayer(owner);
+        events.addAll(game.continueJudgementAndDraw(owner, false));
+        return events;
+    }
+
+    private List<DomainEvent> resumeContentment(Game game, WaitingSkillEffectBehavior waiting,
+                                                Player owner, HandCard judgementCard) {
+        popWaitingAndWardJudgementBehavior(game, waiting);
+
+        List<DomainEvent> events = new ArrayList<>(
+                game.resolveContentmentJudgement(owner, judgementCard));
+        boolean contentmentSuccess = events.stream()
+                .filter(e -> e instanceof ContentmentEvent)
+                .map(ContentmentEvent.class::cast)
+                .anyMatch(ContentmentEvent::isSuccess);
+        game.getCurrentRound().setStage(Stage.Normal);
+        game.getCurrentRound().setActivePlayer(owner);
+        events.addAll(game.continueJudgementAndDraw(owner, contentmentSuccess));
+        return events;
+    }
+
+    private List<DomainEvent> resumeEightDiagram(Game game, WaitingSkillEffectBehavior waiting,
+                                                 Player owner, HandCard judgementCard) {
+        // 先 pop waiting，讓八卦陣結算的 fan-out（萬箭推進/方天/青龍/貫石斧）看得到底層 behavior
+        waiting.setIsOneRound(true);
+        game.removeCompletedBehaviors();
+        game.getCurrentRound().setActivePlayer(owner);
+        return new EightDiagramTacticEquipmentEffectHandler(null, game)
+                .resolveJudgementOutcome(owner.getId(), judgementCard);
+    }
+
+    private List<DomainEvent> resumeTieQi(Game game, WaitingSkillEffectBehavior waiting,
+                                          Player owner, HandCard judgementCard) {
+        Player target = game.getPlayer((String) waiting.getParam(PARAM_TIEQI_TARGET_ID));
+        waiting.setIsOneRound(true);
+        game.removeCompletedBehaviors();
+        Behavior top = game.isTopBehaviorEmpty() ? null : game.peekTopBehavior();
+        if (!(top instanceof NormalActiveKillBehavior killBehavior)) {
+            throw new IllegalStateException("鬼才(鐵騎) resume expects NormalActiveKillBehavior on top");
+        }
+        // 還原暫停前狀態（updateRoundInformation 設 activePlayer = 殺目標）；damage 路徑會自行重設
+        game.getCurrentRound().setActivePlayer(target);
+        return killBehavior.resumeTieQiJudgement(judgementCard, target);
+    }
+
+    private List<DomainEvent> resumeGangLie(Game game, WaitingSkillEffectBehavior waiting,
+                                            Player owner, HandCard judgementCard) {
+        String sourceId = (String) waiting.getParam(PARAM_GANGLIE_SOURCE_ID);
+        // pop 鬼才 waiting + 底下已完成的剛烈 ASK_XIAHOU waiting
+        waiting.setIsOneRound(true);
+        game.removeCompletedBehaviors();
+        return GangLieSkill.resolveJudgementOutcome(game, owner, sourceId, judgementCard);
+    }
+
+    private List<DomainEvent> resumeLuoShen(Game game, WaitingSkillEffectBehavior waiting,
+                                            Player owner, HandCard judgementCard) {
+        waiting.setIsOneRound(true);
+        game.removeCompletedBehaviors();
+
+        List<DomainEvent> events = new ArrayList<>();
+        boolean black = SkillEngine.luoShenResolveOne(game, owner, judgementCard, events);
+        if (black) {
+            // 黑色收牌 → 續判（下一張可能再次觸發鬼才詢問）
+            events.addAll(SkillEngine.luoShenContinueLoop(game, owner));
+            if (!game.isTopBehaviorEmpty()) {
+                return events;
+            }
+        }
         game.getCurrentRound().setStage(Stage.Normal);
         game.getCurrentRound().setActivePlayer(owner);
         events.addAll(game.continueJudgementAndDraw(owner, false));

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/GuiCaiSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/GuiCaiSkillTest.java
@@ -1,13 +1,20 @@
 package com.gaas.threeKingdoms.skill;
 
 import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.events.AskDodgeEvent;
 import com.gaas.threeKingdoms.events.AskSkillEffectEvent;
+import com.gaas.threeKingdoms.events.ContentmentEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.EightDiagramTacticEffectEvent;
 import com.gaas.threeKingdoms.events.LightningEvent;
 import com.gaas.threeKingdoms.events.LightningTransferredEvent;
+import com.gaas.threeKingdoms.events.SkillEffectEvent;
 import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.EquipmentPlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic;
 import com.gaas.threeKingdoms.handcard.scrollcard.Lightning;
 import com.gaas.threeKingdoms.player.Player;
 import org.junit.jupiter.api.DisplayName;
@@ -19,10 +26,11 @@ import static com.gaas.threeKingdoms.handcard.PlayCard.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * 司馬懿 鬼才（#164）— v1：閃電判定路徑。
+ * 司馬懿 鬼才（#164）— 覆蓋全部判定路徑：閃電 / 樂不思蜀 / 八卦陣 / 鐵騎 / 剛烈 / 洛神。
  * 注意：handleLightningJudgement 以參數收閃電卡（產品 caller judgePlayerShouldDelay
  * 判定前已從判定區 pop）；測試不可把卡放進判定區，否則 resolve 後
  * continueJudgementAndDraw 會對判定區殘留的閃電再判一次（隨機牌 → 不確定性）。
+ * 判定牌以 deck.add 控制（Stack — list 最後一個元素最先被抽）。
  */
 public class GuiCaiSkillTest extends PassiveSkillTestBase {
 
@@ -112,5 +120,356 @@ public class GuiCaiSkillTest extends PassiveSkillTestBase {
 
         assertFalse(events.stream().anyMatch(e -> e instanceof AskSkillEffectEvent));
         assertTrue(events.stream().anyMatch(e -> e instanceof LightningTransferredEvent));
+    }
+
+    // ===== 樂不思蜀判定 =====
+
+    @DisplayName("樂不思蜀判定抽牌後暫停，詢問鬼才")
+    @Test
+    public void guiCaiAskedBeforeContentmentJudgementResolves() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        game.getPlayer("player-b").getHand().addCardToHand(new Peach(BH3029));
+
+        game.getDeck().add(List.of(new Kill(BS8008))); // 黑桃：原判定生效（跳過出牌）
+        List<DomainEvent> events = game.handleContentmentJudgement(a);
+
+        AskSkillEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskSkillEffectEvent).map(e -> (AskSkillEffectEvent) e)
+                .findFirst().orElseThrow();
+        assertEquals("鬼才", ask.getSkillName());
+        assertEquals("player-b", ask.getPlayerId());
+        assertEquals(List.of(BS8008.getCardId()), ask.getDataCardIds());
+        assertFalse(events.stream().anyMatch(e -> e instanceof ContentmentEvent), "判定尚未結算");
+    }
+
+    @DisplayName("鬼才 ACCEPT 以紅心替換 → 樂不思蜀判定不生效")
+    @Test
+    public void guiCaiReplaceMakesContentmentFail() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        b.getHand().addCardToHand(new Peach(BH3029)); // 紅心 — 替換用
+
+        game.getDeck().add(List.of(new Kill(BS8008)));
+        game.handleContentmentJudgement(a);
+
+        List<DomainEvent> events = game.playerUseSkillEffect(
+                "player-b", "鬼才", "ACCEPT", List.of(BH3029.getCardId()), null);
+
+        ContentmentEvent contentment = events.stream()
+                .filter(e -> e instanceof ContentmentEvent).map(e -> (ContentmentEvent) e)
+                .findFirst().orElseThrow();
+        assertFalse(contentment.isSuccess(), "替換成紅心 → 判定不生效");
+        assertEquals(0, b.getHandSize(), "替換牌已打出");
+        assertTrue(game.getGraveyard().contains(BH3029.getCardId()));
+    }
+
+    @DisplayName("鬼才 SKIP → 原黑桃樂不思蜀判定生效")
+    @Test
+    public void guiCaiSkipContentmentOriginalApplies() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        game.getPlayer("player-b").getHand().addCardToHand(new Peach(BH3029));
+
+        game.getDeck().add(List.of(new Kill(BS8008)));
+        game.handleContentmentJudgement(a);
+
+        List<DomainEvent> events = game.playerUseSkillEffect("player-b", "鬼才", "SKIP", null, null);
+
+        ContentmentEvent contentment = events.stream()
+                .filter(e -> e instanceof ContentmentEvent).map(e -> (ContentmentEvent) e)
+                .findFirst().orElseThrow();
+        assertTrue(contentment.isSuccess(), "原黑桃判定生效");
+    }
+
+    // ===== 八卦陣判定 =====
+
+    @DisplayName("八卦陣判定抽牌後暫停，詢問鬼才")
+    @Test
+    public void guiCaiAskedBeforeEightDiagramJudgementResolves() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(new Peach(BH3029));
+        b.getEquipment().setArmor(new EightDiagramTactic(EC2067));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.getDeck().add(List.of(new Kill(BS9009))); // 黑桃：原判定失敗（要出閃）
+        List<DomainEvent> events = game.playerUseEquipment(
+                "player-b", EC2067.getCardId(), "player-b", EquipmentPlayType.ACTIVE);
+
+        AskSkillEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskSkillEffectEvent).map(e -> (AskSkillEffectEvent) e)
+                .findFirst().orElseThrow();
+        assertEquals("鬼才", ask.getSkillName());
+        assertEquals("player-b", ask.getPlayerId());
+        assertFalse(events.stream().anyMatch(e -> e instanceof EightDiagramTacticEffectEvent),
+                "八卦陣尚未結算");
+    }
+
+    @DisplayName("鬼才 ACCEPT 以紅心替換 → 八卦陣成功（視為出閃）")
+    @Test
+    public void guiCaiReplaceMakesEightDiagramSucceed() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(new Peach(BH3029));
+        b.getEquipment().setArmor(new EightDiagramTactic(EC2067));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.getDeck().add(List.of(new Kill(BS9009)));
+        game.playerUseEquipment("player-b", EC2067.getCardId(), "player-b", EquipmentPlayType.ACTIVE);
+
+        List<DomainEvent> events = game.playerUseSkillEffect(
+                "player-b", "鬼才", "ACCEPT", List.of(BH3029.getCardId()), null);
+
+        EightDiagramTacticEffectEvent effect = events.stream()
+                .filter(e -> e instanceof EightDiagramTacticEffectEvent)
+                .map(e -> (EightDiagramTacticEffectEvent) e)
+                .findFirst().orElseThrow();
+        assertTrue(effect.isSuccess(), "替換成紅心 → 八卦陣成功");
+        assertEquals(4, b.getHP(), "視為出閃，不受傷");
+        assertTrue(game.isTopBehaviorEmpty(), "殺已結算完畢");
+    }
+
+    @DisplayName("鬼才 SKIP → 原黑桃判定八卦陣失敗，續問閃")
+    @Test
+    public void guiCaiSkipEightDiagramFailsAsksDodge() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(new Peach(BH3029));
+        b.getEquipment().setArmor(new EightDiagramTactic(EC2067));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.getDeck().add(List.of(new Kill(BS9009)));
+        game.playerUseEquipment("player-b", EC2067.getCardId(), "player-b", EquipmentPlayType.ACTIVE);
+
+        List<DomainEvent> events = game.playerUseSkillEffect("player-b", "鬼才", "SKIP", null, null);
+
+        EightDiagramTacticEffectEvent effect = events.stream()
+                .filter(e -> e instanceof EightDiagramTacticEffectEvent)
+                .map(e -> (EightDiagramTacticEffectEvent) e)
+                .findFirst().orElseThrow();
+        assertFalse(effect.isSuccess(), "原黑桃判定 → 八卦陣失敗");
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent
+                        && ((AskDodgeEvent) e).getPlayerId().equals("player-b")),
+                "失敗後續問閃");
+    }
+
+    // ===== 鐵騎判定 =====
+
+    @DisplayName("馬超鐵騎判定抽牌後暫停，詢問鬼才")
+    @Test
+    public void guiCaiAskedBeforeTieQiJudgementResolves() {
+        Game game = createGame(General.馬超, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(List.of(new Peach(BH3029), new Dodge(BH2028)));
+
+        game.getDeck().add(List.of(new Kill(BS9009))); // 黑桃：原本鐵騎生效
+        List<DomainEvent> events = game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        AskSkillEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskSkillEffectEvent).map(e -> (AskSkillEffectEvent) e)
+                .findFirst().orElseThrow();
+        assertEquals("鬼才", ask.getSkillName());
+        assertEquals("player-b", ask.getPlayerId());
+        assertEquals("player-a", ask.getDataPlayerId(), "判定 owner 為馬超");
+        assertFalse(events.stream().anyMatch(e -> e instanceof SkillEffectEvent
+                && ((SkillEffectEvent) e).getSkillName().equals("鐵騎")), "鐵騎尚未結算");
+        assertEquals(4, b.getHP());
+    }
+
+    @DisplayName("鬼才 ACCEPT 以紅心替換 → 鐵騎不生效，照常問閃")
+    @Test
+    public void guiCaiReplaceMakesTieQiFail() {
+        Game game = createGame(General.馬超, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(List.of(new Peach(BH3029), new Dodge(BH2028)));
+
+        game.getDeck().add(List.of(new Kill(BS9009)));
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        List<DomainEvent> events = game.playerUseSkillEffect(
+                "player-b", "鬼才", "ACCEPT", List.of(BH3029.getCardId()), null);
+
+        assertTrue(events.stream().anyMatch(e -> e instanceof SkillEffectEvent
+                        && ((SkillEffectEvent) e).getSkillName().equals("鐵騎")
+                        && !((SkillEffectEvent) e).isAccepted()),
+                "替換成紅心 → 鐵騎不生效");
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskDodgeEvent
+                && ((AskDodgeEvent) e).getPlayerId().equals("player-b")), "照常問閃");
+        assertEquals(4, b.getHP());
+
+        // 迴歸保護：resume 後 activePlayer 須還原為殺目標，否則目標出閃會被擋
+        game.playerPlayCard("player-b", BH2028.getCardId(), "player-a", "active");
+        assertEquals(4, b.getHP(), "閃擋下殺");
+        assertTrue(game.isTopBehaviorEmpty());
+    }
+
+    @DisplayName("鬼才 SKIP → 原黑桃判定鐵騎生效，目標不能閃直接扣血")
+    @Test
+    public void guiCaiSkipTieQiSuccessDamagesTarget() {
+        Game game = createGame(General.馬超, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(List.of(new Peach(BH3029), new Dodge(BH2028)));
+
+        game.getDeck().add(List.of(new Kill(BS9009)));
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        List<DomainEvent> events = game.playerUseSkillEffect("player-b", "鬼才", "SKIP", null, null);
+
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskDodgeEvent), "鐵騎生效不問閃");
+        assertEquals(3, b.getHP(), "直接扣血");
+        assertEquals(2, b.getHandSize(), "SKIP 不消耗手牌，閃也未被消耗");
+        assertTrue(game.isTopBehaviorEmpty());
+    }
+
+    // ===== 剛烈判定 =====
+
+    @DisplayName("夏侯惇剛烈 ACCEPT 後判定抽牌暫停，詢問鬼才（巢狀 waiting）")
+    @Test
+    public void guiCaiAskedBeforeGangLieJudgementResolves() {
+        Game game = createGame(General.甘寧, General.夏侯惇, General.司馬懿, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        game.getPlayer("player-c").getHand().addCardToHand(new Peach(BH3029));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerPlayCard("player-b", "", "player-a", "skip");
+        game.getDeck().add(List.of(new Kill(BS9009))); // 黑桃：原本剛烈生效
+        List<DomainEvent> events = game.playerUseSkillEffect("player-b", "剛烈", "ACCEPT", null, null);
+
+        AskSkillEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskSkillEffectEvent).map(e -> (AskSkillEffectEvent) e)
+                .findFirst().orElseThrow();
+        assertEquals("鬼才", ask.getSkillName());
+        assertEquals("player-c", ask.getPlayerId());
+        assertFalse(events.stream().anyMatch(e -> e instanceof SkillEffectEvent
+                && ((SkillEffectEvent) e).getSkillName().equals("剛烈")
+                && ((SkillEffectEvent) e).isAccepted()), "剛烈判定尚未結算");
+    }
+
+    @DisplayName("鬼才 ACCEPT 以紅心替換 → 剛烈判定不生效，不問來源")
+    @Test
+    public void guiCaiReplaceMakesGangLieFail() {
+        Game game = createGame(General.甘寧, General.夏侯惇, General.司馬懿, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        Player c = game.getPlayer("player-c");
+        c.getHand().addCardToHand(new Peach(BH3029));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerPlayCard("player-b", "", "player-a", "skip");
+        game.getDeck().add(List.of(new Kill(BS9009)));
+        game.playerUseSkillEffect("player-b", "剛烈", "ACCEPT", null, null);
+
+        List<DomainEvent> events = game.playerUseSkillEffect(
+                "player-c", "鬼才", "ACCEPT", List.of(BH3029.getCardId()), null);
+
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskSkillEffectEvent
+                        && ((AskSkillEffectEvent) e).getSkillName().equals("剛烈")),
+                "判定紅心不生效 → 不問來源");
+        assertTrue(game.isTopBehaviorEmpty());
+        assertEquals(4, a.getHP());
+    }
+
+    @DisplayName("鬼才 SKIP → 原黑桃剛烈判定生效，問來源棄兩張或受 1 傷")
+    @Test
+    public void guiCaiSkipGangLieSuccessAsksSource() {
+        Game game = createGame(General.甘寧, General.夏侯惇, General.司馬懿, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        game.getPlayer("player-c").getHand().addCardToHand(new Peach(BH3029));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerPlayCard("player-b", "", "player-a", "skip");
+        game.getDeck().add(List.of(new Kill(BS9009)));
+        game.playerUseSkillEffect("player-b", "剛烈", "ACCEPT", null, null);
+
+        List<DomainEvent> events = game.playerUseSkillEffect("player-c", "鬼才", "SKIP", null, null);
+
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskSkillEffectEvent
+                        && ((AskSkillEffectEvent) e).getSkillName().equals("剛烈")
+                        && ((AskSkillEffectEvent) e).getPlayerId().equals("player-a")),
+                "剛烈生效 → 問來源");
+
+        game.playerUseSkillEffect("player-a", "剛烈", "DAMAGE", null, null);
+        assertEquals(3, a.getHP(), "來源選擇受 1 點傷害");
+    }
+
+    // ===== 洛神判定 =====
+
+    @DisplayName("甄姬洛神每張判定牌抽出後暫停，詢問鬼才；ACCEPT 紅心替換 → 停止收牌")
+    @Test
+    public void guiCaiReplaceStopsLuoShenLoop() {
+        Game game = createGame(General.甄姬, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        b.getHand().addCardToHand(new Peach(BH3029));
+
+        // 抽序 = BS8008(黑，原本收牌續判) → BH4030
+        game.getDeck().add(List.of(new Peach(BH4030), new Kill(BS8008)));
+        List<DomainEvent> events = game.playerTakeTurnStartInJudgement(a);
+
+        AskSkillEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskSkillEffectEvent).map(e -> (AskSkillEffectEvent) e)
+                .findFirst().orElseThrow();
+        assertEquals("鬼才", ask.getSkillName());
+        assertEquals(List.of(BS8008.getCardId()), ask.getDataCardIds());
+        assertFalse(events.stream().anyMatch(e -> e instanceof SkillEffectEvent
+                && ((SkillEffectEvent) e).getSkillName().equals("洛神")), "判定尚未結算");
+
+        List<DomainEvent> resumeEvents = game.playerUseSkillEffect(
+                "player-b", "鬼才", "ACCEPT", List.of(BH3029.getCardId()), null);
+
+        assertTrue(resumeEvents.stream().anyMatch(e -> e instanceof SkillEffectEvent
+                        && ((SkillEffectEvent) e).getSkillName().equals("洛神")
+                        && !((SkillEffectEvent) e).isAccepted()),
+                "替換成紅心 → 洛神停止");
+        assertFalse(a.getHand().getCards().stream().anyMatch(c -> c.getId().equals(BS8008.getCardId())),
+                "原判定牌不收");
+        assertTrue(game.getGraveyard().contains(BS8008.getCardId()));
+        assertTrue(game.getGraveyard().contains(BH3029.getCardId()));
+    }
+
+    @DisplayName("鬼才 SKIP → 黑色判定牌照收並續判（下一張再次詢問）")
+    @Test
+    public void guiCaiSkipLuoShenBlackCollectsAndContinues() {
+        Game game = createGame(General.甄姬, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        b.getHand().addCardToHand(new Peach(BH3029));
+
+        // 抽序 = BS8008(黑) → BH4030(紅停)
+        game.getDeck().add(List.of(new Peach(BH4030), new Kill(BS8008)));
+        game.playerTakeTurnStartInJudgement(a);
+
+        List<DomainEvent> firstResume = game.playerUseSkillEffect("player-b", "鬼才", "SKIP", null, null);
+
+        assertTrue(a.getHand().getCards().stream().anyMatch(c -> c.getId().equals(BS8008.getCardId())),
+                "黑色判定牌照收");
+        assertTrue(firstResume.stream().anyMatch(e -> e instanceof AskSkillEffectEvent
+                        && ((AskSkillEffectEvent) e).getSkillName().equals("鬼才")),
+                "續判下一張 → 再次詢問鬼才");
+
+        List<DomainEvent> secondResume = game.playerUseSkillEffect("player-b", "鬼才", "SKIP", null, null);
+
+        assertTrue(secondResume.stream().anyMatch(e -> e instanceof SkillEffectEvent
+                        && ((SkillEffectEvent) e).getSkillName().equals("洛神")
+                        && !((SkillEffectEvent) e).isAccepted()),
+                "紅色 → 洛神停止");
+        assertEquals(3, a.getHandSize(), "收 1 張判定牌 + 摸 2 張");
+        assertTrue(game.isTopBehaviorEmpty());
     }
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/SkillEffectTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/SkillEffectTest.java
@@ -68,4 +68,50 @@ public class SkillEffectTest extends AbstractBaseIntegrationTest {
         assertEquals(3, saved.getPlayer("player-b").getHP());
         assertTrue(saved.getTopBehavior().isEmpty());
     }
+
+    @Test
+    public void testGuiCaiReplaceTieQiJudgementAcrossRequests() throws Exception {
+        // Given：A（馬超）殺 B（司馬懿）；鐵騎判定牌疊黑桃（原本生效 B 不能閃）
+        Player playerA = createPlayer("player-a", 4, General.馬超, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008));
+        Player playerB = createPlayer("player-b", 4, General.司馬懿, HealthStatus.ALIVE, Role.MINISTER,
+                new Peach(BH3029), new com.gaas.threeKingdoms.handcard.basiccard.Dodge(BH2028));
+        Player playerC = createPlayer("player-c", 4, General.孫權, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Kill(BS9009))); // 鐵騎判定牌：黑桃 → 原本生效
+        game.setDeck(deck);
+        repository.save(game);
+
+        // When：A 殺 B → 鐵騎判定抽牌後暫停，詢問鬼才（WaitingSkillEffectBehavior 經 MongoDB 存取）
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+
+        Game paused = repository.findById(gameId).orElseThrow();
+        assertFalse(paused.getTopBehavior().isEmpty(), "鬼才詢問中，判定暫停");
+        assertEquals(4, paused.getPlayer("player-b").getHP(), "尚未結算");
+
+        // B 發動鬼才：以紅心桃替換判定牌 → 鐵騎不生效 → 照常問閃
+        mockMvc.perform(post("/api/games/" + gameId + "/player:useSkillEffect")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "playerId": "player-b",
+                                  "skillName": "鬼才",
+                                  "choice": "ACCEPT",
+                                  "cardIds": ["BH3029"]
+                                }"""))
+                .andExpect(status().isOk());
+
+        // B 出閃擋下
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "BH2028", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+
+        // Then：鐵騎被鬼才化解，B 無傷
+        Game saved = repository.findById(gameId).orElseThrow();
+        assertEquals(4, saved.getPlayer("player-b").getHP(), "替換成紅心 → 鐵騎不生效，閃擋下殺");
+        assertEquals(0, saved.getPlayer("player-b").getHandSize(), "替換牌與閃都已打出");
+        assertTrue(saved.getGraveyard().contains(BH3029.getCardId()), "替換牌進墓地");
+        assertTrue(saved.getTopBehavior().isEmpty());
+    }
 }


### PR DESCRIPTION
## 摘要

依 [wiki 標準版敘述](https://sanguosha.fandom.com/zh/wiki/%E5%8F%B8%E9%A9%AC%E6%87%BF?variant=zh-tw)「**當一名角色的判定牌生效前**，你可以打出一張手牌代替之」，鬼才先前（PR #211）只覆蓋閃電判定；本 PR 把「抽牌 → 鬼才暫停點 → resolve」樣板推廣到其餘全部判定路徑，使行為與官方敘述一致。

## 覆蓋路徑

| 判定 | 暫停點 | resume 重入 |
|---|---|---|
| 閃電（既有） | `Game.handleLightningJudgement` | `resolveLightningJudgement` + `continueJudgementAndDraw` |
| 樂不思蜀（新） | `Game.handleContentmentJudgement`（拆 draw/resolve；含 Ward 路徑） | `resolveContentmentJudgement`，success 旗標 thread 進 `continueJudgementAndDraw` |
| 八卦陣（新） | `EightDiagramTacticEquipmentEffectHandler.doHandle` 抽牌後 | 新 `resolveJudgementOutcome`（萬箭推進 / 方天 / 青龍 / 貫石斧 fan-out 不變） |
| 鐵騎（新） | `NormalActiveKillBehavior.emitAskDodgeOrHuJia` 抽牌後 | 新 `resumeTieQiJudgement`；activePlayer 還原為殺目標 |
| 剛烈（新） | `GangLieSkill.resolveXiaHouChoice` 抽牌後（巢狀 WaitingSkillEffectBehavior） | 新 static `resolveJudgementOutcome` |
| 洛神（新） | `SkillEngine.luoShenContinueLoop` 每張抽牌後（逐張詢問） | `luoShenResolveOne` + 續 loop / `continueJudgementAndDraw` |

## 設計

- `GuiCaiSkill.tryPause(...)`：共用暫停點入口 — 場上有存活且有手牌的司馬懿 → push `WaitingSkillEffectBehavior(鬼才)`（判定型別/owner/判定牌 id 全部存 params，MongoDB 可持久化），發 `AskSkillEffectEvent`
- `resolveChoice` 以 `PARAM_JUDGEMENT_TYPE` dispatch 到各 resume 路徑；ACCEPT/SKIP 共用判定牌決定邏輯不變
- 同一次判定僅詢問一次（官方 FAQ）；瀕死閃電救回 resume 路徑不受影響（`playerTakeTurnStartInJudgement` 的洛神暫停檢查限定 `WaitingSkillEffectBehavior`）
- 順帶修正：樂不思蜀 Ward 路徑先前缺 `afterJudgement` 呼叫（天妒在該路徑不觸發）

## 測試

- domain：**522 全綠**（`GuiCaiSkillTest` 5 → 19，每條新路徑含「暫停詢問 / ACCEPT 替換翻轉結果 / SKIP 原判定生效」）
- spring e2e：**248 全綠**（`SkillEffectTest` 新增鬼才跨 request 測試 — 鐵騎判定暫停經 MongoDB 存取後 resolve，並回歸驗證 resume 後目標可正常出閃）

## API_DOC

- §useSkillEffect payload 表：鬼才觸發時機更新為全部判定路徑
- v1 範圍備註：移除「鬼才只覆蓋閃電」follow-up 註記

🤖 Generated with [Claude Code](https://claude.com/claude-code)