### PR TITLE
feat: Debug API — 查看/設定武將牌堆（GeneralCardDeck）

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -881,3 +881,54 @@ curl -X PUT http://localhost:8080/api/debug/games/my-id/deck \
 # 驗證牌堆已更新
 curl http://localhost:8080/api/debug/games/my-id/deck
 ```
+
+---
+
+### 20.1 查看武將牌堆
+
+```
+GET /api/debug/games/{gameId}/generalCardDeck
+```
+
+**回傳**：
+```json
+{
+  "gameId": "my-id",
+  "deckSize": 25,
+  "generalIds": ["SHU001", "WEI001", "WU001", "..."]
+}
+```
+
+- `generalIds[0]` = 下一張被抽的武將
+- 注意：主公的 5 張候選在**建立遊戲（POST /api/games）時已抽走**；建立後查到的是剩餘牌堆，供主公選將後其他玩家依座位順序各抽 3 張
+
+---
+
+### 20.2 設定武將牌堆
+
+```
+PUT /api/debug/games/{gameId}/generalCardDeck
+```
+
+| 欄位 | 型別 | 說明 |
+|------|------|------|
+| generalIds | List\<String\> | 武將牌堆內容（index 0 = 下一張被抽的武將；id 如 `SHU001` 劉備、`WEI002` 司馬懿） |
+
+**回傳**：同查看武將牌堆格式
+
+**特殊情況**：
+- 全量替換，原本武將牌堆會被完全覆蓋
+- 無效 generalId → 400 `{"message": "Invalid general ID: XYZ"}`
+- 允許重複 generalId（測試可能需要）
+- 任何遊戲階段都可以呼叫；實務時機 = 建立遊戲後、主公 `monarchChooseGeneral` **之前**（主公的 5 張候選已在建立時抽走，本 API 影響的是主公選完後其他三位玩家各抽的 3 張，座位順序：主公下家起）
+
+**使用範例**：
+```bash
+# 主公選將後：下家 3 張候選 = 司馬懿/曹操/張遼，再下家 = 關羽/張飛/趙雲，最後 = 孫權/甘寧/呂蒙
+curl -X PUT http://localhost:8080/api/debug/games/my-id/generalCardDeck \
+  -H 'Content-Type: application/json' \
+  -d '{"generalIds": ["WEI002", "WEI001", "WEI004", "SHU002", "SHU003", "SHU005", "WU001", "WU002", "WU003"]}'
+
+# 驗證
+curl http://localhost:8080/api/debug/games/my-id/generalCardDeck
+```

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/DebugController.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/DebugController.java
@@ -2,7 +2,12 @@ package com.gaas.threeKingdoms.controller;
 
 import com.gaas.threeKingdoms.Game;
 import com.gaas.threeKingdoms.controller.dto.DeckResponse;
+import com.gaas.threeKingdoms.controller.dto.GeneralCardDeckResponse;
 import com.gaas.threeKingdoms.controller.dto.SetDeckRequest;
+import com.gaas.threeKingdoms.controller.dto.SetGeneralCardDeckRequest;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.generalcard.GeneralCard;
+import com.gaas.threeKingdoms.generalcard.GeneralCardDeck;
 import com.gaas.threeKingdoms.handcard.Deck;
 import com.gaas.threeKingdoms.handcard.HandCard;
 import com.gaas.threeKingdoms.handcard.PlayCard;
@@ -62,5 +67,54 @@ public class DebugController {
         gameRepository.save(game);
 
         return ResponseEntity.ok(new DeckResponse(gameId, cardIds.size(), cardIds));
+    }
+
+    @GetMapping("/api/debug/games/{gameId}/generalCardDeck")
+    public ResponseEntity<?> getGeneralCardDeck(@PathVariable String gameId) {
+        Game game = gameRepository.findById(gameId)
+                .orElseThrow(() -> new RuntimeException("Game not found: " + gameId));
+
+        List<GeneralCard> cards = game.getGeneralCardDeck().getGeneralStack();
+        // Stack pop 取最後一個元素，所以反轉顯示 draw order（index 0 = 下一張抽的）
+        List<String> drawOrder = new ArrayList<>();
+        for (int i = cards.size() - 1; i >= 0; i--) {
+            drawOrder.add(cards.get(i).getGeneralId());
+        }
+
+        return ResponseEntity.ok(new GeneralCardDeckResponse(gameId, drawOrder.size(), drawOrder));
+    }
+
+    @PutMapping("/api/debug/games/{gameId}/generalCardDeck")
+    public ResponseEntity<?> setGeneralCardDeck(@PathVariable String gameId,
+                                                @RequestBody SetGeneralCardDeckRequest request) {
+        Game game = gameRepository.findById(gameId)
+                .orElseThrow(() -> new RuntimeException("Game not found: " + gameId));
+
+        List<String> generalIds = request.getGeneralIds();
+        if (generalIds == null) {
+            return ResponseEntity.badRequest().body(Map.of("message", "generalIds is required"));
+        }
+
+        // 反序 push，讓 generalIds[0] 在 stack top（下一張抽的）
+        Stack<GeneralCard> stack = new Stack<>();
+        for (int i = generalIds.size() - 1; i >= 0; i--) {
+            String id = generalIds.get(i);
+            General general;
+            try {
+                general = General.findById(id);
+            } catch (IllegalArgumentException e) {
+                return ResponseEntity.badRequest().body(Map.of("message", "Invalid general ID: " + id));
+            }
+            GeneralCard card = new GeneralCard(general);
+            GeneralCard.generals.put(id, card); // 選將流程以此 map 反查
+            stack.push(card);
+        }
+
+        GeneralCardDeck newDeck = new GeneralCardDeck();
+        newDeck.setGeneralStack(stack);
+        game.setGeneralCardDeck(newDeck);
+        gameRepository.save(game);
+
+        return ResponseEntity.ok(new GeneralCardDeckResponse(gameId, generalIds.size(), generalIds));
     }
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/GeneralCardDeckResponse.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/GeneralCardDeckResponse.java
@@ -1,0 +1,14 @@
+package com.gaas.threeKingdoms.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class GeneralCardDeckResponse {
+    private String gameId;
+    private int deckSize;
+    private List<String> generalIds;
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/SetGeneralCardDeckRequest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/dto/SetGeneralCardDeckRequest.java
@@ -1,0 +1,12 @@
+package com.gaas.threeKingdoms.controller.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class SetGeneralCardDeckRequest {
+    private List<String> generalIds;
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/DebugGeneralCardDeckApiTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/DebugGeneralCardDeckApiTest.java
@@ -1,0 +1,109 @@
+package com.gaas.threeKingdoms.e2e;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.generalcard.GeneralCard;
+import com.gaas.threeKingdoms.generalcard.GeneralCardDeck;
+import com.gaas.threeKingdoms.player.HealthStatus;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.rolecard.Role;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import java.util.Arrays;
+
+import static com.gaas.threeKingdoms.e2e.MockUtil.createPlayer;
+import static com.gaas.threeKingdoms.e2e.MockUtil.initGame;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** 武將牌堆 debug API（對應 DebugDeckApiTest 的 deck 版本）。 */
+public class DebugGeneralCardDeckApiTest extends AbstractBaseIntegrationTest {
+
+    @Test
+    public void testGetGeneralCardDeck_ReturnsDrawOrder() throws Exception {
+        givenGameWithKnownGeneralCardDeck();
+
+        mockMvc.perform(get("/api/debug/games/" + gameId + "/generalCardDeck"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.gameId").value(gameId))
+                .andExpect(jsonPath("$.deckSize").value(3))
+                // Stack push 順序：關羽(底) → 張飛 → 趙雲(頂)，pop 先取頂
+                .andExpect(jsonPath("$.generalIds[0]").value("SHU005"))
+                .andExpect(jsonPath("$.generalIds[1]").value("SHU003"))
+                .andExpect(jsonPath("$.generalIds[2]").value("SHU002"));
+    }
+
+    @Test
+    public void testSetGeneralCardDeck_ReplacesDeckAndReturnsNewOrder() throws Exception {
+        givenGameWithKnownGeneralCardDeck();
+
+        mockMvc.perform(put("/api/debug/games/" + gameId + "/generalCardDeck")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "generalIds": ["WEI002", "SHU001"] }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.deckSize").value(2))
+                .andExpect(jsonPath("$.generalIds[0]").value("WEI002"))
+                .andExpect(jsonPath("$.generalIds[1]").value("SHU001"));
+
+        // 驗證 GET 也反映新順序（經 MongoDB 存取）
+        mockMvc.perform(get("/api/debug/games/" + gameId + "/generalCardDeck"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.deckSize").value(2))
+                .andExpect(jsonPath("$.generalIds[0]").value("WEI002"))
+                .andExpect(jsonPath("$.generalIds[1]").value("SHU001"));
+    }
+
+    @Test
+    public void testSetGeneralCardDeck_InvalidGeneralId_Returns400() throws Exception {
+        givenGameWithKnownGeneralCardDeck();
+
+        mockMvc.perform(put("/api/debug/games/" + gameId + "/generalCardDeck")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "generalIds": ["SHU001", "NOPE"] }
+                                """))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.message").value("Invalid general ID: NOPE"));
+    }
+
+    @Test
+    public void testSetGeneralCardDeck_EmptyList_ClearsDeck() throws Exception {
+        givenGameWithKnownGeneralCardDeck();
+
+        mockMvc.perform(put("/api/debug/games/" + gameId + "/generalCardDeck")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "generalIds": [] }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.deckSize").value(0))
+                .andExpect(jsonPath("$.generalIds", hasSize(0)));
+    }
+
+    @Test
+    public void testGetGeneralCardDeck_GameNotFound_Returns4xx() throws Exception {
+        mockMvc.perform(get("/api/debug/games/nonexistent/generalCardDeck"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    private void givenGameWithKnownGeneralCardDeck() {
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH);
+        Player playerB = createPlayer("player-b", 4, General.劉備, HealthStatus.ALIVE, Role.TRAITOR);
+        Player playerC = createPlayer("player-c", 4, General.劉備, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.劉備, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        GeneralCardDeck deck = new GeneralCardDeck();
+        deck.getGeneralStack().push(new GeneralCard(General.關羽));
+        deck.getGeneralStack().push(new GeneralCard(General.張飛));
+        deck.getGeneralStack().push(new GeneralCard(General.趙雲));
+        game.setGeneralCardDeck(deck);
+        repository.save(game);
+    }
+}


### PR DESCRIPTION
## 摘要

使用者需求：GeneralCardDeck 要跟 Deck 一樣有「查看」與「修改」的 debug API。與 `/api/debug/games/{gameId}/deck` 完全同形：

| Method | Path | 說明 |
|---|---|---|
| GET | `/api/debug/games/{gameId}/generalCardDeck` | `{gameId, deckSize, generalIds}`，`generalIds[0]` = 下一張被抽的武將 |
| PUT | `/api/debug/games/{gameId}/generalCardDeck` | body `{generalIds: [...]}` 全量替換；無效 id → 400 `{"message":"Invalid general ID: X"}`；允許重複、允許空 |

## 實作
- `DebugController` 新增兩個 endpoint + `GeneralCardDeckResponse` / `SetGeneralCardDeckRequest` DTO
- PUT 反序 push 讓 `generalIds[0]` 在 stack top；同時登錄 `GeneralCard.generals`（`monarchChoosePlayerGeneral` / `otherChoosePlayerGeneral` 以此 map 反查）
- 持久化沿用既有 `GeneralCardDeckData`（stack 順序 round-trip 已由測試驗證）

## ⚠️ 可用時機（API_DOC 已載明）
主公的 5 張候選在 **建立遊戲（POST /api/games）同一 request** 就抽走了，所以本 API 能控制的是**主公選將之後其他三位玩家各抽的 3 張**（主公下家起座位順序）。若也要控制主公候選，需改 create-game 流程（另議）。

## 測試
- `DebugGeneralCardDeckApiTest` ×5：GET 抽牌順序 / PUT 覆蓋並經 MongoDB 存取後 GET 一致 / 無效 id 400 / 空列表清空 / 不存在 game 4xx
- 純 spring 層變更，domain 不動
- `API_DOC.md` 新增 §20.1 / §20.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)