### PR TITLE
fix: 反饋在真實前端不觸發（skip 的 targetPlayerId 為空 → 傷害來源 null）+ dataCardIds/fallback 修正

### DIFF
--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
@@ -157,7 +157,7 @@ public class ArrowBarrageBehavior extends Behavior
 
         if (isSkip(playType)) {
             int originalHp = currentReactionPlayer.getHP();
-            List<DomainEvent> damagedEvent = game.getDamagedEvent(playerId, targetPlayerId, cardId, card, playType, originalHp, currentReactionPlayer, game.getCurrentRound(), Optional.of(this));
+            List<DomainEvent> damagedEvent = game.getDamagedEvent(playerId, behaviorPlayer.getId(), cardId, card, playType, originalHp, currentReactionPlayer, game.getCurrentRound(), Optional.of(this));
 
             // 偵測 JianXiong 介入：若 WaitingJX 在 stack 頂，把 polling-advance 註冊為
             // callback，等 JianXiong 解決後再執行（避免覆蓋 activePlayer 與打亂 stack）

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
@@ -141,7 +141,7 @@ public class BarbarianInvasionBehavior extends Behavior implements com.gaas.thre
 
         if (isSkip(playType)) {
             int originalHp = currentReactionPlayer.getHP();
-            List<DomainEvent> damagedEvent = game.getDamagedEvent(playerId, targetPlayerId, cardId, card, playType, originalHp, currentReactionPlayer, game.getCurrentRound(), Optional.of(this));
+            List<DomainEvent> damagedEvent = game.getDamagedEvent(playerId, behaviorPlayer.getId(), cardId, card, playType, originalHp, currentReactionPlayer, game.getCurrentRound(), Optional.of(this));
 
             // 偵測 JianXiong 介入：若 WaitingJX 在 stack 頂，把 polling-advance 註冊為
             // callback，等 JianXiong 解決後再執行（避免覆蓋 activePlayer 與打亂 stack）

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/HeavenlyDoubleHalberdKillBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/HeavenlyDoubleHalberdKillBehavior.java
@@ -72,7 +72,7 @@ public class HeavenlyDoubleHalberdKillBehavior extends NormalActiveKillBehavior 
         if (isSkip(playType)) {
             int originalHp = currentReactionPlayer.getHP();
             List<DomainEvent> events = new ArrayList<>(
-                    game.getDamagedEvent(playerId, targetPlayerId, cardId, card, playType,
+                    game.getDamagedEvent(playerId, behaviorPlayer.getId(), cardId, card, playType,
                             originalHp, currentReactionPlayer, currentRound, Optional.of(this)));
 
             boolean isLast = isLastReactionPlayer(playerId);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
@@ -157,7 +157,7 @@ public class NormalActiveKillBehavior extends Behavior
                 return List.of(playCardEvent, askPlayEquipmentEffectEvent, game.getGameStatusEvent("出牌"));
             }
 
-            List<DomainEvent> events = game.getDamagedEvent(playerId, targetPlayerId, cardId, card, playType, originalHp, damagedPlayer, currentRound, Optional.of(this));
+            List<DomainEvent> events = game.getDamagedEvent(playerId, behaviorPlayer.getId(), cardId, card, playType, originalHp, damagedPlayer, currentRound, Optional.of(this));
             String message = game.getGamePhase().getPhaseName().equals("GeneralDying") ? "扣血已瀕臨死亡" : "扣血但還活著";
             events.add(game.getGameStatusEvent(message));
             isOneRound = true;
@@ -169,7 +169,7 @@ public class NormalActiveKillBehavior extends Behavior
             return handleDodgeChain(playerId, playerId, cardId, playType);
         } else if (isQilinBowSuccess(playType)) {
             Round currentRound = game.getCurrentRound();
-            List<DomainEvent> events = game.getDamagedEvent(playerId, targetPlayerId, cardId, card, playType, originalHp, damagedPlayer, currentRound, Optional.of(this));
+            List<DomainEvent> events = game.getDamagedEvent(playerId, behaviorPlayer.getId(), cardId, card, playType, originalHp, damagedPlayer, currentRound, Optional.of(this));
             //playerDyingEvent
             String message = game.getGamePhase().getPhaseName().equals("GeneralDying") ? "扣血已瀕臨死亡" : "扣血但還活著";
             events.add(game.getGameStatusEvent(message));

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/FanKuiSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/FanKuiSkill.java
@@ -76,9 +76,9 @@ public class FanKuiSkill implements OnDamagedSkill, ChoiceResolvableSkill {
         game.updateTopBehavior(waiting);
         game.getCurrentRound().setActivePlayer(damaged);
 
-        // 展示可取的裝備（手牌隱藏不展示內容）
+        // 展示可取的裝備（只列實際存在的裝備 id；手牌隱藏不展示內容）
         return List.of(new AskSkillEffectEvent(SKILL_NAME, damaged.getId(),
-                attacker.getEquipment().getAllEquipmentCardIds(), attacker.getId()));
+                equipmentIds(attacker), attacker.getId()));
     }
 
     @Override
@@ -93,7 +93,7 @@ public class FanKuiSkill implements OnDamagedSkill, ChoiceResolvableSkill {
         if ("ACCEPT".equals(choice)) {
             String takenCardId;
             String pick = (cardIds != null && !cardIds.isEmpty()) ? cardIds.get(0) : null;
-            if (pick != null && attacker.getEquipment().getAllEquipmentCardIds().contains(pick)) {
+            if (pick != null && equipmentIds(attacker).contains(pick)) {
                 takenCardId = takeEquipment(attacker, simaYi, pick);
             } else if (pick != null && pick.matches("\\d+")) {
                 // 手牌 index（0-based，同順手牽羊 targetCardIndex）
@@ -108,8 +108,7 @@ public class FanKuiSkill implements OnDamagedSkill, ChoiceResolvableSkill {
             } else if (attacker.getHandSize() > 0) {
                 takenCardId = takeHandCard(attacker, simaYi, 0);
             } else if (attacker.getEquipment().hasAnyEquipment()) {
-                takenCardId = takeEquipment(attacker, simaYi,
-                        attacker.getEquipment().getAllEquipmentCardIds().get(0));
+                takenCardId = takeEquipment(attacker, simaYi, equipmentIds(attacker).get(0));
             } else {
                 throw new IllegalStateException("attacker has no card to take");
             }
@@ -123,6 +122,13 @@ public class FanKuiSkill implements OnDamagedSkill, ChoiceResolvableSkill {
             throw new IllegalArgumentException("Invalid FanKui choice: " + choice);
         }
         return events;
+    }
+
+    /** 來源實際存在的裝備 id（getAllEquipmentCardIds 會以 "" 佔位空欄，不可直接拿來選/取）。 */
+    private static List<String> equipmentIds(Player player) {
+        return player.getEquipment().getAllEquipmentCards().stream()
+                .map(HandCard::getId)
+                .toList();
     }
 
     private String takeHandCard(Player from, Player to, int index) {

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/FanKuiAoePollingTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/FanKuiAoePollingTest.java
@@ -100,6 +100,21 @@ public class FanKuiAoePollingTest {
         assertTrue(game.getTopBehavior().isEmpty());
     }
 
+    @DisplayName("南蠻：前端 skip 時 targetPlayerId 為空字串 → 來源仍為出南蠻者，反饋照常詢問（使用者回報）")
+    @Test
+    public void fanKuiAskedInBarbarianInvasion_whenSkipHasEmptyTargetPlayerId() {
+        Game game = createGame(General.甘寧, General.司馬懿, General.孫權, General.孫權);
+        game.getPlayer("player-a").getHand()
+                .addCardToHand(List.of(new BarbarianInvasion(SS7007), new Peach(BH3029)));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        List<DomainEvent> e2 = game.playerPlayCard("player-b", "", "", PlayType.SKIP.getPlayType());
+
+        assertTrue(hasFanKuiAsk(e2), "targetPlayerId 空字串也應詢問反饋");
+        List<DomainEvent> e3 = game.playerUseSkillEffect("player-b", "反饋", "ACCEPT", null, null);
+        assertEquals(List.of("player-c"), askKillTargets(e3), "resume 輪詢問 c");
+    }
+
     @DisplayName("南蠻：反饋 SKIP → 一樣 resume 輪詢問 c")
     @Test
     public void fanKuiSkipInBarbarianInvasion_thenNextAskedIsC() {

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch2TriggeredSkillsTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch2TriggeredSkillsTest.java
@@ -135,6 +135,39 @@ public class Batch2TriggeredSkillsTest extends PassiveSkillTestBase {
         assertEquals(1, a.getHandSize());
     }
 
+    @DisplayName("反饋詢問的 dataCardIds 只列實際存在的裝備 id（不含空欄位 \"\"）")
+    @Test
+    public void fanKuiAskListsOnlyExistingEquipmentIds() {
+        Game game = createGame(General.劉備, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        a.getEquipment().setArmor(new com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic(EC2067));
+
+        List<DomainEvent> events = killAndSkip(game, "player-a", "player-b");
+
+        AskSkillEffectEvent ask = events.stream()
+                .filter(e -> e instanceof AskSkillEffectEvent).map(e -> (AskSkillEffectEvent) e)
+                .findFirst().orElseThrow();
+        assertEquals(List.of(EC2067.getCardId()), ask.getDataCardIds(), "只有防具一件，不該有 \"\" 佔位");
+    }
+
+    @DisplayName("來源無手牌、只有防具（武器欄空）→ 反饋 ACCEPT 不指定也能取到防具（修 fallback 取到 \"\" 噴錯）")
+    @Test
+    public void fanKuiFallbackTakesFirstExistingEquipment() {
+        Game game = createGame(General.劉備, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008)); // 出殺後無手牌
+        a.getEquipment().setArmor(new com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic(EC2067));
+
+        killAndSkip(game, "player-a", "player-b");
+        game.playerUseSkillEffect("player-b", "反饋", "ACCEPT", null, null);
+
+        assertTrue(b.getHand().getCards().stream().anyMatch(c -> c.getId().equals(EC2067.getCardId())),
+                "取走唯一的裝備（防具）");
+        assertFalse(a.getEquipment().hasAnyEquipment());
+    }
+
     // ===== 遺計 =====
 
     @DisplayName("郭嘉受傷 → 遺計 ACCEPT 摸兩張")

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch2TriggeredSkillsTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch2TriggeredSkillsTest.java
@@ -168,6 +168,22 @@ public class Batch2TriggeredSkillsTest extends PassiveSkillTestBase {
         assertFalse(a.getEquipment().hasAnyEquipment());
     }
 
+    @DisplayName("使用者回報：前端 skip 時 targetPlayerId 為空字串 → 傷害來源仍應為出殺者，反饋照常詢問")
+    @Test
+    public void fanKuiAskedWhenSkipHasEmptyTargetPlayerId() {
+        Game game = createGame(General.劉備, General.司馬懿, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(Arrays.asList(new Kill(BS8008), new Peach(BH3029)));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        List<DomainEvent> events = game.playerPlayCard("player-b", "", "", "skip"); // targetPlayerId = ""
+
+        assertTrue(events.stream().anyMatch(e -> e instanceof AskSkillEffectEvent
+                && ((AskSkillEffectEvent) e).getSkillName().equals("反饋")
+                && "player-a".equals(((AskSkillEffectEvent) e).getDataPlayerId())),
+                "來源應由 behavior 記錄的出殺者決定，不依賴 request 的 targetPlayerId");
+    }
+
     // ===== 遺計 =====
 
     @DisplayName("郭嘉受傷 → 遺計 ACCEPT 摸兩張")

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/MockMvcUtil.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/MockMvcUtil.java
@@ -194,6 +194,23 @@ public class MockMvcUtil {
                         }""", currentPlayerId, targetPlayerId, cardId, playType.getPlayType())));
     }
 
+    /** 通用武將技回應 endpoint；cardIds / targetPlayerId 可為 null。 */
+    public ResultActions useSkillEffect(String gameId, String playerId, String skillName, String choice,
+                                        java.util.List<String> cardIds, String targetPlayerId) throws Exception {
+        String cardIdsJson = cardIds == null ? "null"
+                : "[" + cardIds.stream().map(id -> "\"" + id + "\"").collect(java.util.stream.Collectors.joining(",")) + "]";
+        String targetJson = targetPlayerId == null ? "null" : "\"" + targetPlayerId + "\"";
+        return this.mockMvc.perform(post("/api/games/" + gameId + "/player:useSkillEffect")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(String.format("""
+                        { "playerId": "%s",
+                          "skillName": "%s",
+                          "choice": "%s",
+                          "cardIds": %s,
+                          "targetPlayerId": %s
+                        }""", playerId, skillName, choice, cardIdsJson, targetJson)));
+    }
+
     public ResultActions chooseHorse(String gameId, String currentPlayerId, String cardId) throws Exception {
         return this.mockMvc.perform(post("/api/games/" + gameId + "/player:chooseHorseCard")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/FanKuiAskPushTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/FanKuiAskPushTest.java
@@ -1,0 +1,90 @@
+package com.gaas.threeKingdoms.e2e.skill;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.Deck;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.equipmentcard.armorcard.EightDiagramTactic;
+import com.gaas.threeKingdoms.player.HealthStatus;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.rolecard.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.gaas.threeKingdoms.e2e.MockUtil.createPlayer;
+import static com.gaas.threeKingdoms.e2e.MockUtil.initGame;
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 使用者回報：A 用殺打 B（司馬懿），B 不出閃扣血，前端沒收到發動武將技的 event。
+ * 本測試直接驗證 websocket 推播內容：B 不出閃那個 request 後，每位玩家都應收到
+ * AskSkillEffectEvent(skillName=反饋, playerId=B)，且 round.activePlayer = B。
+ */
+public class FanKuiAskPushTest extends AbstractBaseIntegrationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @DisplayName("A 殺 B（司馬懿 3HP），B skip 扣血 → 推播含 AskSkillEffectEvent(反饋)，activePlayer=B")
+    @Test
+    public void skipAfterKill_pushesFanKuiAskToAllPlayers() throws Exception {
+        Player playerA = createPlayer("player-a", 4, General.甘寧, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008), new Peach(BH4030));
+        playerA.getEquipment().setArmor(new EightDiagramTactic(EC2067)); // 有一件裝備可被反饋指定
+        Player playerB = createPlayer("player-b", 3, General.司馬懿, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.孫權, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        game.setDeck(new Deck());
+        repository.save(game);
+
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+        websocketUtil.popAllPlayerMessage();
+
+        // B 不出閃
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk());
+
+        for (String playerId : List.of("player-a", "player-b", "player-c", "player-d")) {
+            JsonNode push = objectMapper.readTree(websocketUtil.getValue(playerId));
+
+            JsonNode ask = null;
+            for (JsonNode e : push.get("events")) {
+                if ("AskSkillEffectEvent".equals(e.get("event").asText())) {
+                    ask = e;
+                }
+            }
+            assertNotNull(ask, playerId + " 應收到 AskSkillEffectEvent");
+            assertEquals("反饋", ask.get("data").get("skillName").asText());
+            assertEquals("player-b", ask.get("data").get("playerId").asText(), "被詢問者 = 司馬懿");
+            assertEquals("player-a", ask.get("data").get("dataPlayerId").asText(), "傷害來源 = A");
+            assertEquals(List.of(EC2067.getCardId()),
+                    objectMapper.convertValue(ask.get("data").get("dataCardIds"), List.class),
+                    "dataCardIds 只列來源實際存在的裝備 id（無 \"\" 佔位）");
+
+            assertEquals("player-b", push.get("data").get("round").get("activePlayer").asText(),
+                    "等待 B 回應反饋");
+            assertEquals(2, push.get("data").get("seats").get(1).get("hp").asInt(), "B 已扣血 3→2");
+        }
+
+        // B ACCEPT 指定拿 A 的防具 → 結算、activePlayer 回到 A
+        mockMvcUtil.useSkillEffect(gameId, "player-b", "反饋", "ACCEPT", List.of(EC2067.getCardId()), null)
+                .andExpect(status().isOk());
+        JsonNode after = objectMapper.readTree(websocketUtil.getValue("player-b"));
+        assertEquals("player-a", after.get("data").get("round").get("activePlayer").asText());
+        Game saved = repository.findById(gameId).orElseThrow();
+        assertTrue(saved.getPlayer("player-b").getHand().getCards().stream()
+                .anyMatch(c -> c.getId().equals(EC2067.getCardId())));
+        assertFalse(saved.getPlayer("player-a").getEquipment().hasAnyEquipment());
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/FanKuiFullFlowTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/FanKuiFullFlowTest.java
@@ -64,8 +64,8 @@ public class FanKuiFullFlowTest extends AbstractBaseIntegrationTest {
         mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", "active").andExpect(status().isOk());
         websocketUtil.popAllPlayerMessage();
 
-        // B 不出閃
-        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip").andExpect(status().isOk());
+        // B 不出閃 — 照前端實際 payload：targetPlayerId 為空字串（使用者回報的 JSON）
+        mockMvcUtil.playCard(gameId, "player-b", "", "", "skip").andExpect(status().isOk());
 
         JsonNode pushB = objectMapper.readTree(websocketUtil.getValue("player-b"));
         System.out.println("=== PUSH TO B (full flow) ===\n" + pushB.toPrettyString());

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/FanKuiFullFlowTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/FanKuiFullFlowTest.java
@@ -1,0 +1,91 @@
+package com.gaas.threeKingdoms.e2e.skill;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
+import com.gaas.threeKingdoms.utils.ShuffleWrapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 使用者回報（堅持可重現）：司馬懿被殺、不出閃、扣血後沒有反饋詢問。
+ * 不走 initGame 捷徑 — 完整 API 流程：建局 → 主公選將 → 其他選將（B=司馬懿）→ 發牌 → A 出殺 → B 不出閃。
+ */
+public class FanKuiFullFlowTest extends AbstractBaseIntegrationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @DisplayName("完整流程：A(劉備) 殺 B(司馬懿)，B skip 扣血 → 推播含 AskSkillEffectEvent(反饋)")
+    @Test
+    public void fullFlow_killSimaYi_skip_asksFanKui() throws Exception {
+        // 建局（shuffle 關掉 → 身分：player-a 主公）
+        try (MockedStatic<ShuffleWrapper> mocked = Mockito.mockStatic(ShuffleWrapper.class)) {
+            mocked.when(() -> ShuffleWrapper.shuffle(Mockito.anyList())).thenAnswer(inv -> null);
+            mockMvc.perform(post("/api/games").contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    { "gameId": "%s", "players": ["player-a","player-b","player-c","player-d"] }
+                                    """.formatted(gameId)))
+                    .andExpect(status().isOk());
+        }
+        websocketUtil.popAllPlayerMessage();
+
+        // 牌堆：發牌 a4/b4/c4/d4（A 第一張 = 殺）→ A 回合摸 2
+        mockMvc.perform(put("/api/debug/games/" + gameId + "/deck").contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "cardIds": ["BS8008","BH3029","BH4030","BH2028",
+                                              "BH6032","BH7033","BH8034","BH9035",
+                                              "BC2054","BC3055","BC4056","BC5057",
+                                              "BS7020","BS8021","BS9022","BS0023",
+                                              "BH0036","BHJ037"] }
+                                """))
+                .andExpect(status().isOk());
+
+        // 選將
+        chooseGeneral("player:monarchChooseGeneral", "player-a", "SHU001"); // 劉備
+        websocketUtil.popAllPlayerMessage();
+        chooseGeneral("player:otherChooseGeneral", "player-b", "WEI002");   // 司馬懿
+        chooseGeneral("player:otherChooseGeneral", "player-c", "WU001");
+        chooseGeneral("player:otherChooseGeneral", "player-d", "WU002");    // 最後一位 → 發牌、A 回合開始
+        websocketUtil.popAllPlayerMessage();
+        websocketUtil.popAllPlayerMessage();
+        websocketUtil.popAllPlayerMessage();
+
+        // A 出殺打 B
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", "active").andExpect(status().isOk());
+        websocketUtil.popAllPlayerMessage();
+
+        // B 不出閃
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip").andExpect(status().isOk());
+
+        JsonNode pushB = objectMapper.readTree(websocketUtil.getValue("player-b"));
+        System.out.println("=== PUSH TO B (full flow) ===\n" + pushB.toPrettyString());
+
+        boolean asked = false;
+        for (JsonNode e : pushB.get("events")) {
+            if ("AskSkillEffectEvent".equals(e.get("event").asText())
+                    && "反饋".equals(e.get("data").get("skillName").asText())) {
+                asked = true;
+            }
+        }
+        assertTrue(asked, "B（司馬懿）skip 扣血後應收到 AskSkillEffectEvent(反饋)");
+        assertEquals("player-b", pushB.get("data").get("round").get("activePlayer").asText());
+    }
+
+    private void chooseGeneral(String action, String playerId, String generalId) throws Exception {
+        mockMvc.perform(post("/api/games/" + gameId + "/" + action).contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "playerId": "%s", "generalId": "%s" }
+                                """.formatted(playerId, generalId)))
+                .andExpect(status().isOk());
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_b_use_ArrowBarrage_player_c_skip_for_player_a.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_b_use_ArrowBarrage_player_c_skip_for_player_a.json
@@ -3,7 +3,7 @@
     "event" : "PlayCardEvent",
     "data" : {
       "playerId" : "player-c",
-      "targetPlayerId" : "",
+      "targetPlayerId" : "player-b",
       "cardId" : "",
       "playType" : "skip"
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_b_use_ArrowBarrage_player_c_skip_for_player_b.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_b_use_ArrowBarrage_player_c_skip_for_player_b.json
@@ -3,7 +3,7 @@
     "event" : "PlayCardEvent",
     "data" : {
       "playerId" : "player-c",
-      "targetPlayerId" : "",
+      "targetPlayerId" : "player-b",
       "cardId" : "",
       "playType" : "skip"
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_b_use_ArrowBarrage_player_c_skip_for_player_c.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_b_use_ArrowBarrage_player_c_skip_for_player_c.json
@@ -3,7 +3,7 @@
     "event" : "PlayCardEvent",
     "data" : {
       "playerId" : "player-c",
-      "targetPlayerId" : "",
+      "targetPlayerId" : "player-b",
       "cardId" : "",
       "playType" : "skip"
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_b_use_ArrowBarrage_player_c_skip_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/ArrowBarrage/player_b_use_ArrowBarrage_player_c_skip_for_player_d.json
@@ -3,7 +3,7 @@
     "event" : "PlayCardEvent",
     "data" : {
       "playerId" : "player-c",
-      "targetPlayerId" : "",
+      "targetPlayerId" : "player-b",
       "cardId" : "",
       "playType" : "skip"
     },

--- a/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/Barbarianinvasion/player_b_use_barbarian_player_c_skip_for_player_d.json
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/resources/TestJsonFile/ScrollTest/Barbarianinvasion/player_b_use_barbarian_player_c_skip_for_player_d.json
@@ -3,7 +3,7 @@
     "event" : "PlayCardEvent",
     "data" : {
       "playerId" : "player-c",
-      "targetPlayerId" : "",
+      "targetPlayerId" : "player-b",
       "cardId" : "",
       "playType" : "skip"
     },


### PR DESCRIPTION
## 根因（使用者回報 + websocket JSON 確認）
前端送「不出閃」時 `targetPlayerId` 是**空字串**：
```json
{ "event": "PlayCardEvent", "data": { "playerId": "Scolley", "targetPlayerId": "", "playType": "skip" } }
```
殺 / 南蠻 / 萬箭 / 方天畫戟的 skip 路徑把 request 的 `targetPlayerId` 直接當 `attackerPlayerId` 傳進 `getDamagedEvent` → `DamageContext.sourcePlayer = null` → `FanKuiSkill.onDamaged` 的 `attacker == null` 守門直接不觸發。既有 e2e 都送 `targetPlayerId = 攻擊者 id`，所以一直是綠的。奸雄從墓地取牌不靠 attacker，因此只有反饋（和遺計/剛烈的來源欄位）受影響；裸衣傷害加成與瀕死 `pendingAttackerPlayerId` 也同樣拿不到來源。

## 修法
5 個傷害點（`NormalActiveKillBehavior` ×2、`BarbarianInvasionBehavior`、`ArrowBarrageBehavior`、`HeavenlyDoubleHalberdKillBehavior`）改用 behavior 自己記錄的出牌者 `behaviorPlayer.getId()` 當傷害來源，不再信任 request 欄位。`PlayCardEvent` 顯示用的 `targetPlayerId` 維持原樣。

## 同 PR 順手修
- 反饋 `dataCardIds` 去掉 `""` 空欄佔位，只列實際存在的裝備 id
- 來源無手牌、只有防具（武器欄空）時 ACCEPT 不指定 → 原本取到 `""` 噴 `IllegalStateException`

## 測試
- `FanKuiFullFlowTest`（完整 API 流程：建局→選將→發牌→殺→skip，**skip 帶空 targetPlayerId 與前端一致**）→ 推播含 `AskSkillEffectEvent(反饋)`
- `FanKuiAskPushTest`（websocket 層）：四位玩家推播內容、activePlayer、ACCEPT 取裝備後回 A
- domain +4：殺/南蠻 skip 空 targetPlayerId 仍詢問、dataCardIds 只列實際裝備、fallback 取防具
- `MockMvcUtil.useSkillEffect` helper

## 前端對接提醒
反饋走通用 `AskSkillEffectEvent` + `data.skillName === "反饋"`；回應 `POST /player:useSkillEffect`（`cardIds[0]` = 來源手牌 index 或裝備 id，或 `SKIP`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fixture 變更（附帶）
南蠻/萬箭「全員 skip」的 5 個 fixture：skip 的 `PlayCardEvent.targetPlayerId` 從 `""`（原本只是回聲 request）改為攻擊者 id（`player-b`）— 因為 damage 事件現在帶的是 behavior 記錄的來源。前端若有讀此欄位，現在會拿到「你在回應誰」而非空字串。

青龍偃月刀 `testEightDiagramTacticSuccess_AttackerChoosesKill_TargetAskedEquipmentAgain` 在本地全套中偶發失敗、單獨 2/2 通過 — 既有 websocket 順序 flake，與本 PR 無關。