### PR TITLE
docs: API_DOC 反饋 AOE 備註更新 + test: GuiCai 洛神測試 CI flake 修正

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -714,7 +714,8 @@ POST /api/games/{gameId}/player:useSkillEffect
 轉化殺計入出殺次數限制（咆哮/諸葛連弩豁免照常）；轉化殺對空城/謙遜的目標限制照常套用。
 
 **v1 範圍備註**：
-- 反饋 / 遺計 / 剛烈在 AOE polling（南蠻 / 萬箭）中不觸發（defer-resume 整合 follow-up）；瀕死不觸發
+- 反饋在 AOE polling（南蠻 / 萬箭）中可觸發（PR #221：受傷 → 反饋詢問 → resolve 後 resume 輪詢）；
+  遺計 / 剛烈在 AOE polling 中仍不觸發（可循同一 resume flag 開啟，follow-up）；三者瀕死皆不觸發
 - 剛烈 DAMAGE 反傷不進瀕死流程整合（follow-up）
 - 鐵騎 v1 自動判定（不問）；目標有八卦陣時走防具路徑不受鐵騎影響（follow-up）
 - 梟姬不覆蓋「主動換裝蓋掉舊裝備」路徑（follow-up）

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/GuiCaiSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/GuiCaiSkillTest.java
@@ -418,8 +418,10 @@ public class GuiCaiSkillTest extends PassiveSkillTestBase {
         Player b = game.getPlayer("player-b");
         b.getHand().addCardToHand(new Peach(BH3029));
 
-        // 抽序 = BS8008(黑，原本收牌續判) → BH4030
-        game.getDeck().add(List.of(new Peach(BH4030), new Kill(BS8008)));
+        // 抽序 = BS8008(黑，原本收牌續判) → 洛神停止後摸 2 = BH4030 + BD2093。
+        // 摸牌也必須疊牌控制：initDeck 牌堆裡有同 id 的 BS8008，隨機摸到會誤觸
+        // 「原判定牌不收」斷言（CI flake）
+        game.getDeck().add(List.of(new Dodge(BD2093), new Peach(BH4030), new Kill(BS8008)));
         List<DomainEvent> events = game.playerTakeTurnStartInJudgement(a);
 
         AskSkillEffectEvent ask = events.stream()
@@ -451,8 +453,8 @@ public class GuiCaiSkillTest extends PassiveSkillTestBase {
         Player b = game.getPlayer("player-b");
         b.getHand().addCardToHand(new Peach(BH3029));
 
-        // 抽序 = BS8008(黑) → BH4030(紅停)
-        game.getDeck().add(List.of(new Peach(BH4030), new Kill(BS8008)));
+        // 抽序 = BS8008(黑) → BH4030(紅停) → 摸 2 = BD2093 + BD3094（摸牌疊牌控制，避免隨機）
+        game.getDeck().add(List.of(new Dodge(BD3094), new Dodge(BD2093), new Peach(BH4030), new Kill(BS8008)));
         game.playerTakeTurnStartInJudgement(a);
 
         List<DomainEvent> firstResume = game.playerUseSkillEffect("player-b", "鬼才", "SKIP", null, null);


### PR DESCRIPTION
兩件收尾：

1. **API_DOC**：v1 範圍備註原寫「反饋 / 遺計 / 剛烈在 AOE polling 中不觸發」，PR #221 落地後更新為反饋已支援；遺計 / 剛烈維持 follow-up 註記。
2. **GuiCaiSkillTest CI flake 修正**（本 PR 首次 CI 抽中）：`guiCaiReplaceStopsLuoShenLoop` 只疊了判定牌，洛神停止後甄姬從牌堆隨機摸 2 — `initDeck` 含同 id 的 `BS8008`，隨機摸到會誤觸「原判定牌不收」斷言。兩個洛神測試的摸牌一併疊牌控制；本地 5 連跑穩定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)