### PR TITLE
fix: 傾國出黑牌後遊戲卡住 — playCard 打非閃牌自動轉化為傾國/龍膽（issue #229）

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -706,12 +706,15 @@ POST /api/games/{gameId}/player:useSkillEffect
 | 技能 | choice | cardIds | targetPlayerId | 使用情境 |
 |---|---|---|---|---|
 | 武聖（關羽） | `KILL` | [紅色手牌 id] | 主動殺必填 | 主動出殺（topBehavior 空）或回應南蠻/決鬥（KILL response） |
-| 龍膽（趙雲） | `KILL` / `DODGE` | [閃 id] / [殺 id] | 主動殺必填 | 殺↔閃雙向；回應問閃用 DODGE、回應需殺用 KILL |
-| 傾國（甄姬） | `DODGE` | [黑色手牌 id] | — | 被問閃時（被殺/萬箭/方天畫戟） |
+| 龍膽（趙雲） | `KILL` / `DODGE` | [閃 id] / [殺 id] | 主動殺必填 | 殺↔閃雙向；回應問閃用 DODGE、回應需殺用 KILL；問閃時亦可直接以 `player:playCard` 打出殺，後端自動視為發動龍膽（issue #229） |
+| 傾國（甄姬） | `DODGE` | [黑色手牌 id] | — | 被問閃時（被殺/萬箭/方天畫戟）；亦可直接以 `player:playCard` 打出黑牌，後端自動視為發動傾國（issue #229） |
 | 奇襲（甘寧） | `DISMANTLE` | [黑色手牌 id] | 必填 | 主動；後續走 useDismantleEffect |
 | 國色（大喬） | `CONTENTMENT` | [方塊手牌 id] | 必填 | 主動；牌以樂不思蜀身份進判定區 |
 
 轉化殺計入出殺次數限制（咆哮/諸葛連弩豁免照常）；轉化殺對空城/謙遜的目標限制照常套用。
+
+**問閃時的出牌驗證（issue #229）**：被問閃時以 `player:playCard` 打出非閃牌 —
+可轉化（傾國黑牌 / 龍膽殺）→ 自動發動轉化技視為出閃；不可轉化 → 400 明確錯誤（先前會被默默吞掉導致卡住）。
 
 **v1 範圍備註**：
 - 反饋在 AOE polling（南蠻 / 萬箭）中可觸發（PR #221：受傷 → 反饋詢問 → resolve 後 resume 輪詢）；

--- a/API_DOC.md
+++ b/API_DOC.md
@@ -716,6 +716,46 @@ POST /api/games/{gameId}/player:useSkillEffect
 **問閃時的出牌驗證（issue #229）**：被問閃時以 `player:playCard` 打出非閃牌 —
 可轉化（傾國黑牌 / 龍膽殺）→ 自動發動轉化技視為出閃；不可轉化 → 400 明確錯誤（先前會被默默吞掉導致卡住）。
 
+#### 傾國（甄姬）發動與使用
+
+**條件**：甄姬（`WEI007`）**被問閃時**（被殺、萬箭齊發、方天畫戟 — 收到 `AskDodgeEvent` 或成為問閃對象），手上有黑色（黑桃/梅花）手牌。傾國沒有事前的 `AskSkillEffectEvent` 詢問 — 由前端在問閃 UI 直接提供黑牌作為出閃選項。
+
+**方式一：直接出牌（推薦，前端不需特殊處理）** — 把黑色手牌當一般出牌打出：
+
+```json
+POST /api/games/{gameId}/player:playCard
+{
+  "playerId": "甄姬的playerId",
+  "targetPlayerId": "攻擊者playerId",
+  "cardId": "黑色手牌id",
+  "playType": "active"
+}
+```
+
+後端偵測「被問閃 + 非閃牌 + 有傾國」自動發動轉化。
+
+**方式二：useSkillEffect**：
+
+```json
+POST /api/games/{gameId}/player:useSkillEffect
+{
+  "playerId": "甄姬的playerId",
+  "skillName": "傾國",
+  "choice": "DODGE",
+  "cardIds": ["黑色手牌id"]
+}
+```
+
+**結算（兩種方式相同）**：
+- 廣播 `SkillEffectEvent`（skillName=傾國、accepted=true、dataCardIds=[該黑牌]）+ `PlayCardEvent`（視為出閃）
+- 該黑牌進墓地，效果等同出閃：殺被擋、萬箭/方天畫戟輪詢推進到下一位
+- `round.activePlayer` 回到應繼續行動者（普通殺 → 攻擊者；輪詢 → 下一位被詢問者）
+- 攻擊者裝青龍偃月刀/貫石斧時照常觸發後續詢問（同真閃）
+
+**錯誤情境（400）**：
+- 出紅色牌 / 牌不在手 → `IllegalArgumentException`
+- 不想發動：照原本流程出真閃或 `playType: "skip"`
+
 **v1 範圍備註**：
 - 反饋在 AOE polling（南蠻 / 萬箭）中可觸發（PR #221：受傷 → 反饋詢問 → resolve 後 resume 輪詢）；
   遺計 / 剛烈在 AOE polling 中仍不觸發（可循同一 resume flag 開啟，follow-up）；三者瀕死皆不觸發

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -337,6 +337,21 @@ public class Game {
 
         if (!topBehavior.isEmpty()) {
             Behavior behavior = topBehavior.peek();
+            // 傾國/龍膽：被問閃時直接以 playCard 打出可轉化的非閃牌 → 視為發動轉化技。
+            // 原本會落入各 behavior 非閃 else 分支默默回空 events / null → 前端卡住（issue #229）
+            if (behavior instanceof com.gaas.threeKingdoms.behavior.HuJiaCompatibleAskDodgeBehavior
+                    && behavior.getReactionPlayers().contains(playerId)) {
+                HandCard cardInHand = actingPlayer.getHand().getCard(cardId).orElse(null);
+                if (cardInHand != null && !(cardInHand instanceof com.gaas.threeKingdoms.handcard.basiccard.Dodge)) {
+                    com.gaas.threeKingdoms.skill.trigger.CardConversionSkill conversion =
+                            findDodgeConversionSkill(playerId, cardInHand);
+                    if (conversion != null) {
+                        return applyConversionResponse(playerId, conversion.getSkillName(),
+                                com.gaas.threeKingdoms.skill.trigger.CardConversionSkill.AS_DODGE,
+                                List.of(cardId), targetPlayerId);
+                    }
+                }
+            }
             List<DomainEvent> acceptedEvent = behavior.responseToPlayerAction(playerId, targetPlayerId, cardId, playType);
             //  確認topBehavior是否有需要pop掉的behavior
             removeCompletedBehaviors();
@@ -1016,6 +1031,16 @@ public class Game {
         List<DomainEvent> events = waiting.resolveChoice(playerId, choice, cardIds, targetPlayerId);
         removeCompletedBehaviors();
         return events;
+    }
+
+    /** 玩家是否有可把指定牌當閃打出的轉化技（傾國：黑色手牌 / 龍膽：殺）。 */
+    private com.gaas.threeKingdoms.skill.trigger.CardConversionSkill findDodgeConversionSkill(String playerId, HandCard source) {
+        Player self = getPlayer(playerId);
+        return com.gaas.threeKingdoms.skill.registry.SkillRegistry.of(self.getGeneralCard().getGeneralId()).stream()
+                .filter(sk -> sk instanceof com.gaas.threeKingdoms.skill.trigger.CardConversionSkill)
+                .map(sk -> (com.gaas.threeKingdoms.skill.trigger.CardConversionSkill) sk)
+                .filter(sk -> sk.canConvert(source, com.gaas.threeKingdoms.skill.trigger.CardConversionSkill.AS_DODGE))
+                .findFirst().orElse(null);
     }
 
     private com.gaas.threeKingdoms.skill.trigger.CardConversionSkill findConversionSkill(String playerId, String skillName) {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
@@ -206,9 +206,11 @@ public class ArrowBarrageBehavior extends Behavior
             }
             return events;
         } else {
-            //TODO:怕有其他效果或殺的其他case
+            // 非閃且非可轉化牌（傾國/龍膽已在 Game.playerPlayCard 攔截）— 明確報錯，
+            // 不再回 null 造成前端卡住（issue #229）
+            throw new IllegalArgumentException(
+                    "被詢問出閃時只能出閃、skip 或發動轉化技（傾國/龍膽）：" + cardId);
         }
-        return null;
     }
 
     public boolean isInReactionPlayers(String playerId) {

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/HeavenlyDoubleHalberdKillBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/HeavenlyDoubleHalberdKillBehavior.java
@@ -119,8 +119,10 @@ public class HeavenlyDoubleHalberdKillBehavior extends NormalActiveKillBehavior 
             events.add(game.getGameStatusEvent(playerId + " 出閃"));
             return events;
         } else {
-            //TODO: 其他 case（Phase 2）
-            return new ArrayList<>();
+            // 非閃且非可轉化牌（傾國/龍膽已在 Game.playerPlayCard 攔截）— 明確報錯，
+            // 不再默默回空 events 造成前端卡住（issue #229）
+            throw new IllegalArgumentException(
+                    "被詢問出閃時只能出閃、skip 或發動轉化技（傾國/龍膽）：" + cardId);
         }
     }
 

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/NormalActiveKillBehavior.java
@@ -176,8 +176,10 @@ public class NormalActiveKillBehavior extends Behavior
             isOneRound = true;
             return events;
         } else {
-            //TODO:怕有其他效果或殺的其他case
-            return new ArrayList<>();
+            // 非閃且非可轉化牌（傾國/龍膽已在 Game.playerPlayCard 攔截）— 明確報錯，
+            // 不再默默回空 events 造成前端卡住（issue #229）
+            throw new IllegalArgumentException(
+                    "被詢問出閃時只能出閃、skip 或發動轉化技（傾國/龍膽）：" + cardId);
         }
     }
 

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch4ConversionSkillsTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch4ConversionSkillsTest.java
@@ -8,6 +8,7 @@ import com.gaas.threeKingdoms.generalcard.General;
 import com.gaas.threeKingdoms.handcard.basiccard.Dodge;
 import com.gaas.threeKingdoms.handcard.basiccard.Kill;
 import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.scrollcard.ArrowBarrage;
 import com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion;
 import com.gaas.threeKingdoms.player.Player;
 import org.junit.jupiter.api.DisplayName;
@@ -131,6 +132,194 @@ public class Batch4ConversionSkillsTest extends PassiveSkillTestBase {
 
         assertEquals(4, b.getHP());
         assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("傾國擋普通殺後遊戲可繼續：activePlayer 回攻擊者、可結束回合")
+    @Test
+    public void qingGuoDodgeThenGameContinues() {
+        Game game = createGame(General.劉備, General.甄姬, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(new Kill(BS9009));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        game.playerUseSkillEffect("player-b", "傾國", "DODGE", List.of(BS9009.getCardId()), null);
+
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId(),
+                "傾國後 activePlayer 應回攻擊者");
+        assertTrue(game.getTopBehavior().isEmpty());
+
+        // 遊戲可繼續：A 結束回合 → 輪到 B（甄姬）回合開始詢問洛神
+        List<DomainEvent> events = game.finishAction("player-a");
+        assertEquals("player-b", game.getCurrentRound().getCurrentRoundPlayer().getId(), "回合正常輪替");
+    }
+
+    @DisplayName("傾國回應萬箭齊發（非最後 reactor）→ 輪詢推進到下一家")
+    @Test
+    public void qingGuoAgainstArrowBarrageAdvancesPolling() {
+        Game game = createGame(General.劉備, General.甄姬, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new ArrowBarrage(SHA040));
+        b.getHand().addCardToHand(new Kill(BS9009));
+
+        game.playerPlayCard("player-a", SHA040.getCardId(), "player-a", "active");
+        game.playerUseSkillEffect("player-b", "傾國", "DODGE", List.of(BS9009.getCardId()), null);
+
+        assertEquals(4, b.getHP(), "傾國當閃 → 不扣血");
+        assertEquals("player-c", game.getCurrentRound().getActivePlayer().getId(),
+                "輪詢應推進到 C");
+
+        game.playerPlayCard("player-c", "", "player-a", "skip");
+        game.playerPlayCard("player-d", "", "player-a", "skip");
+        assertEquals(3, game.getPlayer("player-c").getHP());
+        assertEquals(3, game.getPlayer("player-d").getHP());
+        assertTrue(game.getTopBehavior().isEmpty(), "萬箭結算完畢");
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("傾國回應萬箭齊發（最後 reactor）→ 結算收尾、activePlayer 回出牌者")
+    @Test
+    public void qingGuoAsLastReactorInArrowBarrage() {
+        Game game = createGame(General.劉備, General.孫權, General.孫權, General.甄姬);
+        Player a = game.getPlayer("player-a");
+        Player d = game.getPlayer("player-d");
+        a.getHand().addCardToHand(new ArrowBarrage(SHA040));
+        d.getHand().addCardToHand(new Kill(BS9009));
+
+        game.playerPlayCard("player-a", SHA040.getCardId(), "player-a", "active");
+        game.playerPlayCard("player-b", "", "player-a", "skip");
+        game.playerPlayCard("player-c", "", "player-a", "skip");
+        game.playerUseSkillEffect("player-d", "傾國", "DODGE", List.of(BS9009.getCardId()), null);
+
+        assertEquals(4, d.getHP());
+        assertTrue(game.getTopBehavior().isEmpty(), "最後 reactor 傾國 → 萬箭收尾");
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("傾國回應方天畫戟多目標殺 → 推進到下一個目標")
+    @Test
+    public void qingGuoAgainstHeavenlyDoubleHalberd() {
+        Game game = createGame(General.劉備, General.甄姬, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getEquipment().setWeapon(new com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.HeavenlyDoubleHalberdCard(EDQ103));
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(new Kill(BS9009));
+
+        game.playerUseHeavenlyDoubleHalberdKill("player-a", BS8008.getCardId(),
+                List.of("player-b", "player-c"));
+        game.playerUseSkillEffect("player-b", "傾國", "DODGE", List.of(BS9009.getCardId()), null);
+
+        assertEquals(4, b.getHP(), "第一目標傾國擋下");
+        assertEquals("player-c", game.getCurrentRound().getActivePlayer().getId(),
+                "推進到第二目標");
+
+        game.playerPlayCard("player-c", "", "player-a", "skip");
+        assertEquals(3, game.getPlayer("player-c").getHP());
+        assertTrue(game.getTopBehavior().isEmpty());
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("攻擊者裝青龍偃月刀時傾國擋殺 → 觸發 GDCB 詢問，SKIP 後遊戲可繼續")
+    @Test
+    public void qingGuoDodgeTriggersGreenDragonAsk() {
+        Game game = createGame(General.劉備, General.甄姬, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getEquipment().setWeapon(new com.gaas.threeKingdoms.handcard.equipmentcard.weaponcard.GreenDragonCrescentBladeCard(ES5005));
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(new Kill(BS9009));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        List<DomainEvent> events = game.playerUseSkillEffect(
+                "player-b", "傾國", "DODGE", List.of(BS9009.getCardId()), null);
+
+        assertTrue(events.stream().anyMatch(e ->
+                        e instanceof com.gaas.threeKingdoms.events.AskGreenDragonCrescentBladeEffectEvent),
+                "閃被擋 → 詢問青龍偃月刀");
+
+        game.playerUseGreenDragonCrescentBladeEffect("player-a",
+                com.gaas.threeKingdoms.events.AskGreenDragonCrescentBladeEffectEvent.Choice.SKIP, null);
+        assertEquals(4, b.getHP());
+        assertTrue(game.getTopBehavior().isEmpty());
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("issue #229：被問閃時直接以 playCard 打出黑牌 → 自動視為發動傾國")
+    @Test
+    public void qingGuoViaPlainPlayCardAutoConverts() {
+        Game game = createGame(General.劉備, General.甄姬, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(new Kill(BS9009));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        // 前端行為：不走 useSkillEffect，直接把黑牌當一般出牌打出
+        List<DomainEvent> events = game.playerPlayCard("player-b", BS9009.getCardId(), "player-a", "active");
+
+        assertTrue(events.stream().anyMatch(e -> e instanceof com.gaas.threeKingdoms.events.SkillEffectEvent
+                        && ((com.gaas.threeKingdoms.events.SkillEffectEvent) e).getSkillName().equals("傾國")
+                        && ((com.gaas.threeKingdoms.events.SkillEffectEvent) e).isAccepted()),
+                "自動轉化為傾國並廣播 SkillEffectEvent");
+        assertEquals(4, b.getHP(), "視為出閃 → 不扣血");
+        assertTrue(game.getGraveyard().contains(BS9009.getCardId()));
+        assertTrue(game.getTopBehavior().isEmpty());
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId());
+    }
+
+    @DisplayName("issue #229：萬箭齊發被問閃時以 playCard 打出黑牌 → 自動傾國、輪詢推進")
+    @Test
+    public void qingGuoViaPlainPlayCardInArrowBarrage() {
+        Game game = createGame(General.劉備, General.甄姬, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new ArrowBarrage(SHA040));
+        b.getHand().addCardToHand(new Kill(BS9009));
+
+        game.playerPlayCard("player-a", SHA040.getCardId(), "player-a", "active");
+        game.playerPlayCard("player-b", BS9009.getCardId(), "player-a", "active");
+
+        assertEquals(4, b.getHP());
+        assertEquals("player-c", game.getCurrentRound().getActivePlayer().getId(), "輪詢推進到 C");
+    }
+
+    @DisplayName("issue #229：趙雲被問閃時以 playCard 打出殺 → 自動視為發動龍膽")
+    @Test
+    public void longDanViaPlainPlayCardAutoConverts() {
+        Game game = createGame(General.劉備, General.趙雲, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(new Kill(BS9009));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+        List<DomainEvent> events = game.playerPlayCard("player-b", BS9009.getCardId(), "player-a", "active");
+
+        assertTrue(events.stream().anyMatch(e -> e instanceof com.gaas.threeKingdoms.events.SkillEffectEvent
+                        && ((com.gaas.threeKingdoms.events.SkillEffectEvent) e).getSkillName().equals("龍膽")),
+                "殺當閃 → 自動龍膽");
+        assertEquals(4, b.getHP());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("issue #229：無轉化技的玩家被問閃時打出非閃牌 → 明確報錯而非默默吞掉")
+    @Test
+    public void nonConvertibleCardAsDodgeResponseThrows() {
+        Game game = createGame(General.劉備, General.孫權, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        Player b = game.getPlayer("player-b");
+        a.getHand().addCardToHand(new Kill(BS8008));
+        b.getHand().addCardToHand(new Kill(BS9009));
+
+        game.playerPlayCard("player-a", BS8008.getCardId(), "player-b", "active");
+
+        assertThrows(IllegalArgumentException.class, () ->
+                game.playerPlayCard("player-b", BS9009.getCardId(), "player-a", "active"));
+        assertFalse(game.getTopBehavior().isEmpty(), "報錯後仍在等 B 回應");
+        assertEquals(4, b.getHP(), "未結算");
     }
 
     @DisplayName("傾國不能轉紅色牌")

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/QingGuoPushTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/QingGuoPushTest.java
@@ -1,0 +1,107 @@
+package com.gaas.threeKingdoms.e2e.skill;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.handcard.Deck;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.player.HealthStatus;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.rolecard.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.gaas.threeKingdoms.e2e.MockUtil.createPlayer;
+import static com.gaas.threeKingdoms.e2e.MockUtil.initGame;
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * issue #229（前端回報）：甄姬被殺、被問閃時打出黑色手牌（傾國）後遊戲卡住。
+ * 根因：前端以一般 playCard 打出黑牌（非 useSkillEffect），問閃 behavior 的非閃 else
+ * 分支默默回空 events / null → 200 但無推播、狀態不變。
+ * 修法：Game.playerPlayCard 攔截可轉化牌自動視為發動傾國/龍膽。
+ * 本測試驗證 websocket 推播：出黑牌那個 request 後每位玩家都收到結算推播、遊戲可繼續。
+ */
+public class QingGuoPushTest extends AbstractBaseIntegrationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @DisplayName("A 殺 B（甄姬），B 以 playCard 打出黑牌 → 自動傾國、全員收到推播、activePlayer 回 A")
+    @Test
+    public void qingGuoViaPlayCardEndpointPushesToAllPlayers() throws Exception {
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008));
+        Player playerB = createPlayer("player-b", 4, General.甄姬, HealthStatus.ALIVE, Role.MINISTER,
+                new Kill(BS9009)); // 黑桃手牌
+        Player playerC = createPlayer("player-c", 4, General.孫權, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        game.setDeck(new Deck());
+        repository.save(game);
+
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+        websocketUtil.popAllPlayerMessage();
+
+        // 前端行為：直接把黑牌當一般出牌打出（修復前：200 但無推播 → 卡住）
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "BS9009", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+
+        for (String playerId : List.of("player-a", "player-b", "player-c", "player-d")) {
+            JsonNode push = objectMapper.readTree(websocketUtil.getValue(playerId));
+
+            boolean hasQingGuoEffect = false;
+            for (JsonNode e : push.get("events")) {
+                if ("SkillEffectEvent".equals(e.get("event").asText())
+                        && "傾國".equals(e.get("data").get("skillName").asText())) {
+                    hasQingGuoEffect = true;
+                    assertTrue(e.get("data").get("accepted").asBoolean());
+                }
+            }
+            assertTrue(hasQingGuoEffect, playerId + " 應收到 SkillEffectEvent(傾國)");
+            assertEquals("player-a", push.get("data").get("round").get("activePlayer").asText(),
+                    "結算後 activePlayer 回攻擊者");
+            assertEquals(4, push.get("data").get("seats").get(1).get("hp").asInt(), "B 未扣血");
+        }
+
+        // 遊戲可繼續：A 結束回合 → 200（修復前這裡永遠等不到）
+        mockMvcUtil.finishAction(gameId, "player-a").andExpect(status().isOk());
+        Game saved = repository.findById(gameId).orElseThrow();
+        assertEquals("player-b", saved.getCurrentRound().getCurrentRoundPlayer().getId(), "回合正常輪替");
+        assertTrue(saved.getGraveyard().contains(BS9009.getCardId()), "黑牌進墓地");
+    }
+
+    @DisplayName("被問閃時打出非閃且不可轉化的牌 → 400 明確錯誤（不再默默吞掉）")
+    @Test
+    public void nonConvertibleCardAsDodgeReturns400() throws Exception {
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new Kill(BS8008));
+        Player playerB = createPlayer("player-b", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER,
+                new Kill(BS9009));
+        Player playerC = createPlayer("player-c", 4, General.孫權, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        game.setDeck(new Deck());
+        repository.save(game);
+
+        mockMvcUtil.playCard(gameId, "player-a", "player-b", "BS8008", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "BS9009", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isBadRequest());
+
+        // 遊戲狀態未變，B 仍可正常 skip 繼續
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk());
+        Game saved = repository.findById(gameId).orElseThrow();
+        assertEquals(3, saved.getPlayer("player-b").getHP(), "skip 後正常扣血");
+    }
+}


### PR DESCRIPTION
Closes #229

## 根因（前端回報：甄姬被殺出黑牌後卡住）

前端把傾國的黑牌以一般 `player:playCard` 打出（非 API_DOC 的 useSkillEffect）。問閃 behavior 對非閃牌的 else 分支**默默吞掉**（`NormalActiveKillBehavior` 回空 list、`ArrowBarrageBehavior` 回 `null`、`HeavenlyDoubleHalberdKillBehavior` 回空 list）→ HTTP 200 但無事件推播、狀態不變、仍在等閃 → 卡住。

useSkillEffect 路徑本身正確（本 PR 先寫了普通殺/萬箭（中間+最後 reactor）/方天畫戟/青龍偃月刀 5 個 domain 情境測試，全過），確認問題在 playCard 路徑。

## 修法

1. `Game.playerPlayCard` 中央攔截：top behavior 為問閃 host（`HuJiaCompatibleAskDodgeBehavior` — 涵蓋普通殺/萬箭/方天畫戟）且打出的牌非閃、玩家有可轉化為閃的技能（傾國黑牌 / 龍膽殺）→ 自動視為發動轉化技，等同 useSkillEffect DODGE。**前端不需改**。
2. 三個 behavior 的默默吞掉 else 改為明確 `IllegalArgumentException`（400）— 不可轉化的非閃牌不再靜默。

## 測試

- domain 545（+9）：useSkillEffect 多情境 ×5 + playCard 自動轉化 ×3 + 不可轉化報錯 ×1
- spring 263（+2）：`QingGuoPushTest` — playCard 出黑牌後**全員收到 SkillEffectEvent(傾國) 推播**、activePlayer 回攻擊者、A 可 finishAction 繼續；不可轉化 → 400 且遊戲狀態未變可續玩
- 全綠（已先 `mvn install -DskipTests` 重建 parent）

## 前端使用方式（API_DOC 已更新）

- 直接 `player:playCard` 打出黑牌（自動傾國）；或照舊 `player:useSkillEffect` `choice=DODGE`
- 龍膽同理：問閃時 playCard 打出殺 → 自動龍膽

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV1eQrYWBp5rJA25ock1qP