### PR TITLE
feat: 反饋取手牌改為 index 指定（對齊順手牽羊語意）

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -668,7 +668,7 @@ POST /api/games/{gameId}/player:useSkillEffect
 
 | 技能 | 觸發 | choice | cardIds | targetPlayerId |
 |---|---|---|---|---|
-| 反饋（司馬懿） | 受傷後 | `ACCEPT` / `SKIP` | 可選：指定來源裝備 id（不給 = 抽來源第一張手牌） | — |
+| 反饋（司馬懿） | 受傷後（含南蠻/萬箭） | `ACCEPT` / `SKIP` | 可選 1 個值：來源**手牌 index**（數字字串，0-based，同順手牽羊 `targetCardIndex`；張數見 seats）或來源**裝備 id**（`dataCardIds` 列出）；不給 = 取手牌 index 0（無手牌則取第一件裝備） | — |
 | 遺計（郭嘉） | 受傷後 | `ACCEPT`（自摸 2）/ `GIVE`（令他人獲得 1）/ `SKIP` | — | GIVE 必填 |
 | 剛烈（夏侯惇）第一段 | 受傷後 | `ACCEPT`（判定）/ `SKIP` | — | — |
 | 剛烈 第二段（問傷害來源） | 判定非紅桃後 | `DISCARD` / `DAMAGE` | DISCARD 必填 2 張手牌 | — |

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/FanKuiSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/FanKuiSkill.java
@@ -20,13 +20,14 @@ import java.util.List;
 /**
  * 司馬懿 (WEI002) 反饋 — 當你受到傷害時，可獲得傷害來源的一張牌（手牌或裝備）（issue #163）。
  *
- * ACCEPT 取牌規則：
- *   - request.cardIds[0] 指定傷害來源的裝備牌 id → 取該裝備
- *   - 未指定 → 取來源第一張手牌（手牌為隱藏資訊，等同隨機）
+ * ACCEPT 取牌規則（對齊順手牽羊 useSnatchEffect 的選牌語意）：
+ *   - request.cardIds[0] 為數字 → 來源手牌的 0-based index（手牌為隱藏資訊，等同盲選）
+ *   - request.cardIds[0] 為傷害來源的裝備牌 id → 取該裝備
+ *   - 未指定 → 取來源第一張手牌（index 0）；來源無手牌時退而取第一件裝備
  *   - 來源無手牌無裝備 → 觸發時即不詢問
+ *   - 前端可由 GameStatusEvent seats 取得來源手牌張數（index 範圍 0..N-1）
  *
- * v1 範圍：top behavior 為 JianXiongCompatibleTopBehavior 且非 polling caller（或空 stack）
- * 時觸發；AOE polling 中的 defer-resume 整合為 follow-up。
+ * 觸發：top behavior 為 JianXiongCompatibleTopBehavior（含 AOE polling caller，PR #221）或空 stack。
  */
 public class FanKuiSkill implements OnDamagedSkill, ChoiceResolvableSkill {
 
@@ -91,14 +92,21 @@ public class FanKuiSkill implements OnDamagedSkill, ChoiceResolvableSkill {
 
         if ("ACCEPT".equals(choice)) {
             String takenCardId;
-            if (cardIds != null && !cardIds.isEmpty()
-                    && attacker.getEquipment().getAllEquipmentCardIds().contains(cardIds.get(0))) {
-                takenCardId = takeEquipment(attacker, simaYi, cardIds.get(0));
+            String pick = (cardIds != null && !cardIds.isEmpty()) ? cardIds.get(0) : null;
+            if (pick != null && attacker.getEquipment().getAllEquipmentCardIds().contains(pick)) {
+                takenCardId = takeEquipment(attacker, simaYi, pick);
+            } else if (pick != null && pick.matches("\\d+")) {
+                // 手牌 index（0-based，同順手牽羊 targetCardIndex）
+                int index = Integer.parseInt(pick);
+                if (index >= attacker.getHandSize()) {
+                    throw new IllegalArgumentException("Hand card index over size");
+                }
+                takenCardId = takeHandCard(attacker, simaYi, index);
+            } else if (pick != null) {
+                throw new IllegalArgumentException("Invalid FanKui pick: " + pick
+                        + "（須為來源手牌 index 或來源裝備 id）");
             } else if (attacker.getHandSize() > 0) {
-                HandCard taken = attacker.getHand().getCards().get(0);
-                takenCardId = taken.getId();
-                attacker.playCard(takenCardId);
-                simaYi.getHand().addCardToHand(taken);
+                takenCardId = takeHandCard(attacker, simaYi, 0);
             } else if (attacker.getEquipment().hasAnyEquipment()) {
                 takenCardId = takeEquipment(attacker, simaYi,
                         attacker.getEquipment().getAllEquipmentCardIds().get(0));
@@ -115,6 +123,13 @@ public class FanKuiSkill implements OnDamagedSkill, ChoiceResolvableSkill {
             throw new IllegalArgumentException("Invalid FanKui choice: " + choice);
         }
         return events;
+    }
+
+    private String takeHandCard(Player from, Player to, int index) {
+        HandCard taken = from.getHand().getCards().get(index);
+        from.playCard(taken.getId());
+        to.getHand().addCardToHand(taken);
+        return taken.getId();
     }
 
     private String takeEquipment(Player from, Player to, String equipmentId) {

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch2TriggeredSkillsTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch2TriggeredSkillsTest.java
@@ -87,6 +87,54 @@ public class Batch2TriggeredSkillsTest extends PassiveSkillTestBase {
         assertTrue(game.isTopBehaviorEmpty());
     }
 
+    @DisplayName("反饋 ACCEPT cardIds[0] 為數字 → 依 0-based index 取來源手牌（同順手牽羊語意）")
+    @Test
+    public void fanKuiAcceptTakesHandCardByIndex() {
+        Game game = createGame(General.劉備, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        // 出殺後 a 手牌順序 = [BH3029, BH4030]
+        a.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Peach(BH3029), new Peach(BH4030)));
+
+        killAndSkip(game, "player-a", "player-b");
+        game.playerUseSkillEffect("player-b", "反饋", "ACCEPT", List.of("1"), null);
+
+        assertTrue(b.getHand().getCards().stream().anyMatch(c -> c.getId().equals(BH4030.getCardId())),
+                "index 1 → 取第二張手牌");
+        assertEquals(1, a.getHandSize());
+        assertTrue(a.getHand().getCards().stream().anyMatch(c -> c.getId().equals(BH3029.getCardId())),
+                "第一張手牌留在來源");
+    }
+
+    @DisplayName("反饋 ACCEPT index 越界 → IllegalArgumentException，不動任何牌")
+    @Test
+    public void fanKuiAcceptIndexOverSizeThrows() {
+        Game game = createGame(General.劉備, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Peach(BH3029)));
+
+        killAndSkip(game, "player-a", "player-b");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> game.playerUseSkillEffect("player-b", "反饋", "ACCEPT", List.of("1"), null));
+        assertEquals(1, a.getHandSize(), "越界不取牌");
+        assertEquals(0, game.getPlayer("player-b").getHandSize());
+    }
+
+    @DisplayName("反饋 ACCEPT cardIds[0] 既非 index 也非來源裝備 id → IllegalArgumentException")
+    @Test
+    public void fanKuiAcceptInvalidPickThrows() {
+        Game game = createGame(General.劉備, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Peach(BH3029)));
+
+        killAndSkip(game, "player-a", "player-b");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> game.playerUseSkillEffect("player-b", "反饋", "ACCEPT", List.of("EH5031"), null));
+        assertEquals(1, a.getHandSize());
+    }
+
     // ===== 遺計 =====
 
     @DisplayName("郭嘉受傷 → 遺計 ACCEPT 摸兩張")

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/SkillEffectTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/SkillEffectTest.java
@@ -50,13 +50,14 @@ public class SkillEffectTest extends AbstractBaseIntegrationTest {
         mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
                 .andExpect(status().isOk());
 
-        // B ACCEPT 反饋
+        // B ACCEPT 反饋，cardIds[0] = 來源手牌 index（0-based，同順手牽羊 targetCardIndex）
         mockMvc.perform(post("/api/games/" + gameId + "/player:useSkillEffect")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 { "playerId": "player-b",
                                   "skillName": "反饋",
-                                  "choice": "ACCEPT"
+                                  "choice": "ACCEPT",
+                                  "cardIds": ["0"]
                                 }"""))
                 .andExpect(status().isOk());
 


### PR DESCRIPTION
## 摘要

使用者提議：反饋取來源手牌時，像順手牽羊一樣用 index 指定；要拿裝備則指定裝備。前端選牌介面從此與過河拆橋/順手牽羊一致。

## 語意（`useSkillEffect` ACCEPT 的 `cardIds[0]`）

| 傳值 | 行為 |
|---|---|
| 數字字串 `"0"`…`"N-1"` | 來源手牌 **0-based index**（同 `useSnatchEffect.targetCardIndex`；手牌對司馬懿隱藏，實質盲選） |
| 來源裝備 cardId（`AskSkillEffectEvent.dataCardIds` 列出） | 取該裝備（既有行為） |
| 不給 | 取 index 0（向下相容）；來源無手牌時退而取第一件裝備 |
| 越界 / 既非 index 也非裝備 id | `IllegalArgumentException` → 400，不動任何牌 |

前端從 `GameStatusEvent` seats 已可得來源手牌張數（index 範圍），event 不新增欄位。

## 測試
- domain **529 全綠**（`Batch2TriggeredSkillsTest` +3：index 1 取第二張且第一張留在來源 / 越界拋錯不取牌 / 非法值拋錯）
- spring **249 全綠**（反饋 e2e 改走 `cardIds:["0"]` 驗證 HTTP 路徑）
- `API_DOC.md` 反饋列同步更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)