### PR TITLE
feat: 選將進度廣播 GeneralSelectionStatusEvent（issue #237）

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -62,7 +62,7 @@ POST /api/games/{gameId}/player:monarchChooseGeneral
 | playerId | String | 主公玩家 ID |
 | generalId | String | 選擇的武將 ID（如 SHU001 劉備） |
 
-**流程**：主公選將 → 其他玩家收到可選將領列表
+**流程**：主公選將 → 其他玩家收到可選將領列表；另廣播全員選將進度（見下方 GeneralSelectionStatusEvent）
 
 ---
 
@@ -77,7 +77,32 @@ POST /api/games/{gameId}/player:otherChooseGeneral
 | playerId | String | 玩家 ID |
 | generalId | String | 選擇的武將 ID |
 
-**流程**：全部選完 → 發牌（每人 4 張）→ 主公回合開始
+**流程**：每位玩家選完都廣播全員選將進度；全部選完 → 發牌（每人 4 張）→ 主公回合開始（`InitialEndEvent` + `RoundStartEvent` 即開局訊號，無另外的「開始遊戲」API）
+
+### 選將進度廣播 GeneralSelectionStatusEvent（issue #237）
+
+每次有人選完武將（含主公）廣播給**全部玩家**：
+
+```json
+{
+  "gameId": "my-id",
+  "playerIds": ["Scolley", "Happypola", "YangJun", "Tux"],
+  "event": "GeneralSelectionStatusEvent",
+  "data": {
+    "selectedPlayerIds": ["Scolley", "Tux"],
+    "pendingPlayerIds": ["Happypola", "YangJun"],
+    "selectedCount": 2,
+    "totalCount": 4,
+    "allSelected": false
+  },
+  "message": "Tux 已選擇武將（2/4）"
+}
+```
+
+- **不帶武將 id** — 身分局非主公暗選，武將由開局的 `InitialEndEvent` 揭曉（主公另有 `MonarchGeneralChosenEvent` 公開亮將）
+- 最後一位選完會先收到 `allSelected: true` 的進度，接著才是 `InitialEndEvent`
+- 前端判斷：`data.pendingPlayerIds.length === 0` = 全員已選；收到 `InitialEndEvent` = 進入牌局
+- **重整/重連補狀態**：選將階段呼叫 `GET /api/games/{gameId}?playerId=xxx`，推播的 `findGameEvent` 會在 `data.selectionStatus` 帶同一份進度物件（非選將階段為 `null`）
 
 ---
 
@@ -812,6 +837,7 @@ Stack trace 僅記錄於 server log。
 
 | 事件 | 說明 | 觸發 API |
 |------|------|----------|
+| `GeneralSelectionStatusEvent` | 選將進度（每次有人選完武將廣播全員；格式見「其他玩家選將」節） | monarchChooseGeneral / otherChooseGeneral |
 | `PlayCardEvent` | 有人出牌 | playCard |
 | `PlayWardCardEvent` | 有人出無懈可擊 | playWardCard |
 | `GameStatusEvent` | 遊戲狀態更新（每次操作都附帶） | 所有 API |

--- a/LegendsOfTheThreeKingdoms/app/src/main/java/com/gaas/threeKingdoms/usecase/MonarchChooseGeneralUseCase.java
+++ b/LegendsOfTheThreeKingdoms/app/src/main/java/com/gaas/threeKingdoms/usecase/MonarchChooseGeneralUseCase.java
@@ -19,12 +19,14 @@ public class MonarchChooseGeneralUseCase {
     private final GameRepository repository;
 
 
-    public void execute(String gameId, MonarchChooseGeneralRequest request, MonarchChooseGeneralCardPresenter presenter) {
+    public void execute(String gameId, MonarchChooseGeneralRequest request, MonarchChooseGeneralCardPresenter presenter,
+                        OthersChoosePlayerGeneralUseCase.SelectionStatusPresenter selectionStatusPresenter) {
         Game game = repository.findById(gameId)
                 .orElseThrow(() -> new NotFoundException("Game not found"));
         List<DomainEvent> events = game.monarchChoosePlayerGeneral(request.getPlayerId(), request.getGeneralId());
         repository.save(game);
         presenter.renderEvents(events);
+        selectionStatusPresenter.renderEvents(events);
     }
 
 

--- a/LegendsOfTheThreeKingdoms/app/src/main/java/com/gaas/threeKingdoms/usecase/OthersChoosePlayerGeneralUseCase.java
+++ b/LegendsOfTheThreeKingdoms/app/src/main/java/com/gaas/threeKingdoms/usecase/OthersChoosePlayerGeneralUseCase.java
@@ -15,13 +15,14 @@ public class OthersChoosePlayerGeneralUseCase {
 
     private final GameRepository repository;
 
-    public void execute(String gameId, MonarchChooseGeneralUseCase.MonarchChooseGeneralRequest request, InitialEndPresenter initialEndPresenter, RoundStartPresenter roundStartPresenter) {
+    public void execute(String gameId, MonarchChooseGeneralUseCase.MonarchChooseGeneralRequest request, InitialEndPresenter initialEndPresenter, RoundStartPresenter roundStartPresenter, SelectionStatusPresenter selectionStatusPresenter) {
         Game game = repository.findById(gameId)
                 .orElseThrow(() -> new NotFoundException("Game not found"));
         List<DomainEvent> events = game.othersChoosePlayerGeneral(request.getPlayerId(), request.getGeneralId());
         repository.save(game);
         initialEndPresenter.renderEvents(events);
         roundStartPresenter.renderEvents(events);
+        selectionStatusPresenter.renderEvents(events);
     }
 
 
@@ -32,6 +33,13 @@ public class OthersChoosePlayerGeneralUseCase {
     }
 
     public interface RoundStartPresenter<T> {
+        void renderEvents(List<DomainEvent> events);
+
+        T present();
+    }
+
+    /** 選將進度廣播（issue #237） */
+    public interface SelectionStatusPresenter<T> {
         void renderEvents(List<DomainEvent> events);
 
         T present();

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/Game.java
@@ -114,8 +114,22 @@ public class Game {
 
         List<DomainEvent> getGeneralCardEventByOthers = getOtherCanChooseGeneralCards();
         getGeneralCardEventByOthers.add(monarchChooseGeneralCardEvent);
+        getGeneralCardEventByOthers.add(buildGeneralSelectionStatusEvent(playerId));
 
         return getGeneralCardEventByOthers;
+    }
+
+    /**
+     * 選將進度快照（issue #237）：只帶「誰選完了」，不帶武將 id — 非主公暗選，
+     * 武將由 InitialEndEvent 開局揭曉。
+     */
+    private GeneralSelectionStatusEvent buildGeneralSelectionStatusEvent(String justSelectedPlayerId) {
+        List<String> selected = players.stream()
+                .filter(p -> p.getGeneralCard() != null).map(Player::getId).toList();
+        List<String> pending = players.stream()
+                .filter(p -> p.getGeneralCard() == null).map(Player::getId).toList();
+        return new GeneralSelectionStatusEvent(gameId,
+                players.stream().map(Player::getId).toList(), selected, pending, justSelectedPlayerId);
     }
 
     public List<DomainEvent> othersChoosePlayerGeneral(String playerId, String generalId) {
@@ -124,7 +138,8 @@ public class Game {
         player.setGeneralCard(generalCard);
 
         if (players.stream().anyMatch(currentPlayer -> currentPlayer.getGeneralCard() == null)) {
-            return Collections.emptyList();
+            // 還有人沒選完：廣播選將進度（先前回空 events → 前端無從得知進度，issue #237）
+            return List.of(buildGeneralSelectionStatusEvent(playerId));
         }
 
         assignHpToPlayers();
@@ -153,7 +168,9 @@ public class Game {
         DomainEvent initialEndEvent = new InitialEndEvent(gameId, playerEvents, roundEvent, this.getGamePhase().getPhaseName());
 
         List<DomainEvent> domainEvents = playerTakeTurn(getCurrentRoundPlayer());
-        List<DomainEvent> combineEvents = new ArrayList<>(List.of(initialEndEvent));
+        // 最後一位選完：進度（allSelected=true）→ InitialEnd 開局（issue #237）
+        List<DomainEvent> combineEvents = new ArrayList<>(
+                List.of(buildGeneralSelectionStatusEvent(playerId), initialEndEvent));
         combineEvents.addAll(domainEvents);
 
         return combineEvents;

--- a/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/GeneralSelectionStatusEvent.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/main/java/com/gaas/threeKingdoms/events/GeneralSelectionStatusEvent.java
@@ -1,0 +1,33 @@
+package com.gaas.threeKingdoms.events;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 選將進度廣播（issue #237）：每次有人選完武將（含主公）就廣播給全部玩家。
+ * <p>
+ * 只帶「誰選完了」，不帶選了什麼 — 身分局其他人是暗選，武將 id 由開局的
+ * {@link InitialEndEvent} 才揭曉（主公亮將另有 MonarchChooseGeneralCardEvent）。
+ */
+@Getter
+public class GeneralSelectionStatusEvent extends DomainEvent {
+
+    private final String gameId;
+    private final List<String> playerIds; // 全部玩家（broadcast 路由用）
+    private final List<String> selectedPlayerIds;
+    private final List<String> pendingPlayerIds;
+    private final boolean allSelected;
+
+    public GeneralSelectionStatusEvent(String gameId, List<String> playerIds,
+                                       List<String> selectedPlayerIds, List<String> pendingPlayerIds,
+                                       String justSelectedPlayerId) {
+        super("GeneralSelectionStatusEvent", String.format("%s 已選擇武將（%d/%d）",
+                justSelectedPlayerId, selectedPlayerIds.size(), playerIds.size()));
+        this.gameId = gameId;
+        this.playerIds = playerIds;
+        this.selectedPlayerIds = selectedPlayerIds;
+        this.pendingPlayerIds = pendingPlayerIds;
+        this.allSelected = pendingPlayerIds.isEmpty();
+    }
+}

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/GeneralSelectionStatusTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/GeneralSelectionStatusTest.java
@@ -1,0 +1,108 @@
+package com.gaas.threeKingdoms;
+
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.GeneralSelectionStatusEvent;
+import com.gaas.threeKingdoms.events.InitialEndEvent;
+import com.gaas.threeKingdoms.events.RoundStartEvent;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.player.Hand;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.rolecard.Role;
+import com.gaas.threeKingdoms.rolecard.RoleCard;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 選將進度廣播（issue #237）：每次有人選完武將就發 GeneralSelectionStatusEvent。
+ * 先前 othersChoosePlayerGeneral 在還有人沒選完時回空 events → 前端無從得知進度。
+ * 進度事件不帶武將 id（非主公暗選，由 InitialEndEvent 開局揭曉）。
+ */
+public class GeneralSelectionStatusTest {
+
+    private Game createInitialGame() {
+        Player a = createPlayer("player-a", Role.MONARCH);
+        Player b = createPlayer("player-b", Role.MINISTER);
+        Player c = createPlayer("player-c", Role.REBEL);
+        Player d = createPlayer("player-d", Role.TRAITOR);
+        Game game = new Game("test-game", List.of(a, b, c, d));
+        game.initDeck();
+        return game;
+    }
+
+    private Player createPlayer(String id, Role role) {
+        Player player = new Player();
+        player.setId(id);
+        player.setHand(new Hand());
+        player.setRoleCard(new RoleCard(role));
+        return player;
+    }
+
+    private Optional<GeneralSelectionStatusEvent> statusEvent(List<DomainEvent> events) {
+        return events.stream()
+                .filter(e -> e instanceof GeneralSelectionStatusEvent)
+                .map(e -> (GeneralSelectionStatusEvent) e)
+                .findFirst();
+    }
+
+    @DisplayName("主公選完武將 → 進度事件 1/4，pending 為其餘三位")
+    @Test
+    public void monarchChooseGeneral_emitsSelectionStatus() {
+        Game game = createInitialGame();
+
+        List<DomainEvent> events = game.monarchChoosePlayerGeneral(
+                "player-a", General.甘寧.getGeneralId());
+
+        GeneralSelectionStatusEvent status = statusEvent(events).orElseThrow();
+        assertEquals(List.of("player-a"), status.getSelectedPlayerIds());
+        assertEquals(List.of("player-b", "player-c", "player-d"), status.getPendingPlayerIds());
+        assertFalse(status.isAllSelected());
+        assertEquals("player-a 已選擇武將（1/4）", status.getMessage());
+        assertEquals("test-game", status.getGameId());
+        assertEquals(List.of("player-a", "player-b", "player-c", "player-d"), status.getPlayerIds());
+    }
+
+    @DisplayName("其他玩家選完（非最後一位）→ 進度事件 2/4（先前回空 events）")
+    @Test
+    public void othersChooseGeneral_midway_emitsSelectionStatus() {
+        Game game = createInitialGame();
+        game.monarchChoosePlayerGeneral("player-a", General.甘寧.getGeneralId());
+
+        List<DomainEvent> events = game.othersChoosePlayerGeneral(
+                "player-b", General.孫權.getGeneralId());
+
+        assertEquals(1, events.size(), "選將中只發進度事件");
+        GeneralSelectionStatusEvent status = statusEvent(events).orElseThrow();
+        assertEquals(List.of("player-a", "player-b"), status.getSelectedPlayerIds());
+        assertEquals(List.of("player-c", "player-d"), status.getPendingPlayerIds());
+        assertFalse(status.isAllSelected());
+        assertEquals("player-b 已選擇武將（2/4）", status.getMessage());
+    }
+
+    @DisplayName("最後一位選完 → 進度 allSelected=true，且照舊發 InitialEnd + RoundStart 開局")
+    @Test
+    public void lastPlayerChooseGeneral_emitsAllSelectedThenInitialEnd() {
+        Game game = createInitialGame();
+        game.monarchChoosePlayerGeneral("player-a", General.甘寧.getGeneralId());
+        game.othersChoosePlayerGeneral("player-b", General.孫權.getGeneralId());
+        game.othersChoosePlayerGeneral("player-c", General.孫權.getGeneralId());
+
+        List<DomainEvent> events = game.othersChoosePlayerGeneral(
+                "player-d", General.孫權.getGeneralId());
+
+        GeneralSelectionStatusEvent status = statusEvent(events).orElseThrow();
+        assertTrue(status.isAllSelected());
+        assertEquals(4, status.getSelectedPlayerIds().size());
+        assertTrue(status.getPendingPlayerIds().isEmpty());
+        // 開局流程不變：InitialEnd + RoundStart 照舊，且進度事件在 InitialEnd 之前
+        assertTrue(events.stream().anyMatch(e -> e instanceof InitialEndEvent));
+        assertTrue(events.stream().anyMatch(e -> e instanceof RoundStartEvent));
+        assertTrue(events.indexOf(status) < events.stream()
+                        .filter(e -> e instanceof InitialEndEvent).findFirst().map(events::indexOf).orElseThrow(),
+                "進度事件應在 InitialEnd 之前");
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/GameController.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/GameController.java
@@ -71,8 +71,10 @@ public class GameController {
     @PostMapping("/api/games/{gameId}/player:monarchChooseGeneral")
     public ResponseEntity<?> chooseGeneralByMonarch(@PathVariable String gameId, @RequestBody ChooseGeneralRequest request) {
         MonarchChooseGeneralCardPresenter monarchChooseGeneralCardPresenter = new MonarchChooseGeneralCardPresenter();
-        monarchChooseGeneralUseCase.execute(gameId, request.toMonarchChooseGeneralRequest(), monarchChooseGeneralCardPresenter);
+        GeneralSelectionStatusPresenter selectionStatusPresenter = new GeneralSelectionStatusPresenter();
+        monarchChooseGeneralUseCase.execute(gameId, request.toMonarchChooseGeneralRequest(), monarchChooseGeneralCardPresenter, selectionStatusPresenter);
         webSocketBroadCast.pushMonarchChooseGeneralsCardEvent(monarchChooseGeneralCardPresenter);
+        webSocketBroadCast.pushGeneralSelectionStatusEvent(selectionStatusPresenter);
         return ResponseEntity.ok(HttpStatus.OK);
     }
 
@@ -80,7 +82,10 @@ public class GameController {
     public ResponseEntity<?> chooseGeneralByOthers(@PathVariable String gameId, @RequestBody ChooseGeneralRequest request) {
         InitialEndPresenter initialEndPresenter = new InitialEndPresenter();
         RoundStartPresenter roundStartPresenter = new RoundStartPresenter();
-        othersChoosePlayerGeneralUseCase.execute(gameId, request.toMonarchChooseGeneralRequest(), initialEndPresenter, roundStartPresenter);
+        GeneralSelectionStatusPresenter selectionStatusPresenter = new GeneralSelectionStatusPresenter();
+        othersChoosePlayerGeneralUseCase.execute(gameId, request.toMonarchChooseGeneralRequest(), initialEndPresenter, roundStartPresenter, selectionStatusPresenter);
+        // 進度先推（選將中；最後一位時 allSelected=true），再推開局事件
+        webSocketBroadCast.pushGeneralSelectionStatusEvent(selectionStatusPresenter);
         webSocketBroadCast.pushInitialEndEvent(initialEndPresenter);
         webSocketBroadCast.pushPlayerTakeTurnEvent(roundStartPresenter);
         return ResponseEntity.ok(HttpStatus.OK);

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/WebSocketBroadCast.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/controller/WebSocketBroadCast.java
@@ -75,6 +75,23 @@ public class WebSocketBroadCast {
         }
     }
 
+    /** 選將進度廣播（issue #237）— 事件不存在（如錯誤流程）時靜默跳過。 */
+    public void pushGeneralSelectionStatusEvent(GeneralSelectionStatusPresenter presenter) {
+        GeneralSelectionStatusPresenter.GeneralSelectionStatusViewModel viewModel = presenter.present();
+        if (viewModel == null) {
+            return;
+        }
+        try {
+            String json = objectMapper.writeValueAsString(viewModel);
+            for (String playerId : viewModel.getPlayerIds()) {
+                messagingTemplate.convertAndSend(String.format("/websocket/legendsOfTheThreeKingdoms/%s/%s", viewModel.getGameId(), playerId), json);
+            }
+        } catch (Exception e) {
+            System.err.println("****************** pushGeneralSelectionStatusEvent ");
+            e.printStackTrace();
+        }
+    }
+
     public void pushInitialEndEvent(InitialEndPresenter presenter) {
         List<InitialEndPresenter.InitialEndViewModel> initialEndViewModels = presenter.present();
         try {

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/FindGamePresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/FindGamePresenter.java
@@ -21,7 +21,24 @@ public class FindGamePresenter implements FindGameByIdUseCase.FindGamePresenter<
                 .filter(player -> playerId.equals(player.getId()))
                 .findFirst()
                 .orElseThrow(NoSuchElementException::new);
-        viewModel = new FindGameViewModel(game.getGameId(), new FindGameDataViewModel(CreateGamePresenter.hiddenRoleInformationByPlayer(game, currentPlayer)), "", playerId);
+        viewModel = new FindGameViewModel(game.getGameId(),
+                new FindGameDataViewModel(
+                        CreateGamePresenter.hiddenRoleInformationByPlayer(game, currentPlayer),
+                        buildSelectionStatus(game)),
+                "", playerId);
+    }
+
+    /** 選將階段（Initial）重整/重連補進度（issue #237）；其餘階段為 null。 */
+    private static GeneralSelectionStatusPresenter.GeneralSelectionStatusDataViewModel buildSelectionStatus(Game game) {
+        if (!"Initial".equals(game.getGamePhase().getPhaseName())) {
+            return null;
+        }
+        List<String> selected = game.getPlayers().stream()
+                .filter(p -> p.getGeneralCard() != null).map(Player::getId).toList();
+        List<String> pending = game.getPlayers().stream()
+                .filter(p -> p.getGeneralCard() == null).map(Player::getId).toList();
+        return new GeneralSelectionStatusPresenter.GeneralSelectionStatusDataViewModel(
+                selected, pending, selected.size(), game.getPlayers().size(), pending.isEmpty());
     }
 
     @Override
@@ -49,6 +66,8 @@ public class FindGamePresenter implements FindGameByIdUseCase.FindGamePresenter<
     @AllArgsConstructor
     public static class FindGameDataViewModel {
         private List<CreateGamePresenter.SeatViewModel> seats;
+        // 選將階段的進度快照（issue #237）；非 Initial 階段為 null（additive 欄位）
+        private GeneralSelectionStatusPresenter.GeneralSelectionStatusDataViewModel selectionStatus;
     }
 
 

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/GeneralSelectionStatusPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/GeneralSelectionStatusPresenter.java
@@ -1,0 +1,64 @@
+package com.gaas.threeKingdoms.presenter;
+
+import com.gaas.threeKingdoms.events.DomainEvent;
+import com.gaas.threeKingdoms.events.GeneralSelectionStatusEvent;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static com.gaas.threeKingdoms.presenter.ViewModel.getEvent;
+
+/**
+ * 選將進度廣播 presenter（issue #237）— 每次有人選完武將（含主公）廣播全員。
+ * 事件不存在時 present() 回 null（broadcast 端跳過）。
+ */
+public class GeneralSelectionStatusPresenter
+        implements com.gaas.threeKingdoms.usecase.OthersChoosePlayerGeneralUseCase.SelectionStatusPresenter<GeneralSelectionStatusPresenter.GeneralSelectionStatusViewModel> {
+
+    private GeneralSelectionStatusViewModel viewModel;
+
+    @Override
+    public void renderEvents(List<DomainEvent> events) {
+        viewModel = getEvent(events, GeneralSelectionStatusEvent.class)
+                .map(e -> new GeneralSelectionStatusViewModel(
+                        e.getGameId(), e.getPlayerIds(),
+                        new GeneralSelectionStatusDataViewModel(
+                                e.getSelectedPlayerIds(), e.getPendingPlayerIds(),
+                                e.getSelectedPlayerIds().size(), e.getPlayerIds().size(),
+                                e.isAllSelected()),
+                        e.getMessage()))
+                .orElse(null);
+    }
+
+    @Override
+    public GeneralSelectionStatusViewModel present() {
+        return viewModel;
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class GeneralSelectionStatusViewModel extends ViewModel<GeneralSelectionStatusDataViewModel> {
+        private String gameId;
+        private List<String> playerIds;
+
+        public GeneralSelectionStatusViewModel(String gameId, List<String> playerIds,
+                                               GeneralSelectionStatusDataViewModel data, String message) {
+            super("GeneralSelectionStatusEvent", data, message);
+            this.gameId = gameId;
+            this.playerIds = playerIds;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GeneralSelectionStatusDataViewModel {
+        private List<String> selectedPlayerIds;
+        private List<String> pendingPlayerIds;
+        private int selectedCount;
+        private int totalCount;
+        private boolean allSelected;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/InitialEndPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/InitialEndPresenter.java
@@ -23,7 +23,8 @@ public class InitialEndPresenter implements OthersChoosePlayerGeneralUseCase.Ini
     private List<InitialEndViewModel> initialEndViewModels;
 
     public void renderEvents(List<DomainEvent> events) {
-        if (!events.isEmpty()) {
+        // 以事件存在與否判斷（選將中 events 只有 GeneralSelectionStatusEvent，issue #237）
+        if (ViewModel.getEvent(events, InitialEndEvent.class).isPresent()) {
             updateInitialEventToViewModel(events);
         } else {
             initialEndViewModels = Collections.emptyList();

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/RoundStartPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/RoundStartPresenter.java
@@ -21,7 +21,8 @@ public class RoundStartPresenter implements OthersChoosePlayerGeneralUseCase.Rou
     }
 
     public void renderEvents(List<DomainEvent> events) {
-        if (!events.isEmpty()) {
+        // 以事件存在與否判斷（選將中 events 只有 GeneralSelectionStatusEvent，issue #237）
+        if (ViewModel.getEvent(events, RoundStartEvent.class).isPresent()) {
             viewModels = new ArrayList<>();
             updateEventToPlayerTakeTurnViewModel(events);
         } else {

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/GameTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/GameTest.java
@@ -121,6 +121,9 @@ public class GameTest extends AbstractBaseIntegrationTest {
 
         shouldGetGeneralCardsByOthers();
 
+        // 主公選完 → 全員收到選將進度 1/4（issue #237）
+        shouldReceiveSelectionStatus(1, false);
+
         shouldChooseGeneralsByOthers();
 
         shouldGetInitialEndGameStatus();
@@ -422,6 +425,9 @@ public class GameTest extends AbstractBaseIntegrationTest {
                 .andExpect(status().isOk())
                 .andReturn();
 
+        // B 選完 → 全員收到選將進度 2/4（issue #237）
+        shouldReceiveSelectionStatus(2, false);
+
         // Then 玩家B武將為馬超 ((玩家B general是 general1 is true)
         Game game = repository.findById("my-id")
                 .orElseThrow(() -> new NotFoundException("Game not found"));
@@ -442,6 +448,9 @@ public class GameTest extends AbstractBaseIntegrationTest {
                                 """))
                 .andExpect(status().isOk())
                 .andReturn();
+
+        // C 選完 → 全員收到選將進度 3/4（issue #237）
+        shouldReceiveSelectionStatus(3, false);
 
         game = repository.findById("my-id")
                 .orElseThrow(() -> new NotFoundException("Game not found"));
@@ -464,6 +473,9 @@ public class GameTest extends AbstractBaseIntegrationTest {
                 .andExpect(status().isOk())
                 .andReturn();
 
+        // D（最後一位）選完 → 全員收到選將進度 4/4 allSelected（在 InitialEnd 之前，issue #237）
+        shouldReceiveSelectionStatus(4, true);
+
         game = repository.findById("my-id")
                 .orElseThrow(() -> new NotFoundException("Game not found"));
 
@@ -473,6 +485,19 @@ public class GameTest extends AbstractBaseIntegrationTest {
         assertEquals(0, game.getGeneralCardDeck().getGeneralStack()
                 .stream().filter(x -> x.getGeneralId().equals("WEI002"))
                 .count());
+    }
+
+    /** 選將進度推播驗證（issue #237）：每位玩家收到 GeneralSelectionStatusEvent 且 selectedCount 正確。 */
+    private void shouldReceiveSelectionStatus(int expectedSelectedCount, boolean expectedAllSelected) throws InterruptedException, JsonProcessingException {
+        for (String playerId : List.of("player-a", "player-b", "player-c", "player-d")) {
+            String message = map.get(playerId).poll(5, TimeUnit.SECONDS);
+            assertNotNull(message, playerId + " 未收到選將進度推播");
+            com.fasterxml.jackson.databind.JsonNode node = objectMapper.readTree(message);
+            assertEquals("GeneralSelectionStatusEvent", node.get("event").asText(), playerId + " 應收到選將進度");
+            assertEquals(expectedSelectedCount, node.get("data").get("selectedCount").asInt());
+            assertEquals(4, node.get("data").get("totalCount").asInt());
+            assertEquals(expectedAllSelected, node.get("data").get("allSelected").asBoolean());
+        }
     }
 
     // 推播 所有玩家的武將 && 手牌

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/GeneralSelectionStatusE2ETest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/GeneralSelectionStatusE2ETest.java
@@ -1,0 +1,100 @@
+package com.gaas.threeKingdoms.e2e;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
+import com.gaas.threeKingdoms.utils.ShuffleWrapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 選將進度（issue #237）：中途選將的推播內容 + 重整/重連（findGame）補進度。
+ * 推播序列的逐步驗證在 GameTest.shouldReceiveSelectionStatus；本測試聚焦
+ * 事件內容細節與 findGameEvent 的 selectionStatus 欄位。
+ */
+public class GeneralSelectionStatusE2ETest extends AbstractBaseIntegrationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @DisplayName("主公+B 選完後：進度推播內容正確；player-c 重整 findGame 補 selectionStatus")
+    @Test
+    public void selectionStatusPushedAndAvailableOnFindGame() throws Exception {
+        // 建局（shuffle 關掉 → player-a 主公）
+        try (MockedStatic<ShuffleWrapper> mocked = Mockito.mockStatic(ShuffleWrapper.class)) {
+            mocked.when(() -> ShuffleWrapper.shuffle(Mockito.anyList())).thenAnswer(inv -> null);
+            mockMvc.perform(post("/api/games").contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    { "gameId": "%s", "players": ["player-a","player-b","player-c","player-d"] }
+                                    """.formatted(gameId)))
+                    .andExpect(status().isOk());
+        }
+        websocketUtil.popAllPlayerMessage();
+
+        // 主公選將 → 消耗 MonarchGeneralChosenEvent / getGeneralCardEventByOthers，取進度推播
+        mockMvc.perform(post("/api/games/" + gameId + "/player:monarchChooseGeneral")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "playerId": "player-a", "generalId": "SHU001" }
+                                """))
+                .andExpect(status().isOk());
+        JsonNode monarchStatus = pollUntilEvent("player-d", "GeneralSelectionStatusEvent");
+        assertEquals(List.of("player-a"),
+                objectMapper.convertValue(monarchStatus.get("data").get("selectedPlayerIds"), List.class));
+        assertEquals("player-a 已選擇武將（1/4）", monarchStatus.get("message").asText());
+        // 消耗 player-c queue 中主公那則 1/4 進度，讓下一步 poll 到的是 2/4
+        pollUntilEvent("player-c", "GeneralSelectionStatusEvent");
+
+        // B 選將 → 全員收到 2/4；事件不帶武將 id（暗選）
+        mockMvc.perform(post("/api/games/" + gameId + "/player:otherChooseGeneral")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "playerId": "player-b", "generalId": "WEI002" }
+                                """))
+                .andExpect(status().isOk());
+        JsonNode bStatus = pollUntilEvent("player-c", "GeneralSelectionStatusEvent");
+        assertEquals(List.of("player-a", "player-b"),
+                objectMapper.convertValue(bStatus.get("data").get("selectedPlayerIds"), List.class));
+        assertEquals(List.of("player-c", "player-d"),
+                objectMapper.convertValue(bStatus.get("data").get("pendingPlayerIds"), List.class));
+        assertFalse(bStatus.get("data").get("allSelected").asBoolean());
+        assertFalse(bStatus.get("data").toString().contains("WEI002"), "進度事件不得洩漏暗選武將 id");
+
+        // player-c 重整 → findGameEvent 帶 selectionStatus（Initial 階段）
+        mockMvc.perform(get("/api/games/" + gameId).param("playerId", "player-c"))
+                .andExpect(status().isOk());
+        JsonNode findGame = pollUntilEvent("player-c", "findGameEvent");
+        JsonNode selectionStatus = findGame.get("data").get("selectionStatus");
+        assertNotNull(selectionStatus, "Initial 階段 findGame 應帶 selectionStatus");
+        assertEquals(2, selectionStatus.get("selectedCount").asInt());
+        assertEquals(4, selectionStatus.get("totalCount").asInt());
+        assertEquals(List.of("player-c", "player-d"),
+                objectMapper.convertValue(selectionStatus.get("pendingPlayerIds"), List.class));
+        assertFalse(selectionStatus.get("allSelected").asBoolean());
+    }
+
+    /** 逐一 poll 該玩家 queue 直到收到指定 event（STOMP 順序不保證；未命中訊息丟棄）。 */
+    private JsonNode pollUntilEvent(String playerId, String eventName) throws Exception {
+        for (int attempt = 0; attempt < 6; attempt++) {
+            String message = websocketUtil.getValue(playerId);
+            if (message == null) {
+                break;
+            }
+            JsonNode node = objectMapper.readTree(message);
+            if (node.has("event") && eventName.equals(node.get("event").asText())) {
+                return node;
+            }
+        }
+        fail(playerId + " 未收到 " + eventName);
+        return null;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/FanKuiFullFlowTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/skill/FanKuiFullFlowTest.java
@@ -50,11 +50,15 @@ public class FanKuiFullFlowTest extends AbstractBaseIntegrationTest {
                                 """))
                 .andExpect(status().isOk());
 
-        // 選將
+        // 選將（每步會多一則 GeneralSelectionStatusEvent 進度推播，issue #237 — pop 數對應調整）
         chooseGeneral("player:monarchChooseGeneral", "player-a", "SHU001"); // 劉備
         websocketUtil.popAllPlayerMessage();
+        websocketUtil.popAllPlayerMessage();
+        websocketUtil.popAllPlayerMessage();
         chooseGeneral("player:otherChooseGeneral", "player-b", "WEI002");   // 司馬懿
+        websocketUtil.popAllPlayerMessage();
         chooseGeneral("player:otherChooseGeneral", "player-c", "WU001");
+        websocketUtil.popAllPlayerMessage();
         chooseGeneral("player:otherChooseGeneral", "player-d", "WU002");    // 最後一位 → 發牌、A 回合開始
         websocketUtil.popAllPlayerMessage();
         websocketUtil.popAllPlayerMessage();


### PR DESCRIPTION
Closes #237

## 背景（前端需求）

選將畫面要顯示「誰選完武將」。目前 `othersChoosePlayerGeneral` 在還有人沒選完時**回空 events 完全不推播**，前端只能本地模擬（四視窗各自只看得到自己）。與前端契約討論後的修正版：不洩漏暗選、不加 canStartGame（本後端為最後一人選完自動開局）、連線狀態另 issue（傳輸層，不進 domain）。

## 實作

**新事件 `GeneralSelectionStatusEvent`** — 每次有人選完武將（含主公）廣播全部玩家：

```json
{ "gameId": "my-id", "playerIds": [...],
  "event": "GeneralSelectionStatusEvent",
  "data": { "selectedPlayerIds": ["Scolley","Tux"], "pendingPlayerIds": ["Happypola","YangJun"],
            "selectedCount": 2, "totalCount": 4, "allSelected": false },
  "message": "Tux 已選擇武將（2/4）" }
```

- **不帶武將 id**（非主公暗選；`InitialEndEvent` 開局才揭曉，主公照舊 `MonarchGeneralChosenEvent` 亮將）
- 最後一位選完：先 `allSelected: true` 進度、接著照舊 `InitialEndEvent` + `RoundStartEvent` 自動開局
- **重整/重連**：Initial 階段的 `findGameEvent` 加帶 `data.selectionStatus`（additive，非選將階段為 null）
- 順帶修：`InitialEndPresenter`/`RoundStartPresenter` 原以「events 非空」當觸發條件（依賴選將中回空 list 的舊行為），改以事件存在與否判斷 — 否則選將中 `orElseThrow` → 400

## 測試

- domain `GeneralSelectionStatusTest` ×3：主公 1/4、中途 2/4（原本回空）、最後一位 allSelected + InitialEnd 順序
- spring `GeneralSelectionStatusE2ETest`：推播內容、**暗選武將 id 不洩漏**、player-c 重整 findGame 補 selectionStatus
- `GameTest` happy path 加 `shouldReceiveSelectionStatus` 逐步消化驗證（1/4→2/4→3/4→4/4 allSelected）
- `FanKuiFullFlowTest` websocket pop 數對應新推播調整
- domain 556 / spring 265 全綠

## 前端接法（可轉給前端）

- 收 `GeneralSelectionStatusEvent` → 渲染 `selectedPlayerIds` / `pendingPlayerIds`
- `data.pendingPlayerIds.length === 0` = 全員已選；收到 `InitialEndEvent` = 進入牌局（無「開始遊戲」API）
- 重整後打 `GET /api/games/{gameId}?playerId=xxx`，`findGameEvent.data.selectionStatus` 補進度

API_DOC 已更新（選將節 + 事件總表）。連線狀態（isConnected）廣播為 Phase 2，另開 issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV1eQrYWBp5rJA25ock1qP