### PR TITLE
fix: 鬼才/奸雄 resolve 後推播的 activePlayer 停在被詢問者

### DIFF
--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingJianXiongResponseBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingJianXiongResponseBehavior.java
@@ -99,6 +99,16 @@ public class WaitingJianXiongResponseBehavior extends Behavior {
             });
         }
 
+        // 最終狀態快照（polling resume 會改 activePlayer；presenter 取最後一個 GameStatusEvent）
+        String skillMessage = "奸雄結算";
+        for (DomainEvent e : events) { // 沿用奸雄自己的訊息（第一則 status），只刷新 round / seats 快照
+            if (e instanceof com.gaas.threeKingdoms.events.GameStatusEvent status) {
+                skillMessage = status.getMessage();
+                break;
+            }
+        }
+        events.add(game.getGameStatusEvent(skillMessage));
+
         isOneRound = true;
         return events;
     }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingSkillEffectBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingSkillEffectBehavior.java
@@ -70,8 +70,23 @@ public class WaitingSkillEffectBehavior extends Behavior {
             });
         }
 
+        // 最終狀態快照：技能 resolve 可能先發 GameStatusEvent 再推進（鬼才 resume 判定、
+        // 反饋 AOE resume 輪詢），presenter 取最後一個 GameStatusEvent 才能拿到正確的
+        // activePlayer / HP（使用者回報：鬼才換牌後 activePlayer 停在司馬懿）
+        events.add(game.getGameStatusEvent(firstStatusMessage(events, skillName + " 結算")));
+
         isOneRound = true;
         return events;
+    }
+
+    /** 沿用技能自己的訊息（第一則 status），只刷新 round / seats 快照。 */
+    private static String firstStatusMessage(List<DomainEvent> events, String fallback) {
+        for (DomainEvent e : events) {
+            if (e instanceof com.gaas.threeKingdoms.events.GameStatusEvent status) {
+                return status.getMessage();
+            }
+        }
+        return fallback;
     }
 
     private ChoiceResolvableSkill findSkill() {

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/GuiCaiSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/GuiCaiSkillTest.java
@@ -6,6 +6,7 @@ import com.gaas.threeKingdoms.events.AskSkillEffectEvent;
 import com.gaas.threeKingdoms.events.ContentmentEvent;
 import com.gaas.threeKingdoms.events.DomainEvent;
 import com.gaas.threeKingdoms.events.EightDiagramTacticEffectEvent;
+import com.gaas.threeKingdoms.events.GameStatusEvent;
 import com.gaas.threeKingdoms.events.LightningEvent;
 import com.gaas.threeKingdoms.events.LightningTransferredEvent;
 import com.gaas.threeKingdoms.events.SkillEffectEvent;
@@ -233,6 +234,31 @@ public class GuiCaiSkillTest extends PassiveSkillTestBase {
         assertTrue(effect.isSuccess(), "替換成紅心 → 八卦陣成功");
         assertEquals(4, b.getHP(), "視為出閃，不受傷");
         assertTrue(game.isTopBehaviorEmpty(), "殺已結算完畢");
+    }
+
+    @DisplayName("使用者回報：鬼才換牌結束後 activePlayer 應回到回合主 A（最後一個 GameStatusEvent 快照）")
+    @Test
+    public void guiCaiResolveFinalStatusSnapshotHasActivePlayerA() {
+        Game game = createGame(General.甘寧, General.孫權, General.司馬懿, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getEquipment().setArmor(new EightDiagramTactic(EC2067));
+        game.getPlayer("player-c").getHand().addCardToHand(new Peach(BH3029));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.getDeck().add(List.of(new Kill(BS9009)));
+        game.playerUseEquipment("player-b", EC2067.getCardId(), "player-b", EquipmentPlayType.ACTIVE);
+        assertEquals("player-c", game.getCurrentRound().getActivePlayer().getId(), "鬼才詢問中");
+
+        List<DomainEvent> events = game.playerUseSkillEffect(
+                "player-c", "鬼才", "ACCEPT", List.of(BH3029.getCardId()), null);
+
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId());
+        GameStatusEvent last = events.stream().filter(e -> e instanceof GameStatusEvent)
+                .map(e -> (GameStatusEvent) e).reduce((x, y) -> y).orElseThrow();
+        assertEquals("player-a", last.getRound().getActivePlayer(),
+                "presenter 取最後一個 GameStatusEvent → 須為推進後的最終狀態（回合主 A）");
     }
 
     @DisplayName("鬼才 SKIP → 原黑桃判定八卦陣失敗，續問閃")

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseJianXiongEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseJianXiongEffectPresenter.java
@@ -24,7 +24,9 @@ public class UseJianXiongEffectPresenter implements UseJianXiongEffectUseCase.Us
     public void renderEvents(List<DomainEvent> events) {
         List<ViewModel<?>> effectViewModels = domainEventToViewModelMapper.mapEventsToViewModels(events);
 
-        GameStatusEvent gameStatusEvent = getEvent(events, GameStatusEvent.class).orElseThrow();
+        // 取最後一個 GameStatusEvent = 技能 resolve + 後續推進（判定 resume / 輪詢 resume）後的最終狀態；
+        // 第一個可能是推進前的快照（activePlayer 仍為被詢問者）
+        GameStatusEvent gameStatusEvent = lastGameStatusEvent(events);
         List<PlayerEvent> playerEvents = gameStatusEvent.getSeats();
         RoundEvent roundEvent = gameStatusEvent.getRound();
         List<PlayerDataViewModel> playerDataViewModels = playerEvents.stream().map(PlayerDataViewModel::new).toList();
@@ -92,5 +94,13 @@ public class UseJianXiongEffectPresenter implements UseJianXiongEffectUseCase.Us
         private String playerId;
         private java.util.List<String> sourceCardIds;
         private boolean taken;
+    }
+    private static GameStatusEvent lastGameStatusEvent(List<DomainEvent> events) {
+        for (int i = events.size() - 1; i >= 0; i--) {
+            if (events.get(i) instanceof GameStatusEvent status) {
+                return status;
+            }
+        }
+        throw new IllegalStateException("No GameStatusEvent in events");
     }
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseSkillEffectPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/UseSkillEffectPresenter.java
@@ -24,7 +24,9 @@ public class UseSkillEffectPresenter implements UseSkillEffectUseCase.UseSkillEf
     public void renderEvents(List<DomainEvent> events) {
         List<ViewModel<?>> effectViewModels = domainEventToViewModelMapper.mapEventsToViewModels(events);
 
-        GameStatusEvent gameStatusEvent = getEvent(events, GameStatusEvent.class).orElseThrow();
+        // 取最後一個 GameStatusEvent = 技能 resolve + 後續推進（判定 resume / 輪詢 resume）後的最終狀態；
+        // 第一個可能是推進前的快照（activePlayer 仍為被詢問者）
+        GameStatusEvent gameStatusEvent = lastGameStatusEvent(events);
         List<PlayerEvent> playerEvents = gameStatusEvent.getSeats();
         RoundEvent roundEvent = gameStatusEvent.getRound();
         List<PlayerDataViewModel> playerDataViewModels = playerEvents.stream().map(PlayerDataViewModel::new).toList();
@@ -96,5 +98,13 @@ public class UseSkillEffectPresenter implements UseSkillEffectUseCase.UseSkillEf
         private boolean accepted;
         private List<String> dataCardIds;
         private String dataPlayerId;
+    }
+    private static GameStatusEvent lastGameStatusEvent(List<DomainEvent> events) {
+        for (int i = events.size() - 1; i >= 0; i--) {
+            if (events.get(i) instanceof GameStatusEvent status) {
+                return status;
+            }
+        }
+        throw new IllegalStateException("No GameStatusEvent in events");
     }
 }

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/GuiCaiEightDiagramActivePlayerTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/GuiCaiEightDiagramActivePlayerTest.java
@@ -1,0 +1,102 @@
+package com.gaas.threeKingdoms.e2e.skill;
+
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.Deck;
+import com.gaas.threeKingdoms.handcard.EquipmentPlayType;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic;
+import com.gaas.threeKingdoms.player.HealthStatus;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.rolecard.Role;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.gaas.threeKingdoms.e2e.MockUtil.createPlayer;
+import static com.gaas.threeKingdoms.e2e.MockUtil.initGame;
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 使用者回報：A 回合 A 殺 B（八卦陣），C=司馬懿 鬼才換牌結束後，activePlayer 停在 C 而非回到 A。
+ */
+public class GuiCaiEightDiagramActivePlayerTest extends AbstractBaseIntegrationTest {
+
+    private void givenAKillsBWithEightDiagram_andCIsSimaYi() throws Exception {
+        Player playerA = createPlayer("player-a", 4, General.甘寧, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008), new Peach(BH4030));
+        Player playerB = createPlayer("player-b", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER);
+        playerB.getEquipment().setArmor(new EightDiagramTactic(EC2067));
+        Player playerC = createPlayer("player-c", 4, General.司馬懿, HealthStatus.ALIVE, Role.REBEL,
+                new Peach(BH3029));
+        Player playerD = createPlayer("player-d", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Kill(BS9009))); // 八卦陣判定牌：黑桃 → 原本失敗
+        game.setDeck(deck);
+        repository.save(game);
+
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+        mockMvcUtil.useEquipment(gameId, "player-b", "player-b", "EC2067", EquipmentPlayType.ACTIVE)
+                .andExpect(status().isOk());
+
+        Game paused = repository.findById(gameId).orElseThrow();
+        assertEquals("player-c", paused.getCurrentRound().getActivePlayer().getId(), "鬼才詢問中 activePlayer = C");
+    }
+
+    private void guiCai(String choice, String cardIdsJson) throws Exception {
+        mockMvc.perform(post("/api/games/" + gameId + "/player:useSkillEffect")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ \"playerId\": \"player-c\", \"skillName\": \"鬼才\", \"choice\": \"" + choice + "\""
+                                + (cardIdsJson == null ? "" : ", \"cardIds\": " + cardIdsJson) + " }"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void guiCaiAcceptMakesEightDiagramSucceed_activePlayerBackToA() throws Exception {
+        givenAKillsBWithEightDiagram_andCIsSimaYi();
+
+        guiCai("ACCEPT", "[\"BH3029\"]"); // 紅心替換 → 八卦陣成功（視為出閃）
+
+        Game saved = repository.findById(gameId).orElseThrow();
+        assertEquals(4, saved.getPlayer("player-b").getHP());
+        assertTrue(saved.getTopBehavior().isEmpty(), "殺已結算");
+        assertEquals("player-a", saved.getCurrentRound().getActivePlayer().getId(),
+                "結算完 activePlayer 應回到回合主 A");
+
+        // A 應能繼續出牌（出桃自療驗證 activePlayer 檢查通過）
+        mockMvcUtil.playCard(gameId, "player-a", "player-a", "BH4030", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void guiCaiSkipEightDiagramFails_BAsksDodge_thenActivePlayerBackToA() throws Exception {
+        givenAKillsBWithEightDiagram_andCIsSimaYi();
+
+        guiCai("SKIP", null); // 黑桃 → 八卦陣失敗 → 問 B 出閃
+
+        Game afterSkip = repository.findById(gameId).orElseThrow();
+        assertFalse(afterSkip.getTopBehavior().isEmpty(), "等 B 回應出閃");
+        assertNotEquals("player-c", afterSkip.getCurrentRound().getActivePlayer().getId(),
+                "activePlayer 不應停在 C");
+
+        // B 不出閃 → 受傷 → 結算
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk());
+
+        Game saved = repository.findById(gameId).orElseThrow();
+        assertEquals(3, saved.getPlayer("player-b").getHP());
+        assertTrue(saved.getTopBehavior().isEmpty());
+        assertEquals("player-a", saved.getCurrentRound().getActivePlayer().getId(),
+                "結算完 activePlayer 應回到回合主 A");
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/presenter/UseSkillEffectPresenterTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/presenter/UseSkillEffectPresenterTest.java
@@ -1,0 +1,50 @@
+package com.gaas.threeKingdoms.presenter;
+
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.GameStatusEvent;
+import com.gaas.threeKingdoms.events.PlayerEvent;
+import com.gaas.threeKingdoms.events.RoundEvent;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.player.HealthStatus;
+import com.gaas.threeKingdoms.rolecard.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.gaas.threeKingdoms.e2e.MockUtil.createPlayer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 使用者回報：鬼才換牌結束後前端看到 activePlayer 停在司馬懿 —
+ * 技能 resolve 先發 GameStatusEvent（activePlayer=被詢問者）再推進，presenter 取第一個就拿到舊快照。
+ */
+public class UseSkillEffectPresenterTest {
+
+    private GameStatusEvent status(String activePlayer, String message) {
+        List<PlayerEvent> seats = List.of(
+                new PlayerEvent(createPlayer("player-a", 4, General.甘寧, HealthStatus.ALIVE, Role.MONARCH)),
+                new PlayerEvent(createPlayer("player-c", 4, General.司馬懿, HealthStatus.ALIVE, Role.REBEL)));
+        return new GameStatusEvent("g1", seats,
+                new RoundEvent("Action", "player-a", activePlayer, null, false), "Normal", message);
+    }
+
+    @DisplayName("多個 GameStatusEvent → round data 取最後一個（推進後的最終狀態）")
+    @Test
+    public void usesLastGameStatusEventForRoundData() {
+        List<DomainEvent> events = List.of(
+                status("player-c", "player-c 發動鬼才"),   // resume 前快照（舊）
+                status("player-a", "發動八卦陣效果"),      // 八卦陣結算後
+                status("player-a", "鬼才 結算"));          // 最終快照
+
+        UseSkillEffectPresenter presenter = new UseSkillEffectPresenter();
+        presenter.renderEvents(events);
+
+        for (UseSkillEffectPresenter.GameViewModel vm : presenter.present()) {
+            assertEquals("player-a", vm.getData().getRound().getActivePlayer(),
+                    "每位玩家收到的 round.activePlayer 應為最終狀態 A，而非第一個快照的 C");
+            assertEquals("鬼才 結算", vm.getMessage());
+        }
+        assertEquals(2, presenter.present().size());
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_a.json
@@ -63,7 +63,7 @@
     "round" : {
       "roundPhase" : "Judgement",
       "currentRoundPlayer" : "player-a",
-      "activePlayer" : "player-a",
+      "activePlayer" : "player-c",
       "dyingPlayer" : "",
       "showKill" : false
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_b.json
@@ -63,7 +63,7 @@
     "round" : {
       "roundPhase" : "Judgement",
       "currentRoundPlayer" : "player-a",
-      "activePlayer" : "player-a",
+      "activePlayer" : "player-c",
       "dyingPlayer" : "",
       "showKill" : false
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_c.json
@@ -63,7 +63,7 @@
     "round" : {
       "roundPhase" : "Judgement",
       "currentRoundPlayer" : "player-a",
-      "activePlayer" : "player-a",
+      "activePlayer" : "player-c",
       "dyingPlayer" : "",
       "showKill" : false
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_aoe_revived_accept_for_player_d.json
@@ -63,7 +63,7 @@
     "round" : {
       "roundPhase" : "Judgement",
       "currentRoundPlayer" : "player-a",
-      "activePlayer" : "player-a",
+      "activePlayer" : "player-c",
       "dyingPlayer" : "",
       "showKill" : false
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_a.json
@@ -63,7 +63,7 @@
     "round" : {
       "roundPhase" : "Judgement",
       "currentRoundPlayer" : "player-a",
-      "activePlayer" : "player-a",
+      "activePlayer" : "player-c",
       "dyingPlayer" : "",
       "showKill" : false
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_b.json
@@ -63,7 +63,7 @@
     "round" : {
       "roundPhase" : "Judgement",
       "currentRoundPlayer" : "player-a",
-      "activePlayer" : "player-a",
+      "activePlayer" : "player-c",
       "dyingPlayer" : "",
       "showKill" : false
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_c.json
@@ -63,7 +63,7 @@
     "round" : {
       "roundPhase" : "Judgement",
       "currentRoundPlayer" : "player-a",
-      "activePlayer" : "player-a",
+      "activePlayer" : "player-c",
       "dyingPlayer" : "",
       "showKill" : false
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/SkillTest/JianXiong/jianxiong_barbarian_accept_for_player_d.json
@@ -63,7 +63,7 @@
     "round" : {
       "roundPhase" : "Judgement",
       "currentRoundPlayer" : "player-a",
-      "activePlayer" : "player-a",
+      "activePlayer" : "player-c",
       "dyingPlayer" : "",
       "showKill" : false
     },


### PR DESCRIPTION
## 回報情境
A 回合，B 有八卦陣，C 是司馬懿。A 殺 B → 八卦陣判定 → C 鬼才換牌 → 結束後 `activePlayer` 停在 C，應回到 A。

## 根因
後端狀態其實正確（MongoDB `round.activePlayer = A`）。問題在**推播**：`GuiCaiSkill.resolveChoice` 在 ACCEPT 當下先發一個 `GameStatusEvent`（此時 activePlayer 仍是 C），之後 resume 八卦陣結算才把 activePlayer 設回 A 並再發一個 status；`UseSkillEffectPresenter` 用 `getEvent(...)` 取**第一個** `GameStatusEvent` → 前端拿到過期快照。

同型問題也存在於反饋 AOE resume（#221）與奸雄 AOE resume（#209）：技能自己的 status 在前，輪詢推進改 activePlayer 在後。

## 修法（通用）
| 層 | 變更 |
|---|---|
| `WaitingSkillEffectBehavior.resolveChoice` | 全部推進完後補一個最終狀態 `GameStatusEvent`（沿用技能第一則訊息，只刷新 round/seats） |
| `WaitingJianXiongResponseBehavior.resolveChoice` | 同上 |
| `UseSkillEffectPresenter` / `UseJianXiongEffectPresenter` | 改取**最後一個** `GameStatusEvent` |

Mapper 不把 `GameStatusEvent` 轉成 per-event view model，多一則快照對前端訊息流無副作用。

## Fixture
8 個 `JianXiong/jianxiong_{barbarian,aoe_revived}_accept_for_player_*.json` 各改一行：`activePlayer: player-a → player-c`。原 fixture 錄到的是這個 bug（奸雄 ACCEPT 後輪詢已推進到 C，卻推播 A）。

## 測試
- 新 e2e `GuiCaiEightDiagramActivePlayerTest` ×2：ACCEPT（八卦陣成功）/ SKIP（失敗→B 出閃→結算）後 activePlayer 都回 A，且 A 能繼續出牌
- domain `GuiCaiSkillTest` +1：resolve 事件的最後一個 status 快照 activePlayer = A
- spring `UseSkillEffectPresenterTest` +1：多個 status → round data 取最後一個
- domain 530 全綠；spring 全套本地跑中，CI 把關

🤖 Generated with [Claude Code](https://claude.com/claude-code)