### PR TITLE
feat: 反饋支援 AOE polling（南蠻/萬箭中受傷可觸發）

### DIFF
--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
@@ -172,6 +172,18 @@ public class ArrowBarrageBehavior extends Behavior
                 return events;
             }
 
+            // 偵測反饋等 OnDamagedSkill 介入（WaitingSkillEffectBehavior + resume flag）：
+            // polling-advance defer 到 WaitingSkillEffectBehavior.resolveChoice 的 resume hook
+            if (!game.isTopBehaviorEmpty()
+                    && game.peekTopBehavior() instanceof WaitingSkillEffectBehavior wse
+                    && "true".equals(wse.getParam(WaitingSkillEffectBehavior.PARAM_RESUME_POLLING))) {
+                List<DomainEvent> events = new ArrayList<>(damagedEvent);
+                String message = game.getGamePhase().getPhaseName().equals("GeneralDying")
+                        ? "扣血已瀕臨死亡" : "扣血但還活著";
+                events.add(game.getGameStatusEvent(message));
+                return events;
+            }
+
             List<DomainEvent> events = new ArrayList<>(damagedEvent);
             events.addAll(advanceAfterDamage(playerId));
             return events;

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
@@ -156,6 +156,18 @@ public class BarbarianInvasionBehavior extends Behavior implements com.gaas.thre
                 return events;
             }
 
+            // 偵測反饋等 OnDamagedSkill 介入（WaitingSkillEffectBehavior + resume flag）：
+            // polling-advance defer 到 WaitingSkillEffectBehavior.resolveChoice 的 resume hook
+            if (!game.isTopBehaviorEmpty()
+                    && game.peekTopBehavior() instanceof WaitingSkillEffectBehavior wse
+                    && "true".equals(wse.getParam(WaitingSkillEffectBehavior.PARAM_RESUME_POLLING))) {
+                List<DomainEvent> events = new ArrayList<>(damagedEvent);
+                String message = game.getGamePhase().getPhaseName().equals("GeneralDying")
+                        ? "扣血已瀕臨死亡" : "扣血但還活著";
+                events.add(game.getGameStatusEvent(message));
+                return events;
+            }
+
             List<DomainEvent> events = new ArrayList<>(damagedEvent);
             events.addAll(advanceAfterDamage(playerId));
             return events;

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingSkillEffectBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingSkillEffectBehavior.java
@@ -24,6 +24,14 @@ import java.util.List;
 @Getter
 public class WaitingSkillEffectBehavior extends Behavior {
 
+    /**
+     * 值 "true" 時：本 waiting 是插在 AOE polling caller（南蠻/萬箭）之上的
+     * OnDamagedSkill 詢問（如反饋），resolve 後需呼叫底層的
+     * {@code resumeJianXiongPolling} 推進輪詢（mirror 奸雄 issue #209 的 reload-safe 樣板；
+     * 本 behavior 無 transient callback，一律走 param + resume hook）。
+     */
+    public static final String PARAM_RESUME_POLLING = "WSE_RESUME_POLLING";
+
     private final String skillName;
 
     public WaitingSkillEffectBehavior(Game game, Player respondingPlayer, String skillName) {
@@ -47,7 +55,21 @@ public class WaitingSkillEffectBehavior extends Behavior {
                     "player %s is not the one who should respond to skill %s", respondingPlayerId, skillName));
         }
         ChoiceResolvableSkill skill = findSkill();
-        List<DomainEvent> events = skill.resolveChoice(game, this, choice, cardIds, targetPlayerId);
+        List<DomainEvent> events = new java.util.ArrayList<>(
+                skill.resolveChoice(game, this, choice, cardIds, targetPlayerId));
+
+        // AOE polling resume：必須在 isOneRound=true 之前跑 —
+        // resume 可能把底層 polling behavior 的 isOneRound 改回 false（mid-poll），
+        // 需先於本 behavior 標記完成、避免 removeCompletedBehaviors 誤 pop polling behavior。
+        if ("true".equals(getParam(PARAM_RESUME_POLLING))) {
+            game.peekTopBehaviorSecondElement().ifPresent(under -> {
+                if (under instanceof com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior compatible
+                        && compatible.isPollingCaller()) {
+                    events.addAll(compatible.resumeJianXiongPolling(behaviorPlayer.getId()));
+                }
+            });
+        }
+
         isOneRound = true;
         return events;
     }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/FanKuiSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/FanKuiSkill.java
@@ -58,14 +58,20 @@ public class FanKuiSkill implements OnDamagedSkill, ChoiceResolvableSkill {
             return List.of(); // 來源無牌可拿
         }
         Behavior top = game.isTopBehaviorEmpty() ? null : game.peekTopBehavior();
-        if (top != null && !(top instanceof JianXiongCompatibleTopBehavior compatible
-                && !compatible.isPollingCaller())) {
-            return List.of(); // AOE polling 整合 follow-up
+        if (top != null && !(top instanceof JianXiongCompatibleTopBehavior)) {
+            return List.of(); // 非相容 host 不觸發
         }
-
-        game.removeCompletedBehaviors();
+        // polling caller（南蠻/萬箭）需保留底層 behavior，resolve 後 resume 輪詢（mirror 奸雄 #209 樣板）
+        boolean isPollingCaller = top instanceof JianXiongCompatibleTopBehavior compatible
+                && compatible.isPollingCaller();
+        if (!isPollingCaller) {
+            game.removeCompletedBehaviors();
+        }
         WaitingSkillEffectBehavior waiting = new WaitingSkillEffectBehavior(game, damaged, SKILL_NAME);
         waiting.putParam(PARAM_ATTACKER_ID, attacker.getId());
+        if (isPollingCaller) {
+            waiting.putParam(WaitingSkillEffectBehavior.PARAM_RESUME_POLLING, "true");
+        }
         game.updateTopBehavior(waiting);
         game.getCurrentRound().setActivePlayer(damaged);
 

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/FanKuiAoePollingTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/FanKuiAoePollingTest.java
@@ -1,0 +1,175 @@
+package com.gaas.threeKingdoms;
+
+import com.gaas.threeKingdoms.builders.PlayerBuilder;
+import com.gaas.threeKingdoms.events.AskDodgeEvent;
+import com.gaas.threeKingdoms.events.AskKillEvent;
+import com.gaas.threeKingdoms.events.AskSkillEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.gamephase.Normal;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.generalcard.GeneralCard;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.RepeatingCrossbowCard;
+import com.gaas.threeKingdoms.handcard.scrollcard.ArrowBarrage;
+import com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion;
+import com.gaas.threeKingdoms.player.*;
+import com.gaas.threeKingdoms.rolecard.Role;
+import com.gaas.threeKingdoms.rolecard.RoleCard;
+import com.gaas.threeKingdoms.round.Round;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 反饋 × AOE polling（南蠻入侵 / 萬箭齊發）— wiki「當你受到傷害後」應含 AOE 傷害。
+ * 先前 FanKuiSkill 在 polling caller 上直接跳過（follow-up 註記）；本測試驗證：
+ * 受傷 → 反饋詢問（polling-advance defer）→ resolve 後 resume 輪詢（不跳人）。
+ * Mirror 奸雄 #209 的 reload-safe 樣板（param flag + resume hook，無 transient callback）。
+ */
+public class FanKuiAoePollingTest {
+
+    private Game createGame(General gA, General gB, General gC, General gD) {
+        Game game = new Game();
+        game.initDeck();
+        Player a = build("player-a", gA, Role.MONARCH);
+        Player b = build("player-b", gB, Role.MINISTER);
+        Player c = build("player-c", gC, Role.REBEL);
+        Player d = build("player-d", gD, Role.TRAITOR);
+        game.setPlayers(asList(a, b, c, d));
+        game.setCurrentRound(new Round(a));
+        game.enterPhase(new Normal(game));
+        return game;
+    }
+
+    private Player build(String id, General general, Role role) {
+        return PlayerBuilder.construct().withId(id)
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(general))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(role))
+                .withHand(new Hand()).withEquipment(new Equipment()).build();
+    }
+
+    private List<String> askKillTargets(List<DomainEvent> events) {
+        return events.stream().filter(e -> e instanceof AskKillEvent)
+                .map(e -> ((AskKillEvent) e).getPlayerId()).toList();
+    }
+
+    private List<String> askDodgeTargets(List<DomainEvent> events) {
+        return events.stream().filter(e -> e instanceof AskDodgeEvent)
+                .map(e -> ((AskDodgeEvent) e).getPlayerId()).toList();
+    }
+
+    private boolean hasFanKuiAsk(List<DomainEvent> events) {
+        return events.stream().anyMatch(e -> e instanceof AskSkillEffectEvent
+                && ((AskSkillEffectEvent) e).getSkillName().equals("反饋"));
+    }
+
+    @DisplayName("南蠻：b=司馬懿 skip 受傷 → 反饋詢問（polling 暫停），ACCEPT 拿 a 手牌後問 c")
+    @Test
+    public void fanKuiAcceptInBarbarianInvasion_thenNextAskedIsC() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(List.of(new BarbarianInvasion(SS7007), new Peach(BH3029)));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        List<DomainEvent> e2 = game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+
+        assertTrue(hasFanKuiAsk(e2), "受傷後應詢問反饋");
+        assertTrue(askKillTargets(e2).isEmpty(), "反饋詢問中，不應先問下一個 reactor");
+        assertEquals(3, b.getHP());
+
+        List<DomainEvent> e3 = game.playerUseSkillEffect("player-b", "反饋", "ACCEPT", null, null);
+
+        assertTrue(b.getHand().getCards().stream().anyMatch(c -> c.getId().equals(BH3029.getCardId())),
+                "司馬懿拿走攻擊者手牌");
+        assertEquals(0, a.getHandSize());
+        assertEquals(List.of("player-c"), askKillTargets(e3), "反饋解決後 resume 輪詢問 c — 跳到 d 即為 bug");
+        assertEquals("player-c", game.getCurrentRound().getActivePlayer().getId());
+
+        List<DomainEvent> e4 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e4), "c skip 後問 d");
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("南蠻：反饋 SKIP → 一樣 resume 輪詢問 c")
+    @Test
+    public void fanKuiSkipInBarbarianInvasion_thenNextAskedIsC() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        game.getPlayer("player-a").getHand()
+                .addCardToHand(List.of(new BarbarianInvasion(SS7007), new Peach(BH3029)));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        List<DomainEvent> e3 = game.playerUseSkillEffect("player-b", "反饋", "SKIP", null, null);
+
+        assertEquals(1, game.getPlayer("player-a").getHandSize(), "SKIP 不拿牌");
+        assertEquals(List.of("player-c"), askKillTargets(e3), "反饋放棄後問 c");
+
+        List<DomainEvent> e4 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e4));
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("萬箭：b=司馬懿 skip 受傷 → 反饋 ACCEPT 指定拿 a 的裝備 → resume 問 c 出閃")
+    @Test
+    public void fanKuiTakesEquipmentInArrowBarrage_thenNextAskedIsC() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new ArrowBarrage(SHA040));
+        a.getEquipment().setWeapon(new RepeatingCrossbowCard(EH5031));
+
+        game.playerPlayCard("player-a", SHA040.getCardId(), "player-a", "active");
+        List<DomainEvent> e2 = game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+
+        assertTrue(hasFanKuiAsk(e2), "受傷後應詢問反饋");
+        assertTrue(askDodgeTargets(e2).isEmpty(), "反饋詢問中，不應先問下一個 reactor");
+
+        List<DomainEvent> e3 = game.playerUseSkillEffect(
+                "player-b", "反饋", "ACCEPT", List.of(EH5031.getCardId()), null);
+
+        assertTrue(b.getHand().getCards().stream().anyMatch(c -> c.getId().equals(EH5031.getCardId())),
+                "司馬懿拿走攻擊者裝備");
+        assertFalse(a.getEquipment().hasAnyEquipment());
+        assertEquals(List.of("player-c"), askDodgeTargets(e3), "反饋解決後 resume 輪詢問 c 出閃");
+
+        List<DomainEvent> e4 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askDodgeTargets(e4));
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("南蠻：最後一個 reactor d=司馬懿 受傷 → 反饋 resolve 後輪詢正常結束")
+    @Test
+    public void fanKuiOnLastReactor_pollingEndsCleanly() {
+        Game game = createGame(General.甘寧, General.孫權, General.孫權, General.司馬懿);
+        Player a = game.getPlayer("player-a");
+        Player d = game.getPlayer("player-d");
+        a.getHand().addCardToHand(List.of(new BarbarianInvasion(SS7007), new Peach(BH3029)));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        List<DomainEvent> e4 = game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+
+        assertTrue(hasFanKuiAsk(e4), "最後一個 reactor 受傷也應詢問反饋");
+        assertFalse(game.getTopBehavior().isEmpty(), "反饋詢問中");
+
+        game.playerUseSkillEffect("player-d", "反饋", "ACCEPT", null, null);
+
+        assertTrue(d.getHand().getCards().stream().anyMatch(c -> c.getId().equals(BH3029.getCardId())));
+        assertTrue(game.getTopBehavior().isEmpty(), "反饋解決後輪詢結束、stack 清空");
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId(),
+                "輪詢結束 activePlayer 回到出牌者");
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/SkillEffectTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/SkillEffectTest.java
@@ -114,4 +114,55 @@ public class SkillEffectTest extends AbstractBaseIntegrationTest {
         assertTrue(saved.getGraveyard().contains(BH3029.getCardId()), "替換牌進墓地");
         assertTrue(saved.getTopBehavior().isEmpty());
     }
+
+    @Test
+    public void testFanKuiInBarbarianInvasionPollingAcrossRequests() throws Exception {
+        // Given：A 出南蠻，B（司馬懿）無殺 skip 受傷 → 反饋詢問（polling defer 經 MongoDB 存取）
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion(SS7007), new Peach(BH3029));
+        Player playerB = createPlayer("player-b", 4, General.司馬懿, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.孫權, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        game.setDeck(new Deck());
+        repository.save(game);
+
+        mockMvcUtil.playCard(gameId, "player-a", "player-a", "SS7007", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk());
+
+        // 反饋詢問中：輪詢暫停（activePlayer = B），底層南蠻 behavior 保留
+        Game paused = repository.findById(gameId).orElseThrow();
+        assertEquals("player-b", paused.getCurrentRound().getActivePlayer().getId());
+        assertEquals(2, paused.getTopBehavior().size(), "南蠻 behavior + 反饋 waiting");
+
+        // B ACCEPT 反饋（拿 A 手牌）→ resume 輪詢問 C
+        mockMvc.perform(post("/api/games/" + gameId + "/player:useSkillEffect")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "playerId": "player-b",
+                                  "skillName": "反饋",
+                                  "choice": "ACCEPT"
+                                }"""))
+                .andExpect(status().isOk());
+
+        Game resumed = repository.findById(gameId).orElseThrow();
+        assertTrue(resumed.getPlayer("player-b").getHand().getCards().stream()
+                .anyMatch(c -> c.getId().equals(BH3029.getCardId())), "司馬懿拿走攻擊者手牌");
+        assertEquals("player-c", resumed.getCurrentRound().getActivePlayer().getId(),
+                "反饋解決後 resume 輪詢問 C");
+
+        // C、D skip → 輪詢正常結束
+        mockMvcUtil.playCard(gameId, "player-c", "player-a", "", "skip")
+                .andExpect(status().isOk());
+        mockMvcUtil.playCard(gameId, "player-d", "player-a", "", "skip")
+                .andExpect(status().isOk());
+
+        Game finalState = repository.findById(gameId).orElseThrow();
+        assertTrue(finalState.getTopBehavior().isEmpty());
+        assertEquals(3, finalState.getPlayer("player-b").getHP());
+        assertEquals(3, finalState.getPlayer("player-c").getHP());
+        assertEquals(3, finalState.getPlayer("player-d").getHP());
+    }
 }


### PR DESCRIPTION
## 摘要

依 [wiki 標準版敘述](https://sanguosha.fandom.com/zh/wiki/%E5%8F%B8%E9%A9%AC%E6%87%BF?variant=zh-tw)「**當你受到傷害後**，你可以獲得傷害來源的一張牌」，反饋先前在南蠻入侵/萬箭齊發的 AOE 輪詢中受傷不會觸發（`FanKuiSkill` 直接跳過並註記 follow-up）。本 PR 補上這條路徑，取牌語意不變（手牌＝隱藏抽取／裝備＝指定 id）。

## 設計 — mirror 奸雄 #209 的 reload-safe 樣板

奸雄已解過同一個問題（transient callback 經 MongoDB reload 遺失 → 改用 resume hook fallback）。反饋直接採 hook-only 版本，不引入 callback：

1. `FanKuiSkill.onDamaged`：top 是 polling caller（南蠻/萬箭）時**保留底層 behavior**（跳過 `removeCompletedBehaviors`），push 反饋 waiting 並標 `PARAM_RESUME_POLLING`
2. `WaitingSkillEffectBehavior.resolveChoice`：flag 存在時，在 `isOneRound=true` **之前**呼叫底層 `resumeJianXiongPolling(damagedId)` 推進輪詢（順序關鍵 — resume 可能把 polling behavior 的 isOneRound 改回 false，需先於本 waiting 標記完成）
3. `BarbarianInvasionBehavior` / `ArrowBarrageBehavior`：damage 後偵測反饋 waiting 在頂 → polling-advance defer（只補 presenter 需要的 `GameStatusEvent`）

無 transient state，經 MongoDB 存取天生安全；決鬥/借刀/普通殺等非 polling 路徑行為不變。

## 測試

- domain：**512 全綠** — 新 `FanKuiAoePollingTest` ×4：
  - 南蠻 ACCEPT 拿手牌 → resume 問 c（不跳人）→ d → 結束
  - 南蠻 SKIP → 同樣 resume 不跳人
  - 萬箭 ACCEPT 指定拿裝備 → resume 問 c 出閃
  - 最後一個 reactor 受傷 → resolve 後輪詢乾淨結束、activePlayer 回到出牌者
- spring e2e：**248 全綠** — `SkillEffectTest` 新增南蠻+反饋跨 request 測試（詢問中 stack = [南蠻, 反饋 waiting]、resolve 後 activePlayer=C、C/D skip 後 stack 清空）

## 相關

- 與 PR #220（鬼才 v2）同屬「司馬懿技能對齊 wiki 敘述」系列，兩 PR 無檔案重疊
- API_DOC v1 範圍備註的「反饋…AOE polling 不觸發」註記待兩 PR 都 merge 後一併更新（該行同時涉及遺計/剛烈，本 PR 不動它們）

🤖 Generated with [Claude Code](https://claude.com/claude-code)