### PR TITLE
feat: 連線狀態廣播 PlayerConnectionStatusEvent（issue #239）

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -104,6 +104,28 @@ POST /api/games/{gameId}/player:otherChooseGeneral
 - 前端判斷：`data.pendingPlayerIds.length === 0` = 全員已選；收到 `InitialEndEvent` = 進入牌局
 - **重整/重連補狀態**：選將階段呼叫 `GET /api/games/{gameId}?playerId=xxx`，推播的 `findGameEvent` 會在 `data.selectionStatus` 帶同一份進度物件（非選將階段為 `null`）
 
+### 連線狀態廣播 PlayerConnectionStatusEvent（issue #239）
+
+玩家 WebSocket 訂閱 `/websocket/legendsOfTheThreeKingdoms/{gameId}/{playerId}` 或斷線時，廣播該局全員：
+
+```json
+{
+  "gameId": "my-id",
+  "event": "PlayerConnectionStatusEvent",
+  "data": {
+    "connectedPlayerIds": ["Scolley", "Happypola", "Tux"],
+    "connectedCount": 3,
+    "totalCount": 4
+  },
+  "message": "Tux 已連線（3/4）"
+}
+```
+
+- 連線是傳輸層狀態（不進遊戲存檔）：訂閱即連線、STOMP session 斷線即離線；重整會連發「已離線」+「已連線」兩則，前端照最後一則渲染
+- 同玩家多分頁：首個分頁連上才算連線、最後一個關閉才算離線
+- 遊戲尚未建立時的訂閱、或非該局玩家的訂閱（觀戰）→ 不廣播
+- 前端判斷：`data.connectedCount === data.totalCount` = 全員在線；此事件在**整場遊戲**都會發（牌局中掉線也會廣播，可做斷線提示）
+
 ---
 
 ## 5. 出牌
@@ -838,6 +860,7 @@ Stack trace 僅記錄於 server log。
 | 事件 | 說明 | 觸發 API |
 |------|------|----------|
 | `GeneralSelectionStatusEvent` | 選將進度（每次有人選完武將廣播全員；格式見「其他玩家選將」節） | monarchChooseGeneral / otherChooseGeneral |
+| `PlayerConnectionStatusEvent` | 連線狀態（玩家訂閱/斷線時廣播全員；格式見「其他玩家選將」節） | WebSocket 訂閱/斷線（非 HTTP API） |
 | `PlayCardEvent` | 有人出牌 | playCard |
 | `PlayWardCardEvent` | 有人出無懈可擊 | playWardCard |
 | `GameStatusEvent` | 遊戲狀態更新（每次操作都附帶） | 所有 API |

--- a/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch2TriggeredSkillsTest.java
+++ b/LegendsOfTheThreeKingdoms/domain/src/test/java/com/gaas/threeKingdoms/skill/Batch2TriggeredSkillsTest.java
@@ -308,8 +308,11 @@ public class Batch2TriggeredSkillsTest extends PassiveSkillTestBase {
     public void luoShenCollectsBlackCardsUntilRed() {
         Game game = createGame(General.甄姬, General.劉備, General.孫權, General.孫權);
         Player a = game.getPlayer("player-a");
-        // Stack：後 add 的先抽 → 抽序 = BS9009(黑) → BS8008(黑) → BH3029(紅停)
-        game.getDeck().add(List.of(new Peach(BH3029), new Kill(BS8008), new Kill(BS9009)));
+        // Stack：後 add 的先抽 → 抽序 = BS9009(黑) → BS8008(黑) → BH3029(紅停) → 摸 2 = BH4030、BH2028
+        // 摸牌也疊死：initDeck 牌堆裡有另一張同 id 的 BH3029，隨機摸到會誤中
+        // 「紅色判定牌不收」斷言（CI 機率性 flake）
+        game.getDeck().add(List.of(new Dodge(BH2028), new Peach(BH4030),
+                new Peach(BH3029), new Kill(BS8008), new Kill(BS9009)));
 
         List<DomainEvent> askEvents = game.playerTakeTurnStartInJudgement(a);
 

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/PlayerConnectionStatusPresenter.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/presenter/PlayerConnectionStatusPresenter.java
@@ -1,0 +1,33 @@
+package com.gaas.threeKingdoms.presenter;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 連線狀態廣播 ViewModel（issue #239）— 純 spring 層，無對應 domain event。
+ */
+public class PlayerConnectionStatusPresenter {
+
+    @Data
+    @NoArgsConstructor
+    public static class PlayerConnectionStatusViewModel extends ViewModel<PlayerConnectionStatusDataViewModel> {
+        private String gameId;
+
+        public PlayerConnectionStatusViewModel(String gameId, PlayerConnectionStatusDataViewModel data, String message) {
+            super("PlayerConnectionStatusEvent", data, message);
+            this.gameId = gameId;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PlayerConnectionStatusDataViewModel {
+        private List<String> connectedPlayerIds;
+        private int connectedCount;
+        private int totalCount;
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/websocket/PlayerConnectionRegistry.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/websocket/PlayerConnectionRegistry.java
@@ -1,0 +1,68 @@
+package com.gaas.threeKingdoms.websocket;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * WebSocket 連線表（issue #239）— 傳輸層狀態，不進 domain / MongoDB。
+ * <p>
+ * sessionId ↔ (gameId, playerId)：同一玩家可能開多分頁（多 session），
+ * 只有該玩家「最後一個 session 斷線」才視為離線。單機部署 in-memory 即可。
+ */
+@Component
+public class PlayerConnectionRegistry {
+
+    /** sessionId → [gameId, playerId] */
+    private final Map<String, String[]> sessions = new HashMap<>();
+    /** gameId → playerId → 該玩家仍連著的 sessionIds */
+    private final Map<String, Map<String, Set<String>>> connections = new HashMap<>();
+
+    /** @return true = 該玩家由離線轉為連線（首個 session） */
+    public synchronized boolean registerSubscription(String sessionId, String gameId, String playerId) {
+        sessions.put(sessionId, new String[]{gameId, playerId});
+        Set<String> playerSessions = connections
+                .computeIfAbsent(gameId, k -> new HashMap<>())
+                .computeIfAbsent(playerId, k -> new HashSet<>());
+        boolean newlyConnected = playerSessions.isEmpty();
+        playerSessions.add(sessionId);
+        return newlyConnected;
+    }
+
+    /** @return 該 session 斷線導致某玩家完全離線時，回傳 [gameId, playerId]；否則 empty */
+    public synchronized Optional<String[]> unregisterSession(String sessionId) {
+        String[] identity = sessions.remove(sessionId);
+        if (identity == null) {
+            return Optional.empty();
+        }
+        String gameId = identity[0];
+        String playerId = identity[1];
+        Map<String, Set<String>> gameConnections = connections.get(gameId);
+        if (gameConnections == null) {
+            return Optional.empty();
+        }
+        Set<String> playerSessions = gameConnections.get(playerId);
+        if (playerSessions == null) {
+            return Optional.empty();
+        }
+        playerSessions.remove(sessionId);
+        if (!playerSessions.isEmpty()) {
+            return Optional.empty(); // 還有其他分頁連著
+        }
+        gameConnections.remove(playerId);
+        if (gameConnections.isEmpty()) {
+            connections.remove(gameId); // 該局無人連線 → 清掉，避免累積
+        }
+        return Optional.of(identity);
+    }
+
+    public synchronized Set<String> getConnectedPlayerIds(String gameId) {
+        Map<String, Set<String>> gameConnections = connections.get(gameId);
+        return gameConnections == null ? Set.of() : Collections.unmodifiableSet(new HashSet<>(gameConnections.keySet()));
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/websocket/WebSocketConnectionListener.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/main/java/com/gaas/threeKingdoms/websocket/WebSocketConnectionListener.java
@@ -1,0 +1,105 @@
+package com.gaas.threeKingdoms.websocket;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.outport.GameRepository;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.presenter.PlayerConnectionStatusPresenter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 連線狀態廣播（issue #239）：監聽 STOMP 訂閱/斷線事件，變動時廣播該局全員
+ * PlayerConnectionStatusEvent。守則：
+ * <ul>
+ *   <li>遊戲不存在或訂閱者不是該局玩家（觀戰/雜訊）→ 記錄於連線表但不廣播</li>
+ *   <li>同玩家多分頁：首個 session 連上才算連線、最後一個斷線才算離線</li>
+ *   <li>連線是傳輸層狀態，不進 domain / MongoDB</li>
+ * </ul>
+ */
+@Component
+public class WebSocketConnectionListener {
+
+    private static final Pattern DESTINATION_PATTERN =
+            Pattern.compile("^/websocket/legendsOfTheThreeKingdoms/([^/]+)/([^/]+)$");
+
+    @Autowired
+    private PlayerConnectionRegistry registry;
+    @Autowired
+    private GameRepository gameRepository;
+    @Autowired
+    private SimpMessagingTemplate messagingTemplate;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @EventListener
+    public void onSubscribe(SessionSubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String destination = accessor.getDestination();
+        String sessionId = accessor.getSessionId();
+        if (destination == null || sessionId == null) {
+            return;
+        }
+        Matcher matcher = DESTINATION_PATTERN.matcher(destination);
+        if (!matcher.matches()) {
+            return;
+        }
+        String gameId = matcher.group(1);
+        String playerId = matcher.group(2);
+        boolean newlyConnected = registry.registerSubscription(sessionId, gameId, playerId);
+        if (newlyConnected) {
+            broadcastConnectionStatus(gameId, playerId, "已連線");
+        }
+    }
+
+    @EventListener
+    public void onDisconnect(SessionDisconnectEvent event) {
+        Optional<String[]> fullyDisconnected = registry.unregisterSession(event.getSessionId());
+        fullyDisconnected.ifPresent(identity ->
+                broadcastConnectionStatus(identity[0], identity[1], "已離線"));
+    }
+
+    private void broadcastConnectionStatus(String gameId, String changedPlayerId, String changeText) {
+        Optional<Game> gameOptional = gameRepository.findById(gameId);
+        if (gameOptional.isEmpty()) {
+            return; // 遊戲尚未建立（前端先開 socket）→ 連線表已記錄，之後的變動會補廣播
+        }
+        Game game = gameOptional.get();
+        List<String> allPlayerIds = game.getPlayers().stream().map(Player::getId).toList();
+        if (!allPlayerIds.contains(changedPlayerId)) {
+            return; // 非該局玩家（觀戰/雜訊）不廣播
+        }
+        Set<String> connected = registry.getConnectedPlayerIds(gameId);
+        // 以座位順序輸出，結果穩定
+        List<String> connectedOrdered = allPlayerIds.stream().filter(connected::contains).toList();
+
+        PlayerConnectionStatusPresenter.PlayerConnectionStatusViewModel viewModel =
+                new PlayerConnectionStatusPresenter.PlayerConnectionStatusViewModel(
+                        gameId,
+                        new PlayerConnectionStatusPresenter.PlayerConnectionStatusDataViewModel(
+                                connectedOrdered, connectedOrdered.size(), allPlayerIds.size()),
+                        String.format("%s %s（%d/%d）", changedPlayerId, changeText,
+                                connectedOrdered.size(), allPlayerIds.size()));
+        try {
+            String json = objectMapper.writeValueAsString(viewModel);
+            for (String playerId : allPlayerIds) {
+                messagingTemplate.convertAndSend(
+                        String.format("/websocket/legendsOfTheThreeKingdoms/%s/%s", gameId, playerId), json);
+            }
+        } catch (Exception e) {
+            System.err.println("****************** pushPlayerConnectionStatusEvent ");
+            e.printStackTrace();
+        }
+    }
+}

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/GameTest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/GameTest.java
@@ -38,6 +38,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Stack;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -118,11 +119,6 @@ public class GameTest extends AbstractBaseIntegrationTest {
         shouldCreateGame();
 
         shouldChooseGeneralsByMonarch();
-
-        shouldGetGeneralCardsByOthers();
-
-        // 主公選完 → 全員收到選將進度 1/4（issue #237）
-        shouldReceiveSelectionStatus(1, false);
 
         shouldChooseGeneralsByOthers();
 
@@ -346,24 +342,36 @@ public class GameTest extends AbstractBaseIntegrationTest {
                 .count());
 
         // WebSocket 推播給前端資訊
-        // 主公選擇的腳色全部人都可以知道
-        // 注意：STOMP 廣播順序不保證（CI flake：偶爾先收到其他事件的 array JSON），
-        // 逐一 poll 直到收到 MonarchGeneralChosenEvent 為止
+        // 主公選完會有多則推播（MonarchGeneralChosenEvent / getGeneralCardEventByOthers /
+        // GeneralSelectionStatusEvent），STOMP 順序不保證（既有 CI flake）→
+        // 每位玩家收齊全部訊息後按 event 類型比對（issue #237）
         for (Player player : game.getPlayers()) {
-            String monarchChooseGeneralCardMessage = null;
-            for (int attempt = 0; attempt < 3; attempt++) {
-                String candidate = map.get(player.getId()).poll(5, TimeUnit.SECONDS);
-                if (candidate != null && candidate.contains("MonarchGeneralChosenEvent")) {
-                    monarchChooseGeneralCardMessage = candidate;
-                    break;
-                }
-            }
+            boolean isMonarch = "player-a".equals(player.getId());
+            Map<String, String> received = pollMessagesByEvent(player.getId(), isMonarch ? 2 : 3);
+
+            String monarchChooseGeneralCardMessage = received.get("MonarchGeneralChosenEvent");
             assertNotNull(monarchChooseGeneralCardMessage,
                     player.getId() + " 未收到 MonarchGeneralChosenEvent");
             MonarchChooseGeneralCardPresenter.MonarchChooseGeneralCardViewModel monarchChooseGeneralCardViewModel = objectMapper.readValue(monarchChooseGeneralCardMessage, MonarchChooseGeneralCardPresenter.MonarchChooseGeneralCardViewModel.class);
             assertEquals("主公已選擇 劉備", monarchChooseGeneralCardViewModel.getMessage());
             assertEquals("SHU001", monarchChooseGeneralCardViewModel.getData().getMonarchGeneralCard());
             assertEquals("MonarchGeneralChosenEvent", monarchChooseGeneralCardViewModel.getEvent());
+
+            // 選將進度 1/4（issue #237）
+            String statusMessage = received.get("GeneralSelectionStatusEvent");
+            assertNotNull(statusMessage, player.getId() + " 未收到選將進度推播");
+            com.fasterxml.jackson.databind.JsonNode statusNode = objectMapper.readTree(statusMessage);
+            assertEquals(1, statusNode.get("data").get("selectedCount").asInt());
+            assertFalse(statusNode.get("data").get("allSelected").asBoolean());
+
+            // 其他玩家另收到 3 張可選武將
+            if (!isMonarch) {
+                String getGeneralCardByOthersMessage = received.get("getGeneralCardEventByOthers");
+                assertNotNull(getGeneralCardByOthersMessage, player.getId() + " 未收到可選武將列表");
+                MonarchChooseGeneralCardPresenter.GetGeneralCardByOthersViewModel getGeneralCardByOthersViewModel = objectMapper.readValue(getGeneralCardByOthersMessage, MonarchChooseGeneralCardPresenter.GetGeneralCardByOthersViewModel.class);
+                assertEquals("請選擇武將", getGeneralCardByOthersViewModel.getMessage());
+                assertEquals(3, getGeneralCardByOthersViewModel.getData().size());
+            }
         }
 
         // PlayerB打主公選擇角色的API
@@ -382,19 +390,6 @@ public class GameTest extends AbstractBaseIntegrationTest {
 
     }
 
-    private void shouldGetGeneralCardsByOthers() throws Exception {
-        Game game = repository.findById("my-id")
-                .orElseThrow(() -> new NotFoundException("Game not found"));
-        List<Player> otherPlayers = game.getPlayers().stream().filter(player -> player.getRoleCard().getRole() != Role.MONARCH).collect(Collectors.toList());
-        for (Player player : otherPlayers) {
-            String getGeneralCardByOthersMessage = map.get(player.getId()).poll(5, TimeUnit.SECONDS);
-            MonarchChooseGeneralCardPresenter.GetGeneralCardByOthersViewModel getGeneralCardByOthersViewModel = objectMapper.readValue(getGeneralCardByOthersMessage, MonarchChooseGeneralCardPresenter.GetGeneralCardByOthersViewModel.class);
-            assertNotNull(getGeneralCardByOthersMessage);
-            assertEquals("請選擇武將", getGeneralCardByOthersViewModel.getMessage());
-            assertEquals(3, getGeneralCardByOthersViewModel.getData().size());
-            assertEquals("getGeneralCardEventByOthers", getGeneralCardByOthersViewModel.getEvent());
-        }
-    }
 
 
     private void shouldChooseGeneralsByOthers() throws Exception {
@@ -485,6 +480,25 @@ public class GameTest extends AbstractBaseIntegrationTest {
         assertEquals(0, game.getGeneralCardDeck().getGeneralStack()
                 .stream().filter(x -> x.getGeneralId().equals("WEI002"))
                 .count());
+    }
+
+    /** 收齊 count 則訊息並按 event 類型歸類（STOMP 順序不保證；同型事件保留最後一則）。 */
+    private Map<String, String> pollMessagesByEvent(String playerId, int count) throws InterruptedException {
+        Map<String, String> byEvent = new java.util.HashMap<>();
+        for (int i = 0; i < count; i++) {
+            String message = map.get(playerId).poll(5, TimeUnit.SECONDS);
+            assertNotNull(message, playerId + " 第 " + (i + 1) + " 則訊息未收到");
+            String eventName = "unknown";
+            try {
+                com.fasterxml.jackson.databind.JsonNode node = objectMapper.readTree(message);
+                if (node.has("event")) {
+                    eventName = node.get("event").asText();
+                }
+            } catch (JsonProcessingException ignored) {
+            }
+            byEvent.put(eventName, message);
+        }
+        return byEvent;
     }
 
     /** 選將進度推播驗證（issue #237）：每位玩家收到 GeneralSelectionStatusEvent 且 selectedCount 正確。 */

--- a/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/PlayerConnectionStatusE2ETest.java
+++ b/LegendsOfTheThreeKingdoms/spring/src/test/java/com/gaas/threeKingdoms/e2e/PlayerConnectionStatusE2ETest.java
@@ -1,0 +1,123 @@
+package com.gaas.threeKingdoms.e2e;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaas.threeKingdoms.Game;
+import com.gaas.threeKingdoms.e2e.testcontainer.test.AbstractBaseIntegrationTest;
+import com.gaas.threeKingdoms.generalcard.General;
+import com.gaas.threeKingdoms.player.HealthStatus;
+import com.gaas.threeKingdoms.player.Player;
+import com.gaas.threeKingdoms.rolecard.Role;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.converter.StringMessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static com.gaas.threeKingdoms.e2e.MockUtil.createPlayer;
+import static com.gaas.threeKingdoms.e2e.MockUtil.initGame;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 連線狀態廣播（issue #239）：STOMP 訂閱/斷線 → PlayerConnectionStatusEvent 廣播該局全員。
+ * 用獨立 gameId — 測試基建的 @BeforeEach 會對預設 gameId 訂閱 a~g（在建局前），
+ * 走預設 gameId 會與那些 session 混流、斷言不穩定。
+ */
+public class PlayerConnectionStatusE2ETest extends AbstractBaseIntegrationTest {
+
+    private static final String CONN_GAME_ID = "conn-status-test";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @AfterEach
+    public void deleteConnGame() {
+        repository.deleteById(CONN_GAME_ID);
+    }
+
+    @DisplayName("玩家逐一連線廣播 1/4→2/4；斷線回落 1/4；非該局玩家訂閱不廣播")
+    @Test
+    public void connectionStatusBroadcastOnSubscribeAndDisconnect() throws Exception {
+        Player playerA = createPlayer("player-a", 4, General.甘寧, HealthStatus.ALIVE, Role.MONARCH);
+        Player playerB = createPlayer("player-b", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER);
+        Player playerC = createPlayer("player-c", 4, General.孫權, HealthStatus.ALIVE, Role.REBEL);
+        Player playerD = createPlayer("player-d", 4, General.孫權, HealthStatus.ALIVE, Role.MINISTER);
+        Game game = initGame(CONN_GAME_ID, Arrays.asList(playerA, playerB, playerC, playerD), playerA);
+        repository.save(game);
+
+        // A 連線 → A 收到 1/4
+        BlockingQueue<String> queueA = new LinkedBlockingQueue<>();
+        StompSession sessionA = connectAndSubscribe("player-a", queueA);
+        JsonNode first = nextEvent(queueA);
+        assertEquals("PlayerConnectionStatusEvent", first.get("event").asText());
+        assertEquals(List.of("player-a"),
+                objectMapper.convertValue(first.get("data").get("connectedPlayerIds"), List.class));
+        assertEquals(1, first.get("data").get("connectedCount").asInt());
+        assertEquals(4, first.get("data").get("totalCount").asInt());
+        assertEquals("player-a 已連線（1/4）", first.get("message").asText());
+
+        // B 連線 → A、B 都收到 2/4（座位順序）
+        BlockingQueue<String> queueB = new LinkedBlockingQueue<>();
+        StompSession sessionB = connectAndSubscribe("player-b", queueB);
+        JsonNode second = nextEvent(queueA);
+        assertEquals(List.of("player-a", "player-b"),
+                objectMapper.convertValue(second.get("data").get("connectedPlayerIds"), List.class));
+        assertEquals("player-b 已連線（2/4）", second.get("message").asText());
+        JsonNode secondForB = nextEvent(queueB);
+        assertEquals(2, secondForB.get("data").get("connectedCount").asInt());
+
+        // B 斷線 → A 收到回落 1/4
+        sessionB.disconnect();
+        JsonNode third = nextEvent(queueA);
+        assertEquals(List.of("player-a"),
+                objectMapper.convertValue(third.get("data").get("connectedPlayerIds"), List.class));
+        assertEquals("player-b 已離線（1/4）", third.get("message").asText());
+
+        // 非該局玩家（觀戰者）訂閱 → 不廣播
+        BlockingQueue<String> queueX = new LinkedBlockingQueue<>();
+        StompSession sessionX = connectAndSubscribe("spectator-x", queueX);
+        assertNull(queueA.poll(1, TimeUnit.SECONDS), "非該局玩家連線不應廣播");
+
+        sessionA.disconnect();
+        sessionX.disconnect();
+    }
+
+    /** 建立單一 STOMP 連線並訂閱該玩家的推播路徑，收到的訊息放入 queue。 */
+    private StompSession connectAndSubscribe(String playerId, BlockingQueue<String> queue) throws Exception {
+        WebSocketStompClient client = new WebSocketStompClient(new StandardWebSocketClient());
+        client.setMessageConverter(new StringMessageConverter());
+        StompSession session = client
+                .connectAsync("ws://localhost:" + port + "/legendsOfTheThreeKingdoms", new StompSessionHandlerAdapter() {})
+                .get(5, TimeUnit.SECONDS);
+        session.subscribe("/websocket/legendsOfTheThreeKingdoms/" + CONN_GAME_ID + "/" + playerId,
+                new StompFrameHandler() {
+                    @Override
+                    public Type getPayloadType(StompHeaders headers) {
+                        return String.class;
+                    }
+
+                    @Override
+                    public void handleFrame(StompHeaders headers, Object payload) {
+                        queue.add((String) payload);
+                    }
+                });
+        return session;
+    }
+
+    private JsonNode nextEvent(BlockingQueue<String> queue) throws Exception {
+        String message = queue.poll(5, TimeUnit.SECONDS);
+        assertNotNull(message, "未收到連線狀態推播");
+        return objectMapper.readTree(message);
+    }
+}


### PR DESCRIPTION
Closes #239

## 需求（前端選將畫面「已連上玩家 (n/4)」— issue #237 的 Phase 2）

後端目前沒有任何連線狀態推播，每個瀏覽器只知道自己連上了。

## 設計

連線是 **WebSocket 傳輸層狀態，不進 domain / MongoDB**（避免與遊戲存檔互相污染）— 純 spring 層：

- `PlayerConnectionRegistry`：in-memory 連線表（sessionId ↔ gameId/playerId）；同玩家多分頁以 session 集合判斷 — 首個分頁連上才算連線、最後一個關閉才算離線
- `WebSocketConnectionListener`：監聽 STOMP `SessionSubscribeEvent` / `SessionDisconnectEvent`，從訂閱路徑解析身分，變動時廣播該局全員：

```json
{ "gameId": "my-id", "event": "PlayerConnectionStatusEvent",
  "data": { "connectedPlayerIds": ["Scolley","Happypola","Tux"], "connectedCount": 3, "totalCount": 4 },
  "message": "Tux 已連線（3/4）" }
```

守則：遊戲不存在（前端先開 socket）或非該局玩家（觀戰）→ 記錄但不廣播；連線清空時移除該局資料；整場遊戲都會發（牌局中掉線可做斷線提示）。單機部署 in-memory 即可。

## 測試

- `PlayerConnectionStatusE2ETest`：用**獨立 gameId**（測試基建 @BeforeEach 會在建局前對預設 gameId 訂閱 a~g，混流會不穩）— 逐一連線廣播 1/4→2/4（座位順序）、斷線回落 1/4、觀戰者訂閱不廣播
- `GameTest` 主公選將段改「收齊 N 則、按 event 類型比對」：STOMP 多執行緒 outbound channel 順序不保證（既有 CI flake 註記），#238 的新推播讓它更易觸發 — 本次撞到後改為順序容忍寫法，三連跑穩定
- domain 556 / spring 267 全綠

## 前端接法

- 收 `PlayerConnectionStatusEvent` → 渲染 `connectedPlayerIds`；重整會連發「已離線」+「已連線」兩則，照最後一則渲染即可
- 搭配 #238 的 `GeneralSelectionStatusEvent`，選將畫面的「已連上 (n/4)」「已選 (n/4)」兩塊資料都齊了

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV1eQrYWBp5rJA25ock1qP