### PR TITLE
feat: 洛神改主動觸發 — 回合開始詢問是否發動，黑色收牌自動續判

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -675,6 +675,7 @@ POST /api/games/{gameId}/player:useSkillEffect
 | 激將（劉備主公技） | 主公劉備被南蠻/決鬥要求出殺時，依座位順序詢問蜀將 | `ACCEPT` / `DECLINE` | ACCEPT 必填 [殺 id]（蜀將手中） | — |
 | 流離（大喬） | 大喬成為殺目標、被問閃之前 | `ACCEPT` / `SKIP` | ACCEPT 必填 [要棄的手牌 id] | ACCEPT 必填：轉移目標（距離 1 內、非攻擊者） |
 | 鬼才（司馬懿） | 任意角色判定牌抽出後、生效前（閃電 / 樂不思蜀 / 八卦陣 / 鐵騎 / 剛烈 / 洛神；dataCardIds = [原判定牌]、dataPlayerId = 判定所屬玩家） | `ACCEPT` / `SKIP` | ACCEPT 必填 [替換用手牌 id] | — |
+| 洛神（甄姬） | 甄姬回合開始、延遲錦囊（閃電/樂不思蜀）判定之前（issue #227） | `ACCEPT`（開始判定：黑色收入手牌自動續判、紅色停，不逐輪詢問）/ `SKIP` | — | — |
 | 護駕（曹操主公技）發動詢問 | 主公曹操被要求出閃、且有其他存活魏將時（issue #217） | `ACCEPT`（開始魏將輪詢，見 §21）/ `SKIP`（自己出閃） | — | — |
 
 ### 自動觸發技（無需呼叫本 API，僅廣播 `SkillEffectEvent`）
@@ -682,7 +683,6 @@ POST /api/games/{gameId}/player:useSkillEffect
 | 武將 | 技能 | 行為 |
 |---|---|---|
 | 郭嘉 | 天妒 | 自己判定牌生效後自動收入手牌（閃電 / 樂不思蜀 / 剛烈判定） |
-| 甄姬 | 洛神 | 回合開始自動判定：黑色收入手牌續判、紅色停 |
 | 馬超 | 鐵騎 | 出殺指定目標後自動判定：非紅桃 → 目標不能出閃直接結算 |
 | 孫尚香 | 梟姬 | 失去裝備（被拆 / 被順 / 被反饋取走）自動摸 2 |
 | 孫權 | 救援 | 主公技。主公孫權瀕死時，其他吳勢力對其使用的桃回復效果 +1（自動加成，出桃仍走 playCard） |
@@ -727,6 +727,7 @@ POST /api/games/{gameId}/player:useSkillEffect
 - 救援採官方標準版語意（桃效果 +1）；issue 原文描述的「可出桃給其」即既有瀕死求桃流程
 - 鬼才覆蓋全部判定路徑：閃電 / 樂不思蜀（皆含 Ward 路徑）/ 八卦陣 / 鐵騎 / 剛烈 / 洛神；
   洛神多張判定牌逐張詢問；同一次判定僅詢問一次（官方 FAQ）
+- 洛神為發動詢問一次（ACCEPT 後黑收自動續判）；判定中每張判定牌仍逐張過鬼才暫停點
 - 武聖/奇襲 v1 限手牌（裝備區紅/黑牌轉化 follow-up）；轉化殺的奸雄取牌為 follow-up
 - 轉化殺的傷害結算以 VirtualKill 進行；事件中 cardId 為來源真實牌
 
@@ -817,7 +818,7 @@ Stack trace 僅記錄於 server log。
 | `HeavenlyDoubleHalberdKillTriggerEvent` | 方天畫戟發動，多目標殺（含 attackerPlayerId、cardId、targetPlayerIds） |
 | `JianXiongEffectEvent` | 奸雄結算結果（含 `playerId`、`sourceCardIds : List<String>`、`taken`） |
 | `HuJiaEffectEvent` | 護駕回應結果（含 `playerId`、`caoCaoPlayerId`、`accepted`、`dodgeCardId`） |
-| `SkillEffectEvent` | 通用武將技結算結果（含 `skillName`、`playerId`、`accepted`、`dataCardIds`、`dataPlayerId`）— 含自動觸發技（天妒/洛神/鐵騎/梟姬/救援/馬術等鎖定技不發事件，僅結果可觀察） |
+| `SkillEffectEvent` | 通用武將技結算結果（含 `skillName`、`playerId`、`accepted`、`dataCardIds`、`dataPlayerId`）— 含自動觸發技（天妒/鐵騎/梟姬/救援/馬術等鎖定技不發事件，僅結果可觀察）；洛神每張判定牌各發一則（accepted=是否黑色收牌） |
 
 ---
 

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -171,10 +171,10 @@ public class Game {
     public List<DomainEvent> playerTakeTurnStartInJudgement(Player currentRoundPlayer) {
         List<DomainEvent> events = new ArrayList<>();
         if (RoundPhase.Judgement.equals(currentRound.getRoundPhase())) {
-            // 洛神：回合開始（延遲錦囊判定之前）黑色判定牌全收
-            events.addAll(SkillEngine.luoShenJudgementLoop(this, currentRoundPlayer));
+            // 洛神：回合開始（延遲錦囊判定之前）先詢問甄姬是否發動（issue #227）
+            events.addAll(SkillEngine.luoShenAskActivation(this, currentRoundPlayer));
             if (!topBehavior.isEmpty()
-                    && topBehavior.peek() instanceof WaitingSkillEffectBehavior) { // 鬼才介入洛神判定 → 暫停
+                    && topBehavior.peek() instanceof WaitingSkillEffectBehavior) { // 洛神詢問（或鬼才介入）→ 暫停
                 return events;
             }
             List<DomainEvent> judgeEvents = judgePlayerShouldDelay();
@@ -206,6 +206,12 @@ public class Game {
             if (!topBehavior.isEmpty()) {
                 return events;
             }
+
+            // 本次補判的樂不思蜀成功也要跳過出牌階段（洛神 resolve 後才進入延遲錦囊判定的路徑）
+            contentmentSuccess = contentmentSuccess || judgeEvents.stream()
+                    .filter(event -> event instanceof ContentmentEvent)
+                    .map(event -> (ContentmentEvent) event)
+                    .anyMatch(ContentmentEvent::isSuccess);
 
             if (RoundPhase.Drawing.equals(currentRound.getRoundPhase())) {
                 DomainEvent drawCardEvent = drawCardToPlayer(currentRoundPlayer, !contentmentSuccess);

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillEngine.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/registry/SkillEngine.java
@@ -220,16 +220,27 @@ public final class SkillEngine {
     }
 
     /**
-     * 洛神：回合開始判定 loop — 黑色（黑桃/梅花）收入手牌續判，紅色停。
-     * 非甄姬回 empty list；含鬼才暫停點（暫停時 caller 應檢查 topBehavior 並中止回合開始流程）。
+     * 洛神：回合開始判定階段先詢問甄姬是否發動（issue #227 改主動觸發）。
+     * 非甄姬回 empty list；有洛神 → push WaitingSkillEffect(洛神) 並回詢問事件
+     * （caller 檢查 topBehavior 為 WaitingSkillEffectBehavior 時中止回合開始流程）。
+     * ACCEPT 後判定 loop（黑收續判、紅停，不再逐輪詢問）由
+     * {@link com.gaas.threeKingdoms.skill.wei.LuoShenSkill#resolveChoice} 進入 {@link #luoShenContinueLoop}。
      */
-    public static List<DomainEvent> luoShenJudgementLoop(Game game, Player roundPlayer) {
+    public static List<DomainEvent> luoShenAskActivation(Game game, Player roundPlayer) {
         boolean hasLuoShen = skillsOf(roundPlayer).stream()
                 .anyMatch(s -> s instanceof com.gaas.threeKingdoms.skill.wei.LuoShenSkill);
         if (!hasLuoShen) {
             return List.of();
         }
-        return luoShenContinueLoop(game, roundPlayer);
+        var waiting = new com.gaas.threeKingdoms.behavior.behavior.WaitingSkillEffectBehavior(
+                game, roundPlayer, com.gaas.threeKingdoms.skill.wei.LuoShenSkill.SKILL_NAME);
+        game.updateTopBehavior(waiting);
+        game.getCurrentRound().setActivePlayer(roundPlayer);
+        return List.of(
+                new com.gaas.threeKingdoms.events.AskSkillEffectEvent(
+                        com.gaas.threeKingdoms.skill.wei.LuoShenSkill.SKILL_NAME,
+                        roundPlayer.getId(), List.of(), null),
+                game.getGameStatusEvent("洛神：詢問 " + roundPlayer.getId() + " 是否發動"));
     }
 
     /** 洛神判定 loop 本體（鬼才 resume 後續判亦由此進入）；每張判定牌抽出後先過鬼才暫停點。 */

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/LuoShenSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/LuoShenSkill.java
@@ -1,15 +1,27 @@
 package com.gaas.threeKingdoms.skill.wei;
 
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.behavior.behavior.WaitingSkillEffectBehavior;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.SkillEffectEvent;
 import com.gaas.threeKingdoms.generalcard.General;
-import com.gaas.threeKingdoms.skill.Skill;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.round.Stage;
+import com.gaas.threeKingdoms.skill.registry.SkillEngine;
+import com.gaas.threeKingdoms.skill.trigger.ChoiceResolvableSkill;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 甄姬 (WEI007) 洛神 — 回合開始階段可判定：黑色收為手牌並繼續判定，紅色結束（issue #171）。
- * v1 自動觸發（黑色全收，紅色停 — 嚴格有利不詢問）；
- * 觸發點在 Game.playerTakeTurnStartInJudgement（delay scroll 判定之前）。
- * Marker：實際 loop 邏輯在 SkillEngine.luoShenJudgementLoop。
+ *
+ * issue #227 改主動觸發：回合開始判定階段先詢問（AskSkillEffectEvent），
+ * ACCEPT 後進入判定 loop（黑收自動續判、紅停，不逐輪詢問）；SKIP 直接進原判定/摸牌流程。
+ * 詢問推送在 {@link SkillEngine#luoShenAskActivation}；loop 在 {@link SkillEngine#luoShenContinueLoop}
+ * （含鬼才暫停點，鬼才 resume 後由 GuiCaiSkill.resumeLuoShen 接手收尾）。
  */
-public class LuoShenSkill implements Skill {
+public class LuoShenSkill implements ChoiceResolvableSkill {
 
     public static final String GENERAL_ID = General.甄姬.getGeneralId();
     public static final String SKILL_NAME = "洛神";
@@ -22,5 +34,33 @@ public class LuoShenSkill implements Skill {
     @Override
     public String getSkillName() {
         return SKILL_NAME;
+    }
+
+    @Override
+    public List<DomainEvent> resolveChoice(Game game, WaitingSkillEffectBehavior waiting,
+                                           String choice, List<String> cardIds, String targetPlayerId) {
+        Player owner = waiting.getBehaviorPlayer();
+        List<DomainEvent> events = new ArrayList<>();
+        // 先 pop 本 waiting：後續 loop 可能 push 鬼才 waiting，收尾的 continueJudgementAndDraw
+        // 也需要空 stack 才會推進到摸牌
+        waiting.setIsOneRound(true);
+        game.removeCompletedBehaviors();
+
+        if ("ACCEPT".equals(choice)) {
+            events.addAll(SkillEngine.luoShenContinueLoop(game, owner));
+            if (!game.isTopBehaviorEmpty()) {
+                return events; // 鬼才介入 → 暫停，後續由 GuiCaiSkill.resumeLuoShen 收尾
+            }
+        } else if ("SKIP".equals(choice)) {
+            events.add(new SkillEffectEvent(SKILL_NAME, owner.getId(), false, List.of(), null));
+            events.add(game.getGameStatusEvent("放棄洛神"));
+        } else {
+            throw new IllegalArgumentException("Invalid LuoShen choice: " + choice);
+        }
+
+        game.getCurrentRound().setStage(Stage.Normal);
+        game.getCurrentRound().setActivePlayer(owner);
+        events.addAll(game.continueJudgementAndDraw(owner, false));
+        return events;
     }
 }

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch2TriggeredSkillsTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch2TriggeredSkillsTest.java
@@ -292,7 +292,7 @@ public class Batch2TriggeredSkillsTest extends PassiveSkillTestBase {
 
     // ===== 洛神 =====
 
-    @DisplayName("甄姬回合開始洛神 → 黑色判定牌全收，紅色停")
+    @DisplayName("甄姬回合開始先詢問洛神；ACCEPT → 黑色判定牌全收，紅色停")
     @Test
     public void luoShenCollectsBlackCardsUntilRed() {
         Game game = createGame(General.甄姬, General.劉備, General.孫權, General.孫權);
@@ -300,7 +300,16 @@ public class Batch2TriggeredSkillsTest extends PassiveSkillTestBase {
         // Stack：後 add 的先抽 → 抽序 = BS9009(黑) → BS8008(黑) → BH3029(紅停)
         game.getDeck().add(List.of(new Peach(BH3029), new Kill(BS8008), new Kill(BS9009)));
 
-        List<DomainEvent> events = game.playerTakeTurnStartInJudgement(a);
+        List<DomainEvent> askEvents = game.playerTakeTurnStartInJudgement(a);
+
+        assertTrue(askEvents.stream().anyMatch(e -> e instanceof AskSkillEffectEvent
+                        && ((AskSkillEffectEvent) e).getSkillName().equals("洛神")
+                        && ((AskSkillEffectEvent) e).getPlayerId().equals("player-a")),
+                "回合開始先詢問洛神，不自動判定");
+        assertFalse(a.getHand().getCards().stream().anyMatch(c -> c.getId().equals(BS9009.getCardId())),
+                "詢問前不收牌");
+
+        List<DomainEvent> events = game.playerUseSkillEffect("player-a", "洛神", "ACCEPT", null, null);
 
         assertTrue(a.getHand().getCards().stream().anyMatch(c -> c.getId().equals(BS9009.getCardId())));
         assertTrue(a.getHand().getCards().stream().anyMatch(c -> c.getId().equals(BS8008.getCardId())));
@@ -308,7 +317,51 @@ public class Batch2TriggeredSkillsTest extends PassiveSkillTestBase {
                 "紅色判定牌不收");
         long luoShenEvents = events.stream().filter(e -> e instanceof SkillEffectEvent
                 && ((SkillEffectEvent) e).getSkillName().equals("洛神")).count();
-        assertEquals(3, luoShenEvents, "兩黑一紅共三次判定事件");
+        assertEquals(3, luoShenEvents, "兩黑一紅共三次判定事件（ACCEPT 後不逐輪詢問）");
+        assertTrue(game.isTopBehaviorEmpty(), "resolve 後 stack 清空");
+    }
+
+    @DisplayName("洛神 SKIP → 不判定，直接進入摸牌流程")
+    @Test
+    public void luoShenSkipProceedsToDraw() {
+        Game game = createGame(General.甄姬, General.劉備, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        int handBefore = a.getHandSize();
+        game.playerTakeTurnStartInJudgement(a);
+
+        List<DomainEvent> events = game.playerUseSkillEffect("player-a", "洛神", "SKIP", null, null);
+
+        assertTrue(events.stream().anyMatch(e -> e instanceof SkillEffectEvent
+                        && ((SkillEffectEvent) e).getSkillName().equals("洛神")
+                        && !((SkillEffectEvent) e).isAccepted()),
+                "SKIP 廣播放棄事件");
+        assertEquals(handBefore + 2, a.getHandSize(), "不判定，直接摸 2");
+        assertTrue(game.isTopBehaviorEmpty());
+        assertEquals(a, game.getCurrentRound().getActivePlayer());
+    }
+
+    @DisplayName("洛神先於延遲錦囊判定：詢問時閃電尚未判定，resolve 後才判閃電")
+    @Test
+    public void luoShenAskedBeforeLightningJudgement() {
+        Game game = createGame(General.甄姬, General.劉備, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.addDelayScrollCard(new Lightning(SSA014));
+        // 抽序 = BH3029(洛神紅停) → BH4030(閃電判定紅心，不中轉移) → 摸 2 = BD2093 + BD3094
+        game.getDeck().add(List.of(new Dodge(BD3094), new Dodge(BD2093), new Peach(BH4030), new Peach(BH3029)));
+
+        game.playerTakeTurnStartInJudgement(a);
+
+        assertTrue(a.getDelayScrollCards().stream().anyMatch(c -> c.getId().equals(SSA014.getCardId())),
+                "洛神詢問期間閃電尚未判定");
+
+        game.playerUseSkillEffect("player-a", "洛神", "ACCEPT", null, null);
+
+        assertFalse(a.getDelayScrollCards().stream().anyMatch(c -> c.getId().equals(SSA014.getCardId())),
+                "洛神結算後才判閃電（紅心不中 → 移出 A 判定區）");
+        assertTrue(b.getDelayScrollCards().stream().anyMatch(c -> c.getId().equals(SSA014.getCardId())),
+                "閃電不中轉移給下家");
+        assertEquals(4, a.getHP(), "閃電未命中");
     }
 
     @DisplayName("非甄姬回合開始 → 洛神不觸發")
@@ -321,6 +374,8 @@ public class Batch2TriggeredSkillsTest extends PassiveSkillTestBase {
 
         assertFalse(events.stream().anyMatch(e -> e instanceof SkillEffectEvent
                 && ((SkillEffectEvent) e).getSkillName().equals("洛神")));
+        assertFalse(events.stream().anyMatch(e -> e instanceof AskSkillEffectEvent
+                && ((AskSkillEffectEvent) e).getSkillName().equals("洛神")));
     }
 
     // ===== 鐵騎 =====

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/GuiCaiSkillTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/GuiCaiSkillTest.java
@@ -448,7 +448,8 @@ public class GuiCaiSkillTest extends PassiveSkillTestBase {
         // 摸牌也必須疊牌控制：initDeck 牌堆裡有同 id 的 BS8008，隨機摸到會誤觸
         // 「原判定牌不收」斷言（CI flake）
         game.getDeck().add(List.of(new Dodge(BD2093), new Peach(BH4030), new Kill(BS8008)));
-        List<DomainEvent> events = game.playerTakeTurnStartInJudgement(a);
+        game.playerTakeTurnStartInJudgement(a); // issue #227：先詢問洛神
+        List<DomainEvent> events = game.playerUseSkillEffect("player-a", "洛神", "ACCEPT", null, null);
 
         AskSkillEffectEvent ask = events.stream()
                 .filter(e -> e instanceof AskSkillEffectEvent).map(e -> (AskSkillEffectEvent) e)
@@ -481,7 +482,8 @@ public class GuiCaiSkillTest extends PassiveSkillTestBase {
 
         // 抽序 = BS8008(黑) → BH4030(紅停) → 摸 2 = BD2093 + BD3094（摸牌疊牌控制，避免隨機）
         game.getDeck().add(List.of(new Dodge(BD3094), new Dodge(BD2093), new Peach(BH4030), new Kill(BS8008)));
-        game.playerTakeTurnStartInJudgement(a);
+        game.playerTakeTurnStartInJudgement(a); // issue #227：先詢問洛神
+        game.playerUseSkillEffect("player-a", "洛神", "ACCEPT", null, null);
 
         List<DomainEvent> firstResume = game.playerUseSkillEffect("player-b", "鬼才", "SKIP", null, null);
 

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/SkillEffectTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/SkillEffectTest.java
@@ -166,4 +166,76 @@ public class SkillEffectTest extends AbstractBaseIntegrationTest {
         assertEquals(3, finalState.getPlayer("player-c").getHP());
         assertEquals(3, finalState.getPlayer("player-d").getHP());
     }
+    @Test
+    public void testLuoShenAskThenAcceptAcrossRequests() throws Exception {
+        // Given：A 回合結束後輪到 B（甄姬）；判定牌疊 BS9009(黑收) → BH3029(紅停)，摸 2 = BH2028 + BH4030
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH);
+        Player playerB = createPlayer("player-b", 4, General.甄姬, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.孫權, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Peach(BH4030), new com.gaas.threeKingdoms.handcard.basiccard.Dodge(BH2028),
+                new Peach(BH3029), new Kill(BS9009)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        // When：A 結束回合 → B 回合開始，先詢問洛神並暫停（WaitingSkillEffectBehavior 經 MongoDB 存取）
+        mockMvcUtil.finishAction(gameId, "player-a").andExpect(status().isOk());
+
+        Game paused = repository.findById(gameId).orElseThrow();
+        assertFalse(paused.getTopBehavior().isEmpty(), "洛神詢問中，回合開始流程暫停");
+        assertEquals(0, paused.getPlayer("player-b").getHandSize(), "尚未判定，未收牌未摸牌");
+        assertEquals("player-b", paused.getCurrentRound().getActivePlayer().getId());
+
+        // B ACCEPT 洛神 → 黑色 BS9009 收入手牌、紅色 BH3029 停 → 接著摸 2
+        mockMvc.perform(post("/api/games/" + gameId + "/player:useSkillEffect")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "playerId": "player-b",
+                                  "skillName": "洛神",
+                                  "choice": "ACCEPT"
+                                }"""))
+                .andExpect(status().isOk());
+
+        // Then：收 1 張黑判定牌 + 摸 2，紅判定牌進墓地，流程推進到 B 的出牌階段
+        Game saved = repository.findById(gameId).orElseThrow();
+        assertTrue(saved.getPlayer("player-b").getHand().getCards().stream()
+                .anyMatch(c -> c.getId().equals(BS9009.getCardId())), "黑色判定牌收入手牌");
+        assertEquals(3, saved.getPlayer("player-b").getHandSize(), "收 1 + 摸 2");
+        assertTrue(saved.getGraveyard().contains(BH3029.getCardId()), "紅色判定牌進墓地");
+        assertTrue(saved.getTopBehavior().isEmpty());
+        assertEquals("player-b", saved.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @Test
+    public void testLuoShenSkipAcrossRequests() throws Exception {
+        // Given：同上，但 B 放棄洛神
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH);
+        Player playerB = createPlayer("player-b", 4, General.甄姬, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.孫權, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Peach(BH4030), new com.gaas.threeKingdoms.handcard.basiccard.Dodge(BH2028)));
+        game.setDeck(deck);
+        repository.save(game);
+
+        mockMvcUtil.finishAction(gameId, "player-a").andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/games/" + gameId + "/player:useSkillEffect")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "playerId": "player-b",
+                                  "skillName": "洛神",
+                                  "choice": "SKIP"
+                                }"""))
+                .andExpect(status().isOk());
+
+        // Then：不判定，直接摸 2 進出牌階段
+        Game saved = repository.findById(gameId).orElseThrow();
+        assertEquals(2, saved.getPlayer("player-b").getHandSize(), "SKIP 不判定，直接摸 2");
+        assertTrue(saved.getTopBehavior().isEmpty());
+        assertEquals("player-b", saved.getCurrentRound().getActivePlayer().getId());
+    }
 }


### PR DESCRIPTION
Closes #227

## 變更內容

洛神（甄姬 WEI007）由 v1 全自動觸發改為**發動詢問一次**：

1. 甄姬回合開始（延遲錦囊判定**之前**）→ 收到 `AskSkillEffectEvent(skillName=洛神)`，回合開始流程暫停
2. `POST /player:useSkillEffect` `ACCEPT` → 進入判定 loop：黑色收入手牌**自動續判**（不逐輪詢問）、紅色停
3. `SKIP` → 不判定，直接進原延遲錦囊判定 / 摸牌流程
4. 判定中每張判定牌仍逐張過鬼才暫停點（#220 行為不變，鬼才 resume 後由 `resumeLuoShen` 收尾）

## 實作

- `SkillEngine.luoShenAskActivation`：push `WaitingSkillEffect(洛神)` + ask 事件（取代原 `luoShenJudgementLoop` 直接判定）
- `LuoShenSkill` 改實作 `ChoiceResolvableSkill`（原為純 marker）；resolve 先 pop waiting 再跑 loop / 收尾
- `Game.continueJudgementAndDraw` 補偵測本次補判的樂不思蜀成功（原只吃參數；洛神 resolve 後才判樂不思蜀的路徑會漏跳過出牌階段）
- API_DOC：洛神移入 useSkillEffect 詢問表；自動觸發表移除

## 測試

- domain 536（+1 net）：Batch2 洛神 ACCEPT/SKIP/順序（洛神先於閃電判定）×3、GuiCai 洛神 ×2 補 ACCEPT 步驟
- spring 263（+2）：洛神 ACCEPT / SKIP 跨 request e2e（WaitingSkillEffectBehavior 經 MongoDB reload）
- 全綠（domain 536 / spring 263；已先 `mvn install -DskipTests` 重建 parent）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV1eQrYWBp5rJA25ock1qP