### PR TITLE
fix: 回合玩家自己死亡後 goNextRound 誤跳到 0 號座位（issue #231）

### DIFF
--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -716,10 +716,13 @@ public class Game {
     }
 
     private Player findNextAlivePlayer(Player player) {
+        // 存活判準沿用座位表成員資格（死亡結算即移出座位表），不用 healthStatus：
+        // 測試 fixture 未必有設定 healthStatus
+        List<Player> seatedPlayers = seatingChart.getPlayers();
         int seat = players.indexOf(player);
         for (int i = 1; i <= players.size(); i++) {
             Player candidate = players.get((seat + i) % players.size());
-            if (candidate.isStillAlive()) {
+            if (seatedPlayers.contains(candidate)) {
                 return candidate;
             }
         }

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -708,9 +708,22 @@ public class Game {
     }
 
     public List<DomainEvent> goNextRound(Player player) {
-        Player nextPlayer = seatingChart.getNextPlayer(player);
+        // 不可用 seatingChart.getNextPlayer：回合玩家自己死亡時已被移出座位表，
+        // indexOf = -1 會誤跳到 0 號位（issue #231）。改以原始座位順序找下一位存活玩家。
+        Player nextPlayer = findNextAlivePlayer(player);
         currentRound = new Round(nextPlayer);
         return playerTakeTurn(nextPlayer);
+    }
+
+    private Player findNextAlivePlayer(Player player) {
+        int seat = players.indexOf(player);
+        for (int i = 1; i <= players.size(); i++) {
+            Player candidate = players.get((seat + i) % players.size());
+            if (candidate.isStillAlive()) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("No alive player found after " + player.getId());
     }
 
     public void askActivePlayerPlayPeachCard() {

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/PlayerDeathTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/PlayerDeathTest.java
@@ -1385,4 +1385,177 @@ public class PlayerDeathTest {
         assertEquals(0, game.getPlayer("player-b").getBloodCard().getHp());
 
     }
+
+    @DisplayName("""
+            Given
+            玩家ABCD（issue #231 回歸：距離跨屍減一）
+            B hp = 1，A 手牌有殺，ABCD 都沒有桃
+            A 到 C 的座位距離為 2（隔著 B）
+
+            When
+            A 殺 B，全員 skip 桃 → B 死亡
+
+            Then
+            A 到 C 的距離變為 1，A 不需武器即可攻擊 C
+            """)
+    @Test
+    public void givenPlayerABCD_WhenBDies_ThenDistanceAcrossDeadPlayerReducesByOne() {
+        // Given
+        Game game = new Game();
+        game.initDeck();
+
+        Player playerA = PlayerBuilder.construct()
+                .withId("player-a")
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(General.甘寧))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(Role.MONARCH))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .build();
+        playerA.getHand().addCardToHand(Arrays.asList(new Kill(BS8008)));
+
+        Player playerB = PlayerBuilder.construct()
+                .withId("player-b")
+                .withBloodCard(new BloodCard(1))
+                .withGeneralCard(new GeneralCard(General.孫權))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(Role.TRAITOR))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .build();
+
+        Player playerC = PlayerBuilder.construct()
+                .withId("player-c")
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(General.關羽))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(Role.REBEL))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .build();
+
+        Player playerD = PlayerBuilder.construct()
+                .withId("player-d")
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(General.張飛))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(Role.MINISTER))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .build();
+
+        game.setPlayers(Arrays.asList(playerA, playerB, playerC, playerD));
+        game.setCurrentRound(new Round(playerA));
+        game.enterPhase(new Normal(game));
+
+        assertEquals(2, game.getSeatingChart().calculateDistance(playerA, playerC));
+        assertFalse(game.isInAttackRange(playerA, playerC));
+
+        // When：A 殺 B，全員 skip 桃 → B 死亡
+        game.playerPlayCard(playerA.getId(), "BS8008", playerB.getId(), PlayType.ACTIVE.getPlayType());
+        game.playerPlayCard(playerB.getId(), "", playerB.getId(), PlayType.SKIP.getPlayType());
+        game.playerPlayCard(playerB.getId(), "", playerB.getId(), PlayType.SKIP.getPlayType());
+        game.playerPlayCard(playerC.getId(), "", playerB.getId(), PlayType.SKIP.getPlayType());
+        game.playerPlayCard(playerD.getId(), "", playerB.getId(), PlayType.SKIP.getPlayType());
+        game.playerPlayCard(playerA.getId(), "", playerB.getId(), PlayType.SKIP.getPlayType());
+
+        // Then：B 移出座位表，A→C 距離由 2 減為 1，可直接攻擊
+        assertTrue(game.getSeatingChart().getPlayers().stream().noneMatch(p -> p.getId().equals("player-b")));
+        assertEquals(1, game.getSeatingChart().calculateDistance(playerA, playerC));
+        assertTrue(game.isInAttackRange(playerA, playerC));
+    }
+
+    @DisplayName("""
+            Given
+            玩家ABCD（issue #231：回合玩家自己死亡後的輪替）
+            B hp = 3，B 的判定區有閃電，B 沒有桃
+            A 的回合結束後輪到 B
+
+            When
+            B 回合開始閃電判定失敗（黑桃 3）→ 3 點傷害 → B 瀕死，全員 skip 桃 → B 死亡
+
+            Then
+            下一回合是 C（死者的下一位），而非座位表第 0 位的 A
+            """)
+    @Test
+    public void givenCurrentRoundPlayerDiesOnOwnTurn_ThenNextRoundGoesToPlayerAfterDeadOne() {
+        // Given
+        Game game = new Game();
+        game.initDeck();
+        game.setDeck(new com.gaas.threeKingdoms.handcard.Deck(List.of(
+                new com.gaas.threeKingdoms.handcard.scrollcard.Dismantle(SS3003), // B 的閃電判定牌（黑桃 3 → 命中）
+                new com.gaas.threeKingdoms.handcard.scrollcard.Dismantle(SS3003),
+                new com.gaas.threeKingdoms.handcard.scrollcard.Dismantle(SS3003),
+                new com.gaas.threeKingdoms.handcard.scrollcard.Dismantle(SS3003),
+                new com.gaas.threeKingdoms.handcard.scrollcard.Dismantle(SS3003),
+                new com.gaas.threeKingdoms.handcard.scrollcard.Dismantle(SS3003),
+                new com.gaas.threeKingdoms.handcard.scrollcard.Dismantle(SS3003),
+                new com.gaas.threeKingdoms.handcard.scrollcard.Dismantle(SS3003)
+        )));
+
+        Player playerA = PlayerBuilder.construct()
+                .withId("player-a")
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(General.劉備))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(Role.MONARCH))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .build();
+
+        java.util.Stack<com.gaas.threeKingdoms.handcard.scrollcard.ScrollCard> delayScrolls = new java.util.Stack<>();
+        delayScrolls.push(new com.gaas.threeKingdoms.handcard.scrollcard.Lightning(SSA014));
+        Player playerB = PlayerBuilder.construct()
+                .withId("player-b")
+                .withBloodCard(new BloodCard(3))
+                .withGeneralCard(new GeneralCard(General.關羽))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(Role.TRAITOR))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .withDelayScrollCards(delayScrolls)
+                .build();
+
+        Player playerC = PlayerBuilder.construct()
+                .withId("player-c")
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(General.張飛))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(Role.REBEL))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .build();
+
+        Player playerD = PlayerBuilder.construct()
+                .withId("player-d")
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(General.趙雲))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(Role.MINISTER))
+                .withHand(new Hand())
+                .withEquipment(new Equipment())
+                .build();
+
+        game.setPlayers(Arrays.asList(playerA, playerB, playerC, playerD));
+        game.setCurrentRound(new Round(playerA));
+        game.enterPhase(new Normal(game));
+
+        // When：A 結束回合 → B 回合開始閃電判定失敗 → B 瀕死
+        game.finishAction(playerA.getId());
+        assertEquals(0, playerB.getBloodCard().getHp());
+
+        // 全員 skip 桃（詢問順序從瀕死者 B 開始）
+        game.playerPlayCard(playerB.getId(), "", playerB.getId(), PlayType.SKIP.getPlayType());
+        game.playerPlayCard(playerC.getId(), "", playerB.getId(), PlayType.SKIP.getPlayType());
+        game.playerPlayCard(playerD.getId(), "", playerB.getId(), PlayType.SKIP.getPlayType());
+        List<DomainEvent> events = game.playerPlayCard(playerA.getId(), "", playerB.getId(), PlayType.SKIP.getPlayType());
+
+        // Then：B 死亡，下一回合是死者的下一位 C（修正前誤跳到座位表第 0 位的 A）
+        SettlementEvent settlementEvent = getEvent(events, SettlementEvent.class).orElseThrow(RuntimeException::new);
+        assertEquals("player-b", settlementEvent.getPlayerId());
+        assertTrue(game.getSeatingChart().getPlayers().stream().noneMatch(p -> p.getId().equals("player-b")));
+        assertEquals("player-c", game.getCurrentRound().getCurrentRoundPlayer().getId());
+        assertEquals("player-c", game.getCurrentRound().getActivePlayer().getId());
+    }
 }


### PR DESCRIPTION
Closes #231

## 背景

源自「玩家死亡後，距離 2 跨屍的玩家距離是否減一」的提問。查證結果：**距離機制已正確** — 死亡結算 `removeDyingPlayer` 會把死者移出 `SeatingChart`，距離自動減一，MongoDB 序列化也以存活名單來回存。本 PR 補回歸測試釘住此行為。

## 真正的 bug

查證時發現：`DyingAskPeachBehavior` 死亡結算先 `removeDyingPlayer(dyingPlayer)`，之後若死者正是回合玩家會呼叫 `goNextRound(dyingPlayer)` → `seatingChart.getNextPlayer` 的 `indexOf` 回 **-1** → `(−1+1) % size = 0` → 下一回合錯誤地跳到座位表第 0 位，而非死者的下一位（中間玩家被跳過回合）。死者恰為 0 號位時碰巧正確，故平常不易發現。

觸發情境：回合玩家在自己回合中死亡 — 例如回合開始閃電判定失敗 3 點傷害致死、自己回合決鬥失敗致死。

## 修法

`Game.goNextRound` 改用 `findNextAlivePlayer`：以 `Game.players`（保留原始座位順序、含死者）由死者座位往後找第一位**仍在座位表上**的玩家。存活判準沿用座位表成員資格（與原行為一致；不用 healthStatus，測試 fixture 未必有設）。對存活玩家呼叫時結果與原本 `seatingChart.getNextPlayer` 完全相同。

## 測試

- `PlayerDeathTest#givenPlayerABCD_WhenBDies_ThenDistanceAcrossDeadPlayerReducesByOne`（回歸）：A 殺死 B 後 `calculateDistance(A,C)` 由 2 → 1、`isInAttackRange(A,C)` 轉 true
- `PlayerDeathTest#givenCurrentRoundPlayerDiesOnOwnTurn_ThenNextRoundGoesToPlayerAfterDeadOne`（bug 重現）：B（1 號位）自己回合閃電判定失敗死亡、全員 skip 桃 → 下一回合為 C。修正前紅：`expected: <player-c> but was: <player-a>`

domain 547 / spring 263 全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV1eQrYWBp5rJA25ock1qP