### PR TITLE
feat: 剛烈在南蠻/萬箭 AOE 傷害中觸發 — 詢問鏈收鏈掃描（issue #233）

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -670,7 +670,7 @@ POST /api/games/{gameId}/player:useSkillEffect
 |---|---|---|---|---|
 | 反饋（司馬懿） | 受傷後（含南蠻/萬箭） | `ACCEPT` / `SKIP` | 可選 1 個值：來源**手牌 index**（數字字串，0-based，同順手牽羊 `targetCardIndex`；張數見 seats）或來源**裝備 id**（`dataCardIds` 列出）；不給 = 取手牌 index 0（無手牌則取第一件裝備） | — |
 | 遺計（郭嘉） | 受傷後 | `ACCEPT`（自摸 2）/ `GIVE`（令他人獲得 1）/ `SKIP` | — | GIVE 必填 |
-| 剛烈（夏侯惇）第一段 | 受傷後 | `ACCEPT`（判定）/ `SKIP` | — | — |
+| 剛烈（夏侯惇）第一段 | 受傷後（含南蠻/萬箭） | `ACCEPT`（判定）/ `SKIP` | — | — |
 | 剛烈 第二段（問傷害來源） | 判定非紅桃後 | `DISCARD` / `DAMAGE` | DISCARD 必填 2 張手牌 | — |
 | 激將（劉備主公技） | 主公劉備被南蠻/決鬥要求出殺時，依座位順序詢問蜀將 | `ACCEPT` / `DECLINE` | ACCEPT 必填 [殺 id]（蜀將手中） | — |
 | 流離（大喬） | 大喬成為殺目標、被問閃之前 | `ACCEPT` / `SKIP` | ACCEPT 必填 [要棄的手牌 id] | ACCEPT 必填：轉移目標（距離 1 內、非攻擊者） |
@@ -757,8 +757,9 @@ POST /api/games/{gameId}/player:useSkillEffect
 - 不想發動：照原本流程出真閃或 `playType: "skip"`
 
 **v1 範圍備註**：
-- 反饋在 AOE polling（南蠻 / 萬箭）中可觸發（PR #221：受傷 → 反饋詢問 → resolve 後 resume 輪詢）；
-  遺計 / 剛烈在 AOE polling 中仍不觸發（可循同一 resume flag 開啟，follow-up）；三者瀕死皆不觸發
+- 反饋 / 剛烈在 AOE polling（南蠻 / 萬箭）中可觸發（PR #221 / issue #165：受傷 → 詢問 →
+  詢問鏈收斂後 resume 輪詢；剛烈兩段式與鬼才巢狀介入亦支援）；
+  遺計在 AOE polling 中仍不觸發（可循同一收鏈掃描開啟，follow-up）；三者瀕死皆不觸發
 - 剛烈 DAMAGE 反傷不進瀕死流程整合（follow-up）
 - 鐵騎 v1 自動判定（不問）；目標有八卦陣時走防具路徑不受鐵騎影響（follow-up）
 - 梟姬不覆蓋「主動換裝蓋掉舊裝備」路徑（follow-up）

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/JianXiongCompatibleTopBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/JianXiongCompatibleTopBehavior.java
@@ -12,6 +12,15 @@ package com.gaas.threeKingdoms.behavior;
 public interface JianXiongCompatibleTopBehavior {
 
     /**
+     * Polling caller 在 damage 後偵測到 OnDamagedSkill 詢問（WaitingSkillEffectBehavior +
+     * resume flag）時，把「待推進的 reactor id」記在自己的 param（BehaviorData 可持久化，
+     * reload-safe）。技能詢問鏈全部完成後（WaitingSkillEffectBehavior.resolveChoice 的
+     * 收鏈掃描），讀取此 param 呼叫 {@link #resumeJianXiongPolling} 並清除。
+     * 剛烈（issue #165）等兩段式/鬼才巢狀詢問也因此能正確 resume。
+     */
+    String PARAM_DEFERRED_ADVANCE_PLAYER_ID = "DEFERRED_ADVANCE_PLAYER_ID";
+
+    /**
      * polling-style caller 在 damage 後仍需保留底層 behavior、等 WaitingJX 解決後 resume polling。
      * caller 須自行：
      *   1. 在 damage 後偵測 {@code WaitingJianXiongResponseBehavior} 在 stack 頂

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/ArrowBarrageBehavior.java
@@ -172,11 +172,13 @@ public class ArrowBarrageBehavior extends Behavior
                 return events;
             }
 
-            // 偵測反饋等 OnDamagedSkill 介入（WaitingSkillEffectBehavior + resume flag）：
-            // polling-advance defer 到 WaitingSkillEffectBehavior.resolveChoice 的 resume hook
+            // 偵測反饋/剛烈等 OnDamagedSkill 介入（WaitingSkillEffectBehavior + resume flag）：
+            // polling-advance defer 到 WaitingSkillEffectBehavior.resolveChoice 的收鏈掃描；
+            // 待推進的 reactor 記在自己的 param（reload-safe）
             if (!game.isTopBehaviorEmpty()
                     && game.peekTopBehavior() instanceof WaitingSkillEffectBehavior wse
                     && "true".equals(wse.getParam(WaitingSkillEffectBehavior.PARAM_RESUME_POLLING))) {
+                putParam(PARAM_DEFERRED_ADVANCE_PLAYER_ID, playerId);
                 List<DomainEvent> events = new ArrayList<>(damagedEvent);
                 String message = game.getGamePhase().getPhaseName().equals("GeneralDying")
                         ? "扣血已瀕臨死亡" : "扣血但還活著";

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/BarbarianInvasionBehavior.java
@@ -156,11 +156,13 @@ public class BarbarianInvasionBehavior extends Behavior implements com.gaas.thre
                 return events;
             }
 
-            // 偵測反饋等 OnDamagedSkill 介入（WaitingSkillEffectBehavior + resume flag）：
-            // polling-advance defer 到 WaitingSkillEffectBehavior.resolveChoice 的 resume hook
+            // 偵測反饋/剛烈等 OnDamagedSkill 介入（WaitingSkillEffectBehavior + resume flag）：
+            // polling-advance defer 到 WaitingSkillEffectBehavior.resolveChoice 的收鏈掃描；
+            // 待推進的 reactor 記在自己的 param（reload-safe）
             if (!game.isTopBehaviorEmpty()
                     && game.peekTopBehavior() instanceof WaitingSkillEffectBehavior wse
                     && "true".equals(wse.getParam(WaitingSkillEffectBehavior.PARAM_RESUME_POLLING))) {
+                putParam(PARAM_DEFERRED_ADVANCE_PLAYER_ID, playerId);
                 List<DomainEvent> events = new ArrayList<>(damagedEvent);
                 String message = game.getGamePhase().getPhaseName().equals("GeneralDying")
                         ? "扣血已瀕臨死亡" : "扣血但還活著";

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingSkillEffectBehavior.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/behavior/behavior/WaitingSkillEffectBehavior.java
@@ -58,24 +58,40 @@ public class WaitingSkillEffectBehavior extends Behavior {
         List<DomainEvent> events = new java.util.ArrayList<>(
                 skill.resolveChoice(game, this, choice, cardIds, targetPlayerId));
 
-        // AOE polling resume：必須在 isOneRound=true 之前跑 —
-        // resume 可能把底層 polling behavior 的 isOneRound 改回 false（mid-poll），
-        // 需先於本 behavior 標記完成、避免 removeCompletedBehaviors 誤 pop polling behavior。
-        if ("true".equals(getParam(PARAM_RESUME_POLLING))) {
-            game.peekTopBehaviorSecondElement().ifPresent(under -> {
-                if (under instanceof com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior compatible
-                        && compatible.isPollingCaller()) {
-                    events.addAll(compatible.resumeJianXiongPolling(behaviorPlayer.getId()));
+        // AOE polling resume 收鏈掃描：damage 當下 polling caller（南蠻/萬箭）把待推進的
+        // reactor 記在自己的 param（DEFERRED_ADVANCE_PLAYER_ID，reload-safe）。本 waiting
+        // 完成後由 stack 頂往下跳過已完成者；第一個未完成 behavior 若正是帶標記的 polling
+        // caller，表示技能詢問鏈已全部收斂 → resume 輪詢並清除標記。
+        // 剛烈兩段式（ASK_XIAHOU → ASK_SOURCE）與鬼才巢狀詢問（issue #165）因此自然收鏈；
+        // 舊版只認「flag waiting 的下一層」，鏈上多一個 waiting 就會斷、輪詢卡住。
+        isOneRound = true;
+        List<com.gaas.threeKingdoms.behavior.Behavior> stack = game.getTopBehavior();
+        for (int i = stack.size() - 1; i >= 0; i--) {
+            com.gaas.threeKingdoms.behavior.Behavior under = stack.get(i);
+            if (under instanceof WaitingSkillEffectBehavior && under.isOneRound()) {
+                continue; // 鏈上已完成、待 pop 的 waiting（含本 behavior 自己）
+            }
+            // 注意不可依 polling behavior 的 isOneRound 判斷 mid-poll（詢問期間可能為 true，
+            // resume 內部才會依剩餘 reactor 重設）；defer 與否只看標記本身
+            if (under instanceof com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior compatible
+                    && compatible.isPollingCaller()) {
+                String deferredReactorId = (String) under.getParam(
+                        com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior.PARAM_DEFERRED_ADVANCE_PLAYER_ID);
+                if (deferredReactorId != null) {
+                    under.putParam(
+                            com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior.PARAM_DEFERRED_ADVANCE_PLAYER_ID,
+                            null);
+                    events.addAll(compatible.resumeJianXiongPolling(deferredReactorId));
                 }
-            });
+            }
+            break; // 只看第一個未完成 behavior
         }
 
         // 最終狀態快照：技能 resolve 可能先發 GameStatusEvent 再推進（鬼才 resume 判定、
-        // 反饋 AOE resume 輪詢），presenter 取最後一個 GameStatusEvent 才能拿到正確的
+        // 反饋/剛烈 AOE resume 輪詢），presenter 取最後一個 GameStatusEvent 才能拿到正確的
         // activePlayer / HP（使用者回報：鬼才換牌後 activePlayer 停在司馬懿）
         events.add(game.getGameStatusEvent(firstStatusMessage(events, skillName + " 結算")));
 
-        isOneRound = true;
         return events;
     }
 

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/GangLieSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/GangLieSkill.java
@@ -26,7 +26,9 @@ import java.util.List;
  *   1. 夏侯惇 ACCEPT → 立即判定；紅桃 → 結束；非紅桃 → push 第二個 WaitingSkillEffect 問來源
  *   2. 來源 choice "DISCARD" + cardIds(2 張手牌) 或 "DAMAGE"（受 1 傷）
  *
- * v1 範圍：非 AOE polling 中觸發；來源手牌 < 2 時只能選 DAMAGE。
+ * AOE polling（南蠻/萬箭）中亦觸發（mirror 反饋 #221）：詢問鏈（含 ASK_SOURCE 第二段、
+ * 鬼才巢狀）全部收斂後由 WaitingSkillEffectBehavior 收鏈掃描 resume 輪詢。
+ * 來源手牌 < 2 時只能選 DAMAGE；反傷不進瀕死流程（同反間，v1 慣例）。
  */
 public class GangLieSkill implements OnDamagedSkill, ChoiceResolvableSkill {
 
@@ -57,15 +59,22 @@ public class GangLieSkill implements OnDamagedSkill, ChoiceResolvableSkill {
             return List.of();
         }
         Behavior top = game.isTopBehaviorEmpty() ? null : game.peekTopBehavior();
-        if (top != null && !(top instanceof JianXiongCompatibleTopBehavior compatible
-                && !compatible.isPollingCaller())) {
+        if (top != null && !(top instanceof JianXiongCompatibleTopBehavior)) {
             return List.of();
         }
-
-        game.removeCompletedBehaviors();
+        // polling caller（南蠻/萬箭）需保留底層 behavior，詢問鏈收斂後 resume 輪詢
+        // （mirror 反饋 #221 樣板；兩段式收鏈由 WaitingSkillEffectBehavior 掃描處理）
+        boolean isPollingCaller = top instanceof JianXiongCompatibleTopBehavior compatible
+                && compatible.isPollingCaller();
+        if (!isPollingCaller) {
+            game.removeCompletedBehaviors();
+        }
         WaitingSkillEffectBehavior waiting = new WaitingSkillEffectBehavior(game, damaged, SKILL_NAME);
         waiting.putParam(PARAM_SOURCE_ID, source.getId());
         waiting.putParam(PARAM_STAGE, "ASK_XIAHOU");
+        if (isPollingCaller) {
+            waiting.putParam(WaitingSkillEffectBehavior.PARAM_RESUME_POLLING, "true");
+        }
         game.updateTopBehavior(waiting);
         game.getCurrentRound().setActivePlayer(damaged);
 

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/GuiCaiSkill.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/skill/wei/GuiCaiSkill.java
@@ -211,9 +211,16 @@ public class GuiCaiSkill implements ChoiceResolvableSkill {
     private List<DomainEvent> resumeGangLie(Game game, WaitingSkillEffectBehavior waiting,
                                             Player owner, HandCard judgementCard) {
         String sourceId = (String) waiting.getParam(PARAM_GANGLIE_SOURCE_ID);
-        // pop 鬼才 waiting + 底下已完成的剛烈 ASK_XIAHOU waiting
+        // pop 鬼才 waiting + 底下已完成的剛烈 ASK_XIAHOU waiting。
+        // 不可用 removeCompletedBehaviors：AOE（南蠻/萬箭）mid-poll 的 polling behavior
+        // isOneRound 亦為 true，會被一併掃掉、收鏈掃描便找不到 deferred polling caller
+        // （issue #165 剛烈 AOE）。只 pop 已完成的技能詢問 waiting。
         waiting.setIsOneRound(true);
-        game.removeCompletedBehaviors();
+        var stack = game.getTopBehavior();
+        while (!stack.isEmpty() && stack.peek() instanceof WaitingSkillEffectBehavior
+                && stack.peek().isOneRound()) {
+            stack.pop();
+        }
         return GangLieSkill.resolveJudgementOutcome(game, owner, sourceId, judgementCard);
     }
 

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/GangLieAoePollingTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/GangLieAoePollingTest.java
@@ -1,0 +1,235 @@
+package com.gaas.threeKingdoms;
+
+import com.gaas.threeKingdoms.builders.PlayerBuilder;
+import com.gaas.threeKingdoms.events.AskDodgeEvent;
+import com.gaas.threeKingdoms.events.AskKillEvent;
+import com.gaas.threeKingdoms.events.AskSkillEffectEvent;
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.gamephase.Normal;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.generalcard.GeneralCard;
+import com.gaas.threeKingdoms.handcard.Deck;
+import com.gaas.threeKingdoms.handcard.PlayType;
+import com.gaas.threeKingdoms.handcard.basiccard.Kill;
+import com.gaas.threeKingdoms.handcard.basiccard.Peach;
+import com.gaas.threeKingdoms.handcard.scrollcard.ArrowBarrage;
+import com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion;
+import com.gaas.threeKingdoms.handcard.scrollcard.Dismantle;
+import com.gaas.threeKingdoms.player.*;
+import com.gaas.threeKingdoms.rolecard.Role;
+import com.gaas.threeKingdoms.rolecard.RoleCard;
+import com.gaas.threeKingdoms.round.Round;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.gaas.threeKingdoms.handcard.PlayCard.*;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 剛烈 × AOE polling（南蠻入侵 / 萬箭齊發）— wiki「當你受到傷害後」應含 AOE 傷害（issue #165）。
+ * 先前 GangLieSkill 在 polling caller 上直接跳過（Batch 12 註記的同型缺口）；本測試驗證：
+ * 受傷 → 剛烈詢問（polling-advance defer）→ 兩段式詢問鏈（判定 → 問來源）
+ * 甚至鬼才巢狀介入後，收鏈 resume 輪詢（不跳人、不卡住）。
+ */
+public class GangLieAoePollingTest {
+
+    private Game createGame(General gA, General gB, General gC, General gD) {
+        Game game = new Game();
+        game.initDeck();
+        Player a = build("player-a", gA, Role.MONARCH);
+        Player b = build("player-b", gB, Role.MINISTER);
+        Player c = build("player-c", gC, Role.REBEL);
+        Player d = build("player-d", gD, Role.TRAITOR);
+        game.setPlayers(asList(a, b, c, d));
+        game.setCurrentRound(new Round(a));
+        game.enterPhase(new Normal(game));
+        return game;
+    }
+
+    private Player build(String id, General general, Role role) {
+        return PlayerBuilder.construct().withId(id)
+                .withBloodCard(new BloodCard(4))
+                .withGeneralCard(new GeneralCard(general))
+                .withHealthStatus(HealthStatus.ALIVE)
+                .withRoleCard(new RoleCard(role))
+                .withHand(new Hand()).withEquipment(new Equipment()).build();
+    }
+
+    private List<String> askKillTargets(List<DomainEvent> events) {
+        return events.stream().filter(e -> e instanceof AskKillEvent)
+                .map(e -> ((AskKillEvent) e).getPlayerId()).toList();
+    }
+
+    private List<String> askDodgeTargets(List<DomainEvent> events) {
+        return events.stream().filter(e -> e instanceof AskDodgeEvent)
+                .map(e -> ((AskDodgeEvent) e).getPlayerId()).toList();
+    }
+
+    private boolean hasSkillAsk(List<DomainEvent> events, String skillName, String playerId) {
+        return events.stream().anyMatch(e -> e instanceof AskSkillEffectEvent ask
+                && ask.getSkillName().equals(skillName) && ask.getPlayerId().equals(playerId));
+    }
+
+    @DisplayName("南蠻：b=夏侯惇 skip 受傷 → 剛烈 ACCEPT 判定黑桃生效 → 來源 a 棄兩張 → resume 問 c")
+    @Test
+    public void gangLieDiscardInBarbarianInvasion_thenNextAskedIsC() {
+        Game game = createGame(General.甘寧, General.夏侯惇, General.孫權, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(List.of(new BarbarianInvasion(SS7007), new Peach(BH3029), new Kill(BS8008)));
+        game.setDeck(new Deck(List.of(new Dismantle(SS3003)))); // 判定牌：黑桃 3 → 剛烈生效
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        List<DomainEvent> e2 = game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+
+        assertTrue(hasSkillAsk(e2, "剛烈", "player-b"), "受傷後應詢問剛烈");
+        assertTrue(askKillTargets(e2).isEmpty(), "剛烈詢問中，不應先問下一個 reactor");
+        assertEquals(3, game.getPlayer("player-b").getHP());
+
+        List<DomainEvent> e3 = game.playerUseSkillEffect("player-b", "剛烈", "ACCEPT", null, null);
+        assertTrue(hasSkillAsk(e3, "剛烈", "player-a"), "判定生效後應問來源選擇");
+        assertTrue(askKillTargets(e3).isEmpty(), "來源選擇中，仍不應問下一個 reactor");
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId());
+
+        List<DomainEvent> e4 = game.playerUseSkillEffect("player-a", "剛烈", "DISCARD",
+                List.of(BH3029.getCardId(), BS8008.getCardId()), null);
+
+        assertEquals(0, a.getHandSize(), "來源棄兩張手牌");
+        assertTrue(game.getGraveyard().contains(BH3029.getCardId()));
+        assertEquals(List.of("player-c"), askKillTargets(e4), "剛烈鏈收斂後 resume 輪詢問 c — 跳到 d 或卡住即為 bug");
+        assertEquals("player-c", game.getCurrentRound().getActivePlayer().getId());
+
+        List<DomainEvent> e5 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e5), "c skip 後問 d");
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("南蠻：剛烈 SKIP → 直接 resume 輪詢問 c")
+    @Test
+    public void gangLieSkipInBarbarianInvasion_thenNextAskedIsC() {
+        Game game = createGame(General.甘寧, General.夏侯惇, General.孫權, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(List.of(new BarbarianInvasion(SS7007)));
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        List<DomainEvent> e3 = game.playerUseSkillEffect("player-b", "剛烈", "SKIP", null, null);
+
+        assertEquals(List.of("player-c"), askKillTargets(e3), "放棄剛烈後問 c");
+        assertEquals("player-c", game.getCurrentRound().getActivePlayer().getId());
+
+        List<DomainEvent> e4 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e4));
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("萬箭：剛烈 ACCEPT 判定紅桃 → 未生效（不問來源）→ resume 問 c 出閃")
+    @Test
+    public void gangLieHeartJudgementInArrowBarrage_thenNextAskedIsC() {
+        Game game = createGame(General.甘寧, General.夏侯惇, General.孫權, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(new ArrowBarrage(SHA040));
+        game.setDeck(new Deck(List.of(new Peach(BH3029)))); // 判定牌：紅心 3 → 剛烈不生效
+
+        game.playerPlayCard("player-a", SHA040.getCardId(), "player-a", "active");
+        List<DomainEvent> e2 = game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+
+        assertTrue(hasSkillAsk(e2, "剛烈", "player-b"), "受傷後應詢問剛烈");
+        assertTrue(askDodgeTargets(e2).isEmpty(), "剛烈詢問中，不應先問下一個 reactor");
+
+        List<DomainEvent> e3 = game.playerUseSkillEffect("player-b", "剛烈", "ACCEPT", null, null);
+
+        assertFalse(hasSkillAsk(e3, "剛烈", "player-a"), "判定紅桃未生效，不應問來源");
+        assertEquals(4, game.getPlayer("player-a").getHP(), "來源不受傷");
+        assertEquals(List.of("player-c"), askDodgeTargets(e3), "判定未生效直接 resume 問 c 出閃");
+
+        List<DomainEvent> e4 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askDodgeTargets(e4));
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("南蠻：最後一個 reactor d=夏侯惇 → 剛烈 ACCEPT + 來源選 DAMAGE → 輪詢收尾、a 扣 1 血")
+    @Test
+    public void gangLieDamageOnLastReactor_pollingEndsCleanly() {
+        Game game = createGame(General.甘寧, General.孫權, General.孫權, General.夏侯惇);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(List.of(new BarbarianInvasion(SS7007)));
+        game.setDeck(new Deck(List.of(new Dismantle(SS3003)))); // 黑桃 → 生效
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        List<DomainEvent> e4 = game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+
+        assertTrue(hasSkillAsk(e4, "剛烈", "player-d"), "最後一個 reactor 受傷也應詢問剛烈");
+        assertFalse(game.getTopBehavior().isEmpty(), "剛烈詢問中");
+
+        game.playerUseSkillEffect("player-d", "剛烈", "ACCEPT", null, null);
+        game.playerUseSkillEffect("player-a", "剛烈", "DAMAGE", null, null);
+
+        assertEquals(3, a.getHP(), "來源受剛烈 1 點傷害");
+        assertTrue(game.getTopBehavior().isEmpty(), "剛烈鏈收斂後輪詢結束、stack 清空");
+        assertEquals("player-a", game.getCurrentRound().getActivePlayer().getId(),
+                "輪詢結束 activePlayer 回到出牌者");
+    }
+
+    @DisplayName("南蠻 + 鬼才：司馬懿換紅桃判定牌 → 剛烈未生效 → resume 問 c（三層巢狀收鏈）")
+    @Test
+    public void gangLieWithGuiCaiReplacementToHeart_thenNextAskedIsC() {
+        Game game = createGame(General.甘寧, General.夏侯惇, General.司馬懿, General.孫權);
+        game.getPlayer("player-a").getHand().addCardToHand(List.of(new BarbarianInvasion(SS7007)));
+        game.getPlayer("player-c").getHand().addCardToHand(List.of(new Peach(BH3029))); // 司馬懿手牌（紅心）
+        game.setDeck(new Deck(List.of(new Dismantle(SS3003)))); // 原判定黑桃（若無鬼才會生效）
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        List<DomainEvent> e3 = game.playerUseSkillEffect("player-b", "剛烈", "ACCEPT", null, null);
+
+        assertTrue(hasSkillAsk(e3, "鬼才", "player-c"), "判定牌抽出後應詢問司馬懿鬼才");
+        assertTrue(askKillTargets(e3).isEmpty(), "鬼才詢問中，不應先問下一個 reactor");
+
+        List<DomainEvent> e4 = game.playerUseSkillEffect("player-c", "鬼才", "ACCEPT",
+                List.of(BH3029.getCardId()), null);
+
+        assertFalse(hasSkillAsk(e4, "剛烈", "player-a"), "換成紅桃 → 剛烈未生效，不問來源");
+        assertEquals(4, game.getPlayer("player-a").getHP());
+        assertEquals(List.of("player-c"), askKillTargets(e4), "鬼才巢狀收鏈後 resume 問 c");
+
+        List<DomainEvent> e5 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e5));
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+
+    @DisplayName("南蠻 + 鬼才 SKIP：原判定黑桃生效 → 來源棄兩張 → resume 問 c（鬼才不換牌路徑）")
+    @Test
+    public void gangLieWithGuiCaiSkip_thenSourceDiscardsAndPollingResumes() {
+        Game game = createGame(General.甘寧, General.夏侯惇, General.司馬懿, General.孫權);
+        Player a = game.getPlayer("player-a");
+        a.getHand().addCardToHand(List.of(new BarbarianInvasion(SS7007), new Peach(BH3029), new Kill(BS8008)));
+        game.getPlayer("player-c").getHand().addCardToHand(List.of(new Peach(BH4030))); // 司馬懿手牌
+        game.setDeck(new Deck(List.of(new Dismantle(SS3003)))); // 黑桃 → 生效
+
+        game.playerPlayCard("player-a", SS7007.getCardId(), "player-a", "active");
+        game.playerPlayCard("player-b", "", "player-a", PlayType.SKIP.getPlayType());
+        List<DomainEvent> e3 = game.playerUseSkillEffect("player-b", "剛烈", "ACCEPT", null, null);
+        assertTrue(hasSkillAsk(e3, "鬼才", "player-c"));
+
+        List<DomainEvent> e4 = game.playerUseSkillEffect("player-c", "鬼才", "SKIP", null, null);
+        assertTrue(hasSkillAsk(e4, "剛烈", "player-a"), "原判定黑桃生效 → 問來源選擇");
+        assertTrue(askKillTargets(e4).isEmpty(), "來源選擇中，不應先問下一個 reactor");
+
+        List<DomainEvent> e5 = game.playerUseSkillEffect("player-a", "剛烈", "DISCARD",
+                List.of(BH3029.getCardId(), BS8008.getCardId()), null);
+        assertEquals(0, a.getHandSize());
+        assertEquals(List.of("player-c"), askKillTargets(e5), "三層鏈全部收斂後 resume 問 c");
+
+        List<DomainEvent> e6 = game.playerPlayCard("player-c", "", "player-a", PlayType.SKIP.getPlayType());
+        assertEquals(List.of("player-d"), askKillTargets(e6));
+        game.playerPlayCard("player-d", "", "player-a", PlayType.SKIP.getPlayType());
+        assertTrue(game.getTopBehavior().isEmpty());
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/repository/data/BehaviorData.java
@@ -65,6 +65,7 @@ public class BehaviorData {
                 if (params != null && Boolean.TRUE.equals(params.get(POLLING_STARTED))) {
                     barbarianInvasionBehavior.setPollingStarted(true);
                 }
+                restoreDeferredAdvanceParam(barbarianInvasionBehavior);
                 yield barbarianInvasionBehavior;
             }
             case "ArrowBarrageBehavior" -> {
@@ -80,6 +81,7 @@ public class BehaviorData {
                 if (params != null && Boolean.TRUE.equals(params.get(POLLING_STARTED))) {
                     arrowBarrageBehavior.setPollingStarted(true);
                 }
+                restoreDeferredAdvanceParam(arrowBarrageBehavior);
                 yield arrowBarrageBehavior;
             }
             case "BorrowedSwordBehavior" -> {
@@ -440,6 +442,17 @@ public class BehaviorData {
         return behavior;
     }
 
+
+    /**
+     * AOE polling caller 的 deferred-advance 標記（反饋/剛烈詢問鏈收斂後 resume 輪詢用，
+     * issue #165/#221）— toDomain 逐 key 還原，漏掉會在跨 request 時 resume 失效（#209 同型）。
+     */
+    private void restoreDeferredAdvanceParam(Behavior behavior) {
+        String key = com.gaas.threeKingdoms.behavior.JianXiongCompatibleTopBehavior.PARAM_DEFERRED_ADVANCE_PLAYER_ID;
+        if (params != null && params.get(key) != null) {
+            behavior.putParam(key, params.get(key));
+        }
+    }
 
     public static BehaviorData fromDomain(Behavior behavior) {
         Map<String, Object> params = new HashMap<>(behavior.getParams());

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/SkillEffectTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/SkillEffectTest.java
@@ -238,4 +238,76 @@ public class SkillEffectTest extends AbstractBaseIntegrationTest {
         assertTrue(saved.getTopBehavior().isEmpty());
         assertEquals("player-b", saved.getCurrentRound().getActivePlayer().getId());
     }
+
+    @Test
+    public void testGangLieInBarbarianInvasionPollingAcrossRequests() throws Exception {
+        // Given：A 出南蠻，B（夏侯惇）無殺 skip 受傷 → 剛烈兩段式詢問鏈
+        // （ASK_XIAHOU → 判定 → ASK_SOURCE，defer 標記與 waiting 經 3 次 MongoDB 存取）
+        Player playerA = createPlayer("player-a", 4, General.劉備, HealthStatus.ALIVE, Role.MONARCH,
+                new com.gaas.threeKingdoms.handcard.scrollcard.BarbarianInvasion(SS7007),
+                new Peach(BH3029), new Kill(BS9009));
+        Player playerB = createPlayer("player-b", 4, General.夏侯惇, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.孫權, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(gameId, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        Deck deck = new Deck();
+        deck.add(List.of(new Kill(BS8008))); // 剛烈判定牌：黑桃 → 生效
+        game.setDeck(deck);
+        repository.save(game);
+
+        mockMvcUtil.playCard(gameId, "player-a", "player-a", "SS7007", PlayType.ACTIVE.getPlayType())
+                .andExpect(status().isOk());
+        mockMvcUtil.playCard(gameId, "player-b", "player-a", "", "skip")
+                .andExpect(status().isOk());
+
+        // 剛烈詢問中：輪詢暫停（activePlayer = B），底層南蠻 behavior 保留
+        Game paused = repository.findById(gameId).orElseThrow();
+        assertEquals("player-b", paused.getCurrentRound().getActivePlayer().getId());
+        assertEquals(2, paused.getTopBehavior().size(), "南蠻 behavior + 剛烈 waiting");
+        assertEquals(3, paused.getPlayer("player-b").getHP());
+
+        // B ACCEPT 剛烈 → 判定黑桃生效 → 問來源 A（第二段 waiting，輪詢仍暫停）
+        mockMvc.perform(post("/api/games/" + gameId + "/player:useSkillEffect")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "playerId": "player-b",
+                                  "skillName": "剛烈",
+                                  "choice": "ACCEPT"
+                                }"""))
+                .andExpect(status().isOk());
+
+        Game askSource = repository.findById(gameId).orElseThrow();
+        assertEquals("player-a", askSource.getCurrentRound().getActivePlayer().getId(),
+                "判定生效後問來源選擇");
+
+        // A 選 DISCARD 棄兩張手牌 → 剛烈鏈收斂 → resume 輪詢問 C
+        mockMvc.perform(post("/api/games/" + gameId + "/player:useSkillEffect")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "playerId": "player-a",
+                                  "skillName": "剛烈",
+                                  "choice": "DISCARD",
+                                  "cardIds": ["BH3029", "BS9009"]
+                                }"""))
+                .andExpect(status().isOk());
+
+        Game resumed = repository.findById(gameId).orElseThrow();
+        assertEquals(0, resumed.getPlayer("player-a").getHandSize(), "來源棄兩張手牌");
+        assertTrue(resumed.getGraveyard().contains(BH3029.getCardId()));
+        assertEquals("player-c", resumed.getCurrentRound().getActivePlayer().getId(),
+                "剛烈鏈收斂後 resume 輪詢問 C");
+
+        // C、D skip → 輪詢正常結束
+        mockMvcUtil.playCard(gameId, "player-c", "player-a", "", "skip")
+                .andExpect(status().isOk());
+        mockMvcUtil.playCard(gameId, "player-d", "player-a", "", "skip")
+                .andExpect(status().isOk());
+
+        Game finalState = repository.findById(gameId).orElseThrow();
+        assertTrue(finalState.getTopBehavior().isEmpty());
+        assertEquals(3, finalState.getPlayer("player-c").getHP());
+        assertEquals(3, finalState.getPlayer("player-d").getHP());
+        assertEquals("player-a", finalState.getCurrentRound().getActivePlayer().getId(),
+                "輪詢結束 activePlayer 回到出牌者");
+    }
 }


### PR DESCRIPTION
Closes #233

## 背景（夏侯惇 剛烈 進度確認）

wiki「當你受到傷害後」應含 AOE 傷害。剛烈既有實作（#165）在南蠻入侵/萬箭齊發的 polling caller 上直接跳過（Batch 12 註記的同型缺口；反饋已在 #221 修復）。

## 為什麼不能直接套反饋樣板

反饋是單段詢問：resolve 後檢查「flag waiting 的下一層是否為 polling caller」即可 resume。剛烈是**兩段式**（判定生效後 push 第二個 waiting 問來源），還可能被**鬼才**插入第三層 waiting — 舊檢查在鏈上多一個 waiting 就斷，輪詢卡住。

## 修法：收鏈掃描（reload-safe）

1. `GangLieSkill.onDamaged`：polling caller 不跳過，push waiting + resume flag（mirror 反饋）
2. **BI/AB** damage defer 時把「待推進的 reactor id」記在自己的 param `DEFERRED_ADVANCE_PLAYER_ID`（BehaviorData 持久化，無 transient callback）
3. **`WaitingSkillEffectBehavior.resolveChoice`**：任一 waiting 完成後，由 stack 頂往下跳過已完成的 waiting；第一個未完成 behavior 若是帶標記的 polling caller → resume 輪詢並清標記。單段（反饋）、兩段（剛烈）、鬼才巢狀統一在「鏈上最後一個 waiting 完成」時收斂
4. **`GuiCaiSkill.resumeGangLie`**：不可用 `removeCompletedBehaviors` — mid-poll 的南蠻/萬箭 `isOneRound` 為 true 會被一併掃掉、掃描便找不到 polling caller；改只 pop 已完成的技能 waiting
5. **`BehaviorData`**（BI/AB toDomain）補還原 defer 標記 — 漏還原時 domain 測試全綠但跨 request 失效（#209 教訓，spring e2e 抓到）

## 測試（多情境）

domain `GangLieAoePollingTest` ×6：
- 南蠻：ACCEPT → 判定黑 → 來源 DISCARD 兩張 → resume 問下一位
- 南蠻：SKIP → 直接 resume
- 萬箭：判定紅桃 → 未生效（不問來源）→ resume
- 南蠻最後 reactor：ACCEPT + DAMAGE → 輪詢收尾、activePlayer 回出牌者
- 南蠻 + 鬼才換紅桃 → 未生效 → resume（三層巢狀收鏈）
- 南蠻 + 鬼才 SKIP → 黑桃生效 → DISCARD → resume（三層全走完）

spring e2e ×1：南蠻中剛烈兩段式跨 request（defer 標記經 3 次 MongoDB round-trip）。
反饋既有 `FanKuiAoePollingTest` ×5 + e2e 遷移到收鏈掃描後仍綠。

**domain 553 / spring 264 全綠。**

API_DOC：剛烈第一段觸發時機改「受傷後（含南蠻/萬箭）」；v1 備註更新（遺計 AOE 仍為 follow-up）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV1eQrYWBp5rJA25ock1qP